### PR TITLE
Updated to latest python launcher and used module references for python3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
       }
     },
     "@architect-io/python-launcher": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@architect-io/python-launcher/-/python-launcher-0.1.1.tgz",
-      "integrity": "sha512-Or906iD+7wE4yXkuAP2x95DPtoTNLPlcnl2His5QQlLdbGxBpoOoc5eflFQdKO00FGEHO38DgRpucyac//V2uA=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@architect-io/python-launcher/-/python-launcher-0.1.2.tgz",
+      "integrity": "sha512-PASKgnKsG8evtVbMJFZLgnihLsgdeZGuRDj3kUQ8r2SfcPyLsErR2Db3a/HxWr74Yo6Y775CWv6iH1zG7iADaw=="
     },
     "@babel/code-frame": {
       "version": "7.0.0",
@@ -5367,7 +5367,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/architect-team/architect-cli/issues",
   "dependencies": {
     "@architect-io/node-launcher": "^0.1.1",
-    "@architect-io/python-launcher": "^0.1.1",
+    "@architect-io/python-launcher": "^0.1.2",
     "@oclif/command": "^1.5.2",
     "@oclif/config": "^1.8.6",
     "@oclif/plugin-help": "^2.1.2",

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -8,7 +8,7 @@ import * as readline from 'readline';
 import DeploymentConfig from '../common/deployment-config';
 import ServiceConfig from '../common/service-config';
 
-const AVAILABLE_PORTS = Array.from({length: 1000}, (_, k) => k + 50000);
+const AVAILABLE_PORTS = Array.from({length: 1000}, (_, k) => `${k + 50000}`);
 
 export default class Start extends Command {
   static description = 'Start the service locally';
@@ -53,6 +53,7 @@ export default class Start extends Command {
   async run() {
     // Ensures that the python launcher doesn't buffer output and cause hanging
     process.env.PYTHONUNBUFFERED = 'true';
+    process.env.PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION = 'python';
 
     const service_path = process.cwd();
     await this.startService(service_path, true);


### PR DESCRIPTION
Moved protoc execution code to a new namespace and copied the proto files to the tmp directory on the host under folders matching the name of the service. See https://github.com/architect-team/python-launcher/issues/1#issuecomment-461635733 for details.