### PR TITLE
Prevented override of subscriptions in CLI

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -129,9 +129,10 @@ export default class Deploy extends Command {
 
         if (!subscriptions_map[service.config.name]) {
           subscriptions_map[service.config.name] = {};
-        }
-        for (const event of service.config.notifications) {
-          subscriptions_map[service.config.name][event] = {};
+
+          for (const event of service.config.notifications) {
+            subscriptions_map[service.config.name][event] = {};
+          }
         }
 
         if (service.config.subscriptions) {


### PR DESCRIPTION
Had to move the for loop shown inside the condition to see whether or not the object already exists. Currently, prior additions to this object are being overwritten on second passes through the loop.