### PR TITLE
use default namespace regardless of what the user has set locally

### DIFF
--- a/src/commands/environments/create.ts
+++ b/src/commands/environments/create.ts
@@ -112,7 +112,7 @@ export default class EnvironmentCreate extends Command {
   }
 
   private async createKubernetesServiceAccount(kubeconfig_path: string, sa_name: string) {
-    const set_kubeconfig = ['--kubeconfig', kubeconfig_path];
+    const set_kubeconfig = ['--kubeconfig', kubeconfig_path, '--namespace', 'default'];
 
     // Create the service account
     await execa('kubectl', [
@@ -150,7 +150,7 @@ export default class EnvironmentCreate extends Command {
       throw new Error('Invalid kubeconfig format. Did you provide the correct path?');
     }
 
-    const set_kubeconfig = ['--kubeconfig', untildify(kubeconfig_path)];
+    const set_kubeconfig = ['--kubeconfig', untildify(kubeconfig_path), '--namespace', 'default'];
 
     // Get original kubernetes current-context
     const { stdout: original_kubecontext } = await execa('kubectl', [


### PR DESCRIPTION
Previously, if the user hasd set their kubetcl context to a particular namespace, architect was creating serviceaccounts scoped only to that namespace. Those (rightfully) failed our `can-i` check and prevented the creation of an environment.

This commit changes the scope of the architect CLI's kubectl execs to use the `default` namespace.