### PR TITLE
pinning inquirer to a version that works with non-tty

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dotenv-expand": "^5.1.0",
     "execa": "^3.2.0",
     "fs-extra": "^8.1.0",
-    "inquirer": "^7.0.0",
+    "inquirer": "7.0.4",
     "js-yaml": "^3.13.1",
     "reflect-metadata": "^0.1.13",
     "tslib": "^1.10.0",


### PR DESCRIPTION
Fix to pin inquirer before this breaking change: 
https://github.com/SBoudrias/Inquirer.js/pull/891