### PR TITLE
Adding port mapping to config and supported data volumes

### DIFF
--- a/src/common/dependency-manager/local-manager.ts
+++ b/src/common/dependency-manager/local-manager.ts
@@ -80,13 +80,14 @@ export default class LocalDependencyManager extends DependencyManager {
     }
 
     const env_service = this.environment.getServiceDetails(`${config.getName()}:latest`);
+    const configPort = config.getPort();
     const node = new LocalServiceNode({
       service_path: service_path.endsWith('.json') ? path.dirname(service_path) : service_path,
       service_config: config,
       image: config.getImage(),
       tag: 'latest',
       ports: {
-        target: env_service?.port ? env_service.port : 8080,
+        target: env_service?.port ? env_service.port : (configPort ? configPort : 8080),
         expose: await this.getServicePort(),
       },
       parameters: await this.getParamValues(
@@ -147,7 +148,7 @@ export default class LocalDependencyManager extends DependencyManager {
       tag: service_digest.tag,
       image: service_digest.service.url.replace(/(^\w+:|^)\/\//, ''),
       ports: {
-        target: 8080,
+        target: config.getPort() || 8080,
         expose: await this.getServicePort(),
       },
       parameters: await this.getParamValues(

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -99,7 +99,13 @@ export const generate = (dependency_manager: DependencyManager, build_prod = fal
             compose.services[node.normalized_ref].build!.dockerfile = path.resolve(node.service_path, env_service.debug.dockerfile);
           }
           if (env_service.debug.volumes) {
-            compose.services[node.normalized_ref].volumes = env_service.debug.volumes.map((v) => path.resolve(node.service_path, v.split(':')[0]) + ':' + v.split(':')[1]);
+            compose.services[node.normalized_ref].volumes = env_service.debug.volumes.map((v) => {
+              const volumeDef = v.split(':');
+              if (volumeDef.length === 1) {
+                return path.resolve(node.service_path, volumeDef[0]);
+              }
+              return path.resolve(node.service_path, v.split(':')[0]) + ':' + v.split(':')[1];
+            });
           }
         }
       }

--- a/src/dependency-manager/src/service-config/base.ts
+++ b/src/dependency-manager/src/service-config/base.ts
@@ -72,4 +72,5 @@ export abstract class ServiceConfig {
   abstract getPlatforms(): { [s: string]: any };
   abstract addDependency(dependency_name: string, dependency_tag: string): void;
   abstract removeDependency(dependency_name: string): void;
+  abstract getPort(): number | undefined;
 }

--- a/src/dependency-manager/src/service-config/v1.ts
+++ b/src/dependency-manager/src/service-config/v1.ts
@@ -58,6 +58,7 @@ export class ServiceConfigV1 extends ServiceConfig {
   description?: string;
   keywords?: string[];
   image?: string;
+  port?: string;
   command?: string | string[];
   dependencies: { [s: string]: string } = {};
   language?: string;
@@ -186,5 +187,9 @@ export class ServiceConfigV1 extends ServiceConfig {
 
   getPlatforms(): { [s: string]: any } {
     return this.platforms;
+  }
+
+  getPort(): number | undefined {
+    return this.port ? Number(this.port) : undefined;
   }
 }

--- a/test/dependency-manager/builder.test.ts
+++ b/test/dependency-manager/builder.test.ts
@@ -1,0 +1,27 @@
+import { expect } from '@oclif/test';
+import { ServiceConfigBuilder } from '../../src/dependency-manager/src';
+
+describe('builder', function () {
+
+  describe('buildFromJSON', function () {
+    it("port is parsed into the config", function() {
+      const serviceConfigWithNoPort = {
+        "name": "foo/service",
+        "description": "a test service",
+        "dependencies": {},
+        "parameters": {},
+        "datastores": {},
+        "api": {
+          "type": "grpc",
+          "definitions": []
+        },
+        "subscriptions": {},
+        "keywords": [],
+      };
+      const serviceConfigWithConfigPort = { ...serviceConfigWithNoPort, port: "8081" };
+
+      expect(ServiceConfigBuilder.buildFromJSON(serviceConfigWithNoPort).getPort()).undefined;
+      expect(ServiceConfigBuilder.buildFromJSON(serviceConfigWithConfigPort).getPort()).eq(8081);
+    });
+  });
+});


### PR DESCRIPTION
This PR is two updates: 

1) Fixes a bug where port value in the service was ignored in the docker-compose file 
2) Fixed a compose issue where data volumes were not supported `/myapp/directory`