### PR TITLE
Docker context

### DIFF
--- a/src/dependency-manager/src/service-config/base.ts
+++ b/src/dependency-manager/src/service-config/base.ts
@@ -51,8 +51,15 @@ export interface ServiceLivenessProbe {
   interval?: string;
 }
 
+export interface ServiceDockerSpec {
+  dockerfile?: string;
+  context?: string;
+  command?: string | string[];
+  entrypoint?: string | string[];
+}
+
 export interface ServiceDebugOptions {
-  command: string | string[];
+  docker?: ServiceDockerSpec;
 }
 
 export abstract class ServiceConfig {
@@ -60,6 +67,7 @@ export abstract class ServiceConfig {
   abstract getName(): string;
   abstract getLanguage(): string;
   abstract getImage(): string;
+  abstract getDockerOptions(): ServiceDockerSpec;
   abstract getCommand(): string | string[];
   abstract getEntrypoint(): string | string[];
   abstract getDependencies(): { [s: string]: string };
@@ -68,7 +76,7 @@ export abstract class ServiceConfig {
   abstract getApiSpec(): ServiceApiSpec;
   abstract getNotifications(): ServiceEventNotifications;
   abstract getSubscriptions(): ServiceEventSubscriptions;
-  abstract getDebugOptions(): ServiceDebugOptions | undefined;
+  abstract getDebugOptions(): ServiceDebugOptions;
   abstract getPlatforms(): { [s: string]: any };
   abstract addDependency(dependency_name: string, dependency_tag: string): void;
   abstract removeDependency(dependency_name: string): void;

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -12,10 +12,53 @@ import DockerComposeTemplate, { DockerService } from '../../src/common/docker-co
 import PortUtil from '../../src/common/utils/port';
 import ARCHITECTPATHS from '../../src/paths';
 
+const validateComposeFile = (generated_compose: DockerComposeTemplate, expected_compose: DockerComposeTemplate) => {
+  expect(generated_compose.version).to.equal(expected_compose.version);
+
+  for (const svc_key of Object.keys(generated_compose.services)) {
+    expect(Object.keys(expected_compose.services)).to.include(svc_key);
+
+    const input = generated_compose.services[svc_key] as DockerService;
+    const expected = expected_compose.services[svc_key];
+
+    // Expand paths from expected compose templates
+    if (expected.build?.context) {
+      expected.build.context = path.join(__dirname, '../../', expected.build.context).replace(/\/$/gi, '').toLowerCase();
+    }
+
+    if (expected.build?.dockerfile) {
+      expected.build.dockerfile = path.join(__dirname, '../../', expected.build.dockerfile).replace(/\/$/gi, '');
+    }
+
+    if (expected.volumes) {
+      expected.volumes = expected.volumes.map(volume => {
+        const [host, target] = volume.split(':');
+        return `${path.join(__dirname, '../../', host)}:${target}`;
+      });
+    }
+
+    if (input.build?.context) {
+      input.build.context = input.build.context.replace(/\/$/ig, '').toLowerCase();
+    }
+
+    expect(expected.ports).to.have.members(input.ports);
+    expect(expected.image).to.equal(input.image);
+    expect(expected.depends_on).to.have.members(input.depends_on);
+    expect(expected.build).to.eql(input.build);
+    expect(expected.command).to.equal(input.command);
+    expect(input.environment).not.to.be.undefined;
+
+    // Test env variables
+    for (const [key, value] of Object.entries(expected.environment || {})) {
+      expect(value).to.equal(input.environment![key]);
+    }
+  }
+};
+
 describe('deploy', () => {
   let tmp_dir = os.tmpdir();
 
-  before(() => {
+  beforeEach(() => {
     PortUtil.tested_ports = new Set();
 
     const credential_spy = sinon.fake.returns('token');
@@ -31,7 +74,7 @@ describe('deploy', () => {
     sinon.replace(AppService, 'create', app_config_stub);
   });
 
-  after(() => {
+  afterEach(() => {
     sinon.restore();
   });
 
@@ -47,42 +90,22 @@ describe('deploy', () => {
     await Deploy.run(['-l', calculator_env_config_path]);
 
     const expected_compose = fs.readJSONSync(path.join(__dirname, '../mocks/calculator-compose.json')) as DockerComposeTemplate;
+
     expect(compose_spy.calledOnce).to.equal(true);
+    validateComposeFile(compose_spy.firstCall.args[0], expected_compose);
+  });
 
-    expect(compose_spy.firstCall.args[0].version).to.equal(expected_compose.version);
-    for (const svc_key of Object.keys(compose_spy.firstCall.args[0].services)) {
-      expect(Object.keys(expected_compose.services)).to.include(svc_key);
+  it('overrides build context and command for deploys', async () => {
+    const compose_spy = sinon.fake.resolves(null);
+    sinon.replace(Deploy.prototype, 'runCompose', compose_spy);
 
-      const input = compose_spy.firstCall.args[0].services[svc_key] as DockerService;
-      const expected = expected_compose.services[svc_key];
+    // Link the addition service
+    const env_config_path = path.join(__dirname, '../mocks/mock-service/arc.env.json');
+    await Deploy.run(['-l', env_config_path]);
 
-      // Overwrite expected paths with full directories
-      if (expected.build?.context) {
-        expected.build.context = path.join(__dirname, '../../', expected.build.context).replace(/\/$/gi, '').toLowerCase();
-      }
+    const expected_compose = fs.readJSONSync(path.join(__dirname, '../mocks/mock-service/expected-compose.json')) as DockerComposeTemplate;
 
-      if (input.build?.context) {
-        input.build.context = input.build.context.replace(/\/$/ig, '').toLowerCase();
-      }
-
-      if (expected.volumes) {
-        expected.volumes = expected.volumes.map(volume => {
-          const [host, target] = volume.split(':');
-          return `${path.join(__dirname, '../../', host)}:${target}`;
-        });
-      }
-
-      expect(expected.ports).to.have.members(input.ports);
-      expect(expected.image).to.equal(input.image);
-      expect(expected.depends_on).to.have.members(input.depends_on);
-      expect(expected.build).to.eql(input.build);
-      expect(expected.command).to.equal(input.command);
-      expect(input.environment).not.to.be.undefined;
-
-      // Test env variables
-      for (const [key, value] of Object.entries(expected.environment || {})) {
-        expect(value).to.equal(input.environment![key]);
-      }
-    }
+    expect(compose_spy.calledOnce).to.equal(true);
+    validateComposeFile(compose_spy.firstCall.args[0], expected_compose);
   });
 });

--- a/test/mocks/mock-service/.docker/Dockerfile
+++ b/test/mocks/mock-service/.docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:latest
+
+COPY index.js .
+
+CMD ["echo", "\"FAILED\""]
+

--- a/test/mocks/mock-service/arc.env.json
+++ b/test/mocks/mock-service/arc.env.json
@@ -1,0 +1,9 @@
+{
+  "services": {
+    "architect-mocks/test1:latest": {
+      "debug": {
+        "path": "."
+      }
+    }
+  }
+}

--- a/test/mocks/mock-service/architect.json
+++ b/test/mocks/mock-service/architect.json
@@ -1,0 +1,14 @@
+{
+  "name": "architect-mocks/test1",
+  "language": "node",
+  "docker": {
+    "dockerfile": ".docker/Dockerfile",
+    "context": "./src/",
+    "command": "node index.js"
+  },
+  "debug": {
+    "docker": {
+      "command": "echo \"DEBUG\""
+    }
+  }
+}

--- a/test/mocks/mock-service/expected-compose.json
+++ b/test/mocks/mock-service/expected-compose.json
@@ -1,0 +1,31 @@
+{
+  "version": "3",
+  "services": {
+    "architect-mocks.test1.latest": {
+      "ports": [
+        "50000:8080"
+      ],
+      "depends_on": [],
+      "environment": {
+        "EXTERNAL_HOST": "",
+        "INTERNAL_HOST": "architect-mocks.test1.latest",
+        "EXTERNAL_PORT": "80",
+        "INTERNAL_PORT": "8080",
+        "HOST": "architect-mocks.test1.latest",
+        "PORT": "8080"
+      },
+      "command": "echo \"DEBUG\"",
+      "build": {
+        "context": "/test/mocks/mock-service/src/",
+        "args": [
+          "ARCHITECT_DEBUG=1"
+        ],
+        "dockerfile": "/test/mocks/mock-service/.docker/Dockerfile"
+      },
+      "volumes": [
+        "/test/mocks/mock-service/src:/usr/src/app/src"
+      ]
+    }
+  },
+  "volumes": {}
+}

--- a/test/mocks/mock-service/src/index.js
+++ b/test/mocks/mock-service/src/index.js
@@ -1,0 +1,1 @@
+console.log('SUCCESS');


### PR DESCRIPTION
Added support for overriding more docker info both locally while debugging and for production flows:

### Locally

```json
{
  "name": "architect/test-service",
  "debug": {
    "docker": {
      "command": "...",
      "dockerfile": "...",
      "context": "....",
      "entrypoint": "..."
    }
  }
}
```

### Remote builds

_Note: There will have to be a fast-follow to ensure that commands are used for deploys from the platform. Dockerfile and context overrides are build-time features and were worked into the `architect build` command in this PR._

```json
{
  "name": "architect/test-service",
  "docker": {
    "command": "...",
    "dockerfile": "...",
    "context": "....",
    "entrypoint": "..."
  }
}
```