### PR TITLE
Added submodule in examples folder to hipster-shop demo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "test/calculator"]
 	path = test/calculator
 	url = https://github.com/architect-team/calculator-sample-project.git
+[submodule "examples/gcp-microservices-demo"]
+	path = examples/gcp-microservices-demo
+	url = git@github.com:architect-team/microservices-demo.git


### PR DESCRIPTION
I made this a submodule instead of copying the contents because the repo is a fork of the parent. It seemed easier to maintain the fork contents as a properly forked repository.