### PR TITLE
add digest to serviceconfig

### DIFF
--- a/src/dependency-manager/src/index.ts
+++ b/src/dependency-manager/src/index.ts
@@ -1,6 +1,8 @@
 import DependencyManager from './manager';
 
 export default DependencyManager;
+export * from './component-config/base';
+export * from './component-config/builder';
 export * from './environment-config/base';
 export * from './environment-config/builder';
 export * from './graph/node';

--- a/src/dependency-manager/src/service-config/base.ts
+++ b/src/dependency-manager/src/service-config/base.ts
@@ -52,6 +52,8 @@ export abstract class ServiceConfig extends BaseSpec {
   abstract getLanguage(): string;
   abstract getImage(): string;
   abstract setImage(image: string): void;
+  abstract getDigest(): string;
+  abstract setDigest(digest: string): void;
   abstract getCommand(): string[];
   abstract getEntrypoint(): string[];
   abstract getDockerfile(): string | undefined;

--- a/src/dependency-manager/src/service-config/v1.ts
+++ b/src/dependency-manager/src/service-config/v1.ts
@@ -200,6 +200,10 @@ export class ServiceConfigV1 extends ServiceConfig {
   @IsString({ always: true })
   image?: string;
 
+  @IsOptional({ always: true })
+  @IsString({ always: true })
+  digest?: string;
+
   @Transform(value => value instanceof Array ? value : shell_parse(value))
   @IsOptional({ always: true })
   @IsString({ always: true, each: true })
@@ -316,6 +320,14 @@ export class ServiceConfigV1 extends ServiceConfig {
 
   setImage(image: string) {
     this.image = image;
+  }
+
+  getDigest(): string {
+    return this.digest || '';
+  }
+
+  setDigest(digest: string): void {
+    this.digest = digest;
   }
 
   getCommand() {


### PR DESCRIPTION
This adds digest to ServiceConfig and adds the ComponentConfig/Builder to the exports.

It doesn't do anything else that we talked about. Those will be with the rest of my `register` branch. Just wanted to get these in so I could reference them.