### PR TITLE
Added optional arg to register components instead of needing the flag

### DIFF
--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -27,11 +27,13 @@ export default class ComponentRegister extends Command {
       description: 'Path to a component to build',
       exclusive: ['environment'],
       multiple: true,
+      hidden: true,
     }),
     environment: flags.string({
       char: 'e',
       description: 'Path to an environment config including local components to build',
       exclusive: ['component'],
+      hidden: true,
     }),
     tag: flags.string({
       char: 't',
@@ -40,10 +42,19 @@ export default class ComponentRegister extends Command {
     }),
   };
 
+  static args = [{
+    name: 'component',
+    description: 'Path to a component to register',
+  }];
+
   async run() {
-    const { flags } = this.parse(ComponentRegister);
+    const { flags, args } = this.parse(ComponentRegister);
 
     const config_paths: Set<string> = new Set();
+
+    if (args.component) {
+      config_paths.add(path.resolve(untildify(args.component)));
+    }
 
     let dependency_manager = await LocalDependencyManager.create(this.app.api);
     if (flags.environment) {
@@ -60,7 +71,9 @@ export default class ComponentRegister extends Command {
         config_path = path.resolve(untildify(config_path));
         config_paths.add(config_path);
       }
-    } else {
+    }
+
+    if (config_paths.size <= 0) {
       throw new MissingContextError();
     }
 

--- a/src/common/errors/missing-build-context.ts
+++ b/src/common/errors/missing-build-context.ts
@@ -2,7 +2,6 @@ export default class MissingContextError extends Error {
   constructor() {
     super();
     this.name = 'missing_build_context';
-    this.message = 'No context was provided. Please specify either an ' +
-      'environment config or service config path.';
+    this.message = 'No context was provided. Please specify a path to a valid Architect service.';
   }
 }


### PR DESCRIPTION
* Hides the flags for registering multiple components at once from the generated docs (via `hidden` flag)
* Adds an argument to the CLI register command to accept the path to a component as the primary arg (e.g. `architect register ./path/to/component`)