### PR TITLE
Fixed public platform specification

### DIFF
--- a/src/commands/platforms/create.ts
+++ b/src/commands/platforms/create.ts
@@ -49,7 +49,7 @@ export default class PlatformCreate extends Command {
   static flags = {
     ...Command.flags,
     ...AccountUtils.flags,
-    type: flags.string({ char: 't', options: ['KUBERNETES', 'kubernetes', 'ARCHITECT_PUBLIC', 'architect_public', 'ECS', 'ecs'] }),
+    type: flags.string({ char: 't', options: ['KUBERNETES', 'kubernetes', 'ARCHITECT', 'architect', 'ECS', 'ecs'] }),
     host: flags.string({ char: 'h' }),
     kubeconfig: flags.string({ char: 'k', default: '~/.kube/config', exclusive: ['service_token', 'cluster_ca_cert', 'host'] }),
     aws_key: flags.string({ exclusive: ['awsconfig', 'kubeconfig', 'service_token', 'cluster_ca_cert', 'host'] }),
@@ -110,7 +110,7 @@ export default class PlatformCreate extends Command {
         choices: [
           'kubernetes',
           'ecs',
-          'public',
+          'architect',
         ],
       },
     ]);
@@ -122,7 +122,7 @@ export default class PlatformCreate extends Command {
         return await KubernetesPlatformUtils.configure_kubernetes_platform(flags);
       case 'ecs':
         return await EcsPlatformUtils.configure_ecs_platform(flags);
-      case 'public':
+      case 'architect':
         return {};
       default:
         throw new Error(`PlatformType=${selected_type} is not currently supported`);

--- a/test/commands/platforms/create.test.ts
+++ b/test/commands/platforms/create.test.ts
@@ -77,7 +77,7 @@ describe('platform:create', function () {
     sinon.replace(PlatformCreate.prototype, 'create_architect_platform', create_platform_spy);
     const post_to_api_spy = sinon.spy(PlatformCreate.prototype, 'post_platform_to_api');
 
-    await PlatformCreate.run(['platform-name', '-a', 'test-account-name', '-t', 'architect_public']);
+    await PlatformCreate.run(['platform-name', '-a', 'test-account-name', '-t', 'architect']);
     expect(create_platform_spy.calledOnce).true;
     expect(post_to_api_spy.calledOnce).true;
   });
@@ -105,7 +105,7 @@ describe('platform:create', function () {
     sinon.replace(PlatformCreate.prototype, 'create_architect_platform', create_platform_spy);
     const post_to_api_spy = sinon.spy(PlatformCreate.prototype, 'post_platform_to_api');
 
-    await PlatformCreate.run(['-a', 'test-account-name', '-t', 'architect_public']);
+    await PlatformCreate.run(['-a', 'test-account-name', '-t', 'architect']);
     expect(create_platform_spy.calledOnce).true;
     expect(post_to_api_spy.calledOnce).true;
   });


### PR DESCRIPTION
Seems we couldn't register the public platform from the CLI. This fixes that.