### PR TITLE
add max length option back into Refs.url_safe_ref

### DIFF
--- a/src/dependency-manager/src/utils/refs.ts
+++ b/src/dependency-manager/src/utils/refs.ts
@@ -8,7 +8,7 @@ export class Refs {
   private static HASH_LENGTH = 7;
   private static DEFAULT_MAX_LENGTH = 63;
 
-  public static url_safe_ref(ref: string): string {
+  public static url_safe_ref(ref: string, max_length: number = Refs.DEFAULT_MAX_LENGTH): string {
     if (ref === GatewaySlugUtils.StringLiteral) {
       return ref;
     }
@@ -26,7 +26,7 @@ export class Refs {
     url_safe_ref = url_safe_ref.replace(/[^a-zA-Z0-9-]/g, Refs.URL_SAFE_PUNCTUATION_REPLACEMENT);
 
     // slice if the whole thing is too long
-    const max_base_length = Refs.DEFAULT_MAX_LENGTH - Refs.HASH_LENGTH - Refs.URL_SAFE_DELIMITER.length - suffix.length;
+    const max_base_length = max_length - Refs.HASH_LENGTH - Refs.URL_SAFE_DELIMITER.length - suffix.length;
     if (url_safe_ref.length > max_base_length) {
       url_safe_ref = url_safe_ref.slice(0, max_base_length - 1);
       // trim any trailing dashes

--- a/test/dependency-manager/utils/refs.test.ts
+++ b/test/dependency-manager/utils/refs.test.ts
@@ -105,4 +105,22 @@ describe('Refs url_safe_ref', () => {
     expect(url_safe_ref).to.equal(abridged_slug);
     expect(url_safe_ref.length).to.be.lessThan(64);
   });
+
+  it(`Refs.url_safe_ref with max_length of 32 cuts environment string to 32 chars`, async () => {
+    const environment_slug = `this-is-a-long-environment-name-that-should-get-cut`;
+    const abridged_slug = `this-is-a-long-enviro--bcpqo07j`;
+
+    const url_safe_ref = Refs.url_safe_ref(environment_slug, 31);
+    expect(url_safe_ref).to.equal(abridged_slug);
+    expect(url_safe_ref.length).to.be.lessThan(32);
+  });
+
+  it(`Refs.url_safe_ref with max_length of 32 cuts component string to 32 chars`, async () => {
+    const component_slug = `this-is-a/component-name-that-has-more-than-63-chars-it-should-get-lopped-off`;
+    const abridged_slug = `this-is-a--component--62o43gic`;
+
+    const url_safe_ref = Refs.url_safe_ref(component_slug, 31);
+    expect(url_safe_ref).to.equal(abridged_slug);
+    expect(url_safe_ref.length).to.be.lessThan(32);
+  });
 });


### PR DESCRIPTION
@tjhiggins we had taken out the `max_length` option from `url_safe_ref()`. I'm having a hard time remembering exactly why, but I think we decided we didn't want the service names variable across docker-compose, kubernetes, aws.

I'm adding it back in so we can use it for resource naming in ECS.

Once you merge this, I'll test and submit the PR for the API.