### PR TITLE
add tasks to component spec

### DIFF
--- a/examples/basic-task/architect.yml
+++ b/examples/basic-task/architect.yml
@@ -1,0 +1,18 @@
+name: examples/basic-task
+description: Example application that schedules recurring cron tasks
+
+parameters:
+  OUTPUT_TEXT:
+    description: Example text to output in cron
+    default: "Hello world"
+
+tasks:
+  date-logger:
+    interfaces:
+    build:
+      image: alpine
+    command: echo "$(date) - ${OUTPUT_TEXT}"
+    environment:
+      OUTPUT_TEXT: ${{ parameters.OUTPUT_TEXT }}
+
+interfaces:

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -103,6 +103,14 @@ export default class ComponentRegister extends Command {
       service_config.image = image;
     }
 
+    if (raw_config.tasks && Object.keys(raw_config.tasks).length) {
+      for (const [task_name, task_config] of Object.entries(raw_config.tasks)) {
+        const image_tag = `${this.app.config.registry_host}/${raw_config.name}-${task_name}:${tag}`;
+        const image = await this.push_image_if_necessary(config_path, task_name, task_config, image_tag);
+        task_config.image = image;
+      }
+    }
+
     const component_dto = {
       tag: tag,
       config: raw_config,

--- a/src/common/dependency-manager/local-manager.ts
+++ b/src/common/dependency-manager/local-manager.ts
@@ -144,6 +144,13 @@ export default class LocalDependencyManager extends DependencyManager {
           component.setService(sk, sv.merge(debug_options));
         }
       }
+      for (const [tk, tv] of Object.entries(component.getTasks())) {
+        // If debug is enabled merge in debug options ex. debug.command -> command
+        const debug_options = tv.getDebugOptions();
+        if (debug_options) {
+          component.setTask(tk, tv.merge(debug_options));
+        }
+      }
     }
     return components_map;
   }

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -100,7 +100,7 @@ export const generate = async (dependency_manager: LocalDependencyManager): Prom
     }
 
     if (node.is_local && node instanceof ServiceNode) {
-      const environment_component = environment.getComponentByServiceRef(node.ref);
+      const environment_component = environment.getComponentByServiceOrTaskRef(node.ref);
       const component_path = fs.lstatSync(node.local_path).isFile() ? path.dirname(node.local_path) : node.local_path;
       if (!node.node_config.getImage()) {
         const build = node.node_config.getBuild();

--- a/src/dependency-manager/src/component-config/builder.ts
+++ b/src/dependency-manager/src/component-config/builder.ts
@@ -22,6 +22,7 @@ class MissingConfigFileError extends Error {
 export interface RawComponentConfig {
   name: string;
   services: Dictionary<RawServiceConfig>;
+  tasks: Dictionary<RawServiceConfig>;
   extends?: string;
 }
 

--- a/src/dependency-manager/src/component-config/v1.ts
+++ b/src/dependency-manager/src/component-config/v1.ts
@@ -34,7 +34,6 @@ interface ServiceContextV1 {
 
 interface TaskContextV1 {
   environment: Dictionary<string>;
-  interfaces: Dictionary<InterfaceSpec>;
 }
 
 export interface ComponentContextV1 {
@@ -72,9 +71,6 @@ export function transformServices(input?: Dictionary<object | ServiceConfigV1>):
 export function transformTasks(input?: Dictionary<object | TaskConfigV1>): Dictionary<TaskConfigV1> {
   if (!input) {
     return {};
-  }
-  if (!(input instanceof Object)) {
-    return input;
   }
 
   const output: any = {};
@@ -177,8 +173,8 @@ export class ComponentConfigV1 extends ComponentConfig {
   @Transform((value) => !value ? {} : value)
   services?: Dictionary<ServiceConfig>;
 
-  @IsOptional({ groups: ['operator'] })
-  @IsOptional({ groups: ['developer'] }) //TODO:84: should this become optional? should (tasks||services) be required?
+  @IsOptional()
+  @IsObject()
   @Transform((value) => !value ? {} : value)
   tasks?: Dictionary<TaskConfig>;
 
@@ -351,15 +347,7 @@ export class ComponentConfigV1 extends ComponentConfig {
 
     const tasks: Dictionary<TaskContextV1> = {};
     for (const [tk, tv] of Object.entries(this.getTasks())) {
-      const interfaces: Dictionary<InterfaceSpec> = {};
-      for (const [ik, iv] of Object.entries(tv.getInterfaces())) {
-        interfaces[ik] = {
-          ...interface_filler,
-          ...iv,
-        };
-      }
       tasks[tk] = {
-        interfaces,
         environment: tv.getEnvironmentVariables(),
       };
     }

--- a/src/dependency-manager/src/environment-config/base.ts
+++ b/src/dependency-manager/src/environment-config/base.ts
@@ -39,11 +39,11 @@ export abstract class EnvironmentConfig extends ConfigSpec {
 
   abstract getContext(): any;
 
-  getComponentByServiceRef(service_ref: string): ComponentConfig | undefined {
-    const service_tag = service_ref.split(':')[1] || 'latest';
+  getComponentByServiceOrTaskRef(ref: string): ComponentConfig | undefined {
+    const tag = ref.split(':')[1] || 'latest';
     for (const component of Object.values(this.getComponents())) {
       const component_tag = component.getRef().split(':')[1] || 'latest';
-      if (service_ref.startsWith(`${component.getName()}/`) && service_tag === component_tag) {
+      if (ref.startsWith(`${component.getName()}/`) && tag === component_tag) {
         return component;
       }
     }

--- a/src/dependency-manager/src/graph/index.ts
+++ b/src/dependency-manager/src/graph/index.ts
@@ -6,6 +6,7 @@ import { DependencyNode } from './node';
 import GatewayNode from './node/gateway';
 import InterfacesNode from './node/interfaces';
 import { ServiceNode } from './node/service';
+import { TaskNode } from './node/task';
 
 export default class DependencyGraph {
   @Type(() => DependencyNode, {
@@ -13,6 +14,7 @@ export default class DependencyGraph {
       property: '__type',
       subTypes: [
         { value: ServiceNode, name: 'service' },
+        { value: TaskNode, name: 'task' },
         { value: InterfacesNode, name: 'interfaces' },
         { value: GatewayNode, name: 'gateway' },
       ],

--- a/src/dependency-manager/src/graph/node/task.ts
+++ b/src/dependency-manager/src/graph/node/task.ts
@@ -1,0 +1,46 @@
+import { Type } from 'class-transformer';
+import { DependencyNode, DependencyNodeOptions } from '.';
+import { TaskConfig } from '../../task-config/base';
+import { TaskConfigV1 } from '../../task-config/v1';
+
+export interface TaskNodeOptions {
+  ref: string;
+  node_config: TaskConfig;
+  local_path?: string;
+}
+
+export class TaskNode extends DependencyNode implements TaskNodeOptions {
+  __type = 'task';
+
+  @Type(() => TaskConfigV1)
+  node_config!: TaskConfig;
+
+  ref!: string;
+  local_path!: string;
+
+  constructor(options: TaskNodeOptions & DependencyNodeOptions) {
+    super();
+    if (options) {
+      this.ref = options.ref;
+      this.node_config = options.node_config;
+      this.local_path = options.local_path || '';
+    }
+  }
+
+  get interfaces(): { [key: string]: any } {
+    return this.node_config.getInterfaces();
+  }
+
+  get ports(): string[] {
+    const ports = Object.values(this.interfaces).map((i) => i.port) as string[];
+    return [...new Set(ports)];
+  }
+
+  get is_external() {
+    return Object.keys(this.interfaces).length > 0 && Object.values(this.interfaces).every((i) => i.host);
+  }
+
+  get is_local() {
+    return this.local_path !== '';
+  }
+}

--- a/src/dependency-manager/src/service-config/v1.ts
+++ b/src/dependency-manager/src/service-config/v1.ts
@@ -246,7 +246,7 @@ export class ServiceConfigV1 extends ServiceConfig {
   environment?: Dictionary<string>;
 
   @IsOptional({ groups: ['operator', 'debug'] })
-  @IsObject({ groups: ['developer'], message: 'interfaces must be defined even if it is empty since the majority of services need to expose ports' })
+  @IsObject({ groups: ['developer'], message: 'interfaces must be defined even if it is empty since the majority of services need to expose ports' }) //TODO:84: this assumption becomes less applicable with tasks
   @Transform((value) => !value ? {} : value)
   interfaces?: Dictionary<InterfaceSpecV1 | string>;
 

--- a/src/dependency-manager/src/task-config/base.ts
+++ b/src/dependency-manager/src/task-config/base.ts
@@ -1,0 +1,9 @@
+import { ServiceConfig } from '../service-config/base';
+
+export abstract class TaskConfig extends ServiceConfig {
+  abstract __version?: string;
+  abstract getSchedule(): string;
+
+  abstract getDebugOptions(): TaskConfig | undefined;
+  abstract setDebugOptions(value: TaskConfig): void;
+}

--- a/src/dependency-manager/src/task-config/v1.ts
+++ b/src/dependency-manager/src/task-config/v1.ts
@@ -1,0 +1,39 @@
+import { Type } from 'class-transformer';
+import { Allow, IsEmpty, IsInstance, IsOptional, IsString } from 'class-validator';
+import { ServiceConfigV1 } from '../service-config/v1';
+import { TaskConfig } from './base';
+
+//TODO:84:Tasks: let's rethink our abstraction patterns a bit here. There's a chance we don't want TaskConfig extending ServiceConfig
+export class TaskConfigV1 extends ServiceConfigV1 implements TaskConfig {
+  @Allow({ always: true })
+  __version?: string;
+
+  @IsOptional({ always: true })
+  @IsString({ always: true })
+  // @Matches(/^[a-zA-Z0-9-_]+$/, {
+  //   message: 'schedule must be a valid cron notation',
+  // }) //TODO:84:Tasks: we need to decide on a cron implementation and then write a regex for it. https://stackoverflow.com/questions/14203122/create-a-regular-expression-for-cron-statement
+  schedule?: string;
+
+  @Type(() => TaskConfigV1)
+  @IsOptional({ always: true })
+  @IsInstance(TaskConfigV1, { always: true })
+  @IsEmpty({ groups: ['debug'] })
+  debug?: TaskConfigV1;
+
+  getSchedule(): string {
+    return this.schedule || '';
+  }
+
+  setSchedule(schedule: string): void {
+    this.schedule = schedule;
+  }
+
+  getDebugOptions(): TaskConfig | undefined {
+    return this.debug;
+  }
+
+  setDebugOptions(value: TaskConfigV1) {
+    this.debug = value;
+  }
+}

--- a/src/dependency-manager/src/utils/validation.ts
+++ b/src/dependency-manager/src/utils/validation.ts
@@ -121,3 +121,35 @@ export const validateInterpolation = (param_value: string, context: any, ignore_
   }
   return errors;
 };
+
+// validates that property1 and property2 do not share any common keys
+export const validateCrossDictionaryCollisions = async <T extends BaseSpec>(
+  target: T,
+  property1: string,
+  property2: string,
+  errors: ValidationError[] = [],
+) => {
+  const dictionary1 = (target as any)[property1];
+  if (dictionary1 === undefined || dictionary1 === null || typeof dictionary1 !== 'object') {
+    return errors;
+  }
+  const dictionary2 = (target as any)[property2];
+  if (dictionary2 === undefined || dictionary2 === null || typeof dictionary2 !== 'object') {
+    return errors;
+  }
+
+  const colliding_keys = Object.keys(dictionary1 || {}).find((s: string) => !!dictionary2[s]);
+  if (colliding_keys?.length) {
+    const error = new ValidationError();
+    error.property = property1;
+    error.target = target;
+    error.value = colliding_keys;
+    error.constraints = {
+      'Collision': `${property1} and ${property2} must not share the same keys`,
+    };
+    error.children = [];
+
+    errors.push(error);
+  }
+  return errors;
+};


### PR DESCRIPTION
@tjhiggins - how does this look directionally? Once you think it's safe to merge, I can get to work on the API.

I've left a number of `TODO:84` scattered here that we're going to want to return to (mostly interfaces and references), but theoretically what I have in this PR should give us enough to go on to get TaskNodes deploying remotely.