### PR TITLE
export TaskNode and TaskConfig

### DIFF
--- a/src/dependency-manager/src/index.ts
+++ b/src/dependency-manager/src/index.ts
@@ -7,7 +7,9 @@ export * from './environment-config/base';
 export * from './environment-config/builder';
 export * from './graph/node';
 export * from './graph/node/service';
+export * from './graph/node/task';
 export * from './service-config/base';
+export * from './task-config/base';
 export * from './utils/refs';
 export * from './utils/slugs';
 


### PR DESCRIPTION
@tjhiggins we also need to export the TaskNode/Config.

Try merging this one in and let's hope tests pass. If not, I think we need to resolve (or remove) that nondeterministic test `deploy.test.ts#describe('local deploy environment', ...)` because the release will block me this AM. I'm still moving forward on the terraform side but soon I'll want to bridge them.