### PR TITLE
add resource spec interface to share between TaskConfig and ServiceCo…

### DIFF
--- a/examples/basic-task/architect.yml
+++ b/examples/basic-task/architect.yml
@@ -2,18 +2,18 @@ name: examples/basic-task
 description: Example application that schedules recurring cron tasks
 
 parameters:
-  # OUTPUT_TEXT:
-  #   description: Example text to output in cron
-  #   default: "Hello world"
+  OUTPUT_TEXT:
+    description: Example text to output in cron
+    default: "Hello world"
 
 tasks:
   date-logger:
     schedule: "*/5 * * * *"
-    image: alpine
-    command: echo "$(date) - Hello again"
-    # environment:
-    #   OUTPUT_TEXT: ${{ parameters.OUTPUT_TEXT }} ## TODO:84:interpolation is not working properly at the moment. You'll see that if you try to add this back in and deploy, the string is not replaced before it is translated into terraform
-    interfaces:
+    image: ellerbrock/alpine-bash-curl-ssl # useful public image with bash and curl pre-installed
+    command: echo $OUTPUT_TEXT && curl $SERVER_URL
+    environment:
+      OUTPUT_TEXT: ${{ parameters.OUTPUT_TEXT }}
+      SERVER_URL: ${{ services.api.interfaces.main.url }}
 
 services:
   api:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6360,7 +6360,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -6525,7 +6525,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,8 +10,9 @@ import untildify from 'untildify';
 import Command from '../base-command';
 import DockerComposeTemplate from '../common/docker-compose/template';
 import { AccountUtils } from '../common/utils/account';
+import { BuildSpecV1, ServiceVolumeV1 } from '../dependency-manager/src/common/v1';
 import { ComponentConfigV1 } from '../dependency-manager/src/component-config/v1';
-import { BuildSpecV1, InterfaceSpecV1, ServiceConfigV1, ServiceVolumeV1 } from '../dependency-manager/src/service-config/v1';
+import { InterfaceSpecV1, ServiceConfigV1 } from '../dependency-manager/src/service-config/v1';
 
 export abstract class InitCommand extends Command {
   auth_required() {

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -193,6 +193,9 @@ export const generate = async (dependency_manager: LocalDependencyManager): Prom
       }
 
       if (!seen_edges.has(`${depends_to}__${depends_from}`)) { // Detect circular refs and pick first one
+        if (!compose.services[depends_from]) {
+          continue; // if the depends_from is not in the compose.services, it is an edge from a task which we ignore in docker-compose
+        }
         compose.services[depends_from].depends_on.push(depends_to);
         seen_edges.add(`${depends_to}__${depends_from}`);
         seen_edges.add(`${depends_from}__${depends_to}`);

--- a/src/dependency-manager/src/common/base.ts
+++ b/src/dependency-manager/src/common/base.ts
@@ -1,0 +1,56 @@
+import { ConfigSpec } from '../utils/base-spec';
+import { Dictionary } from '../utils/dictionary';
+
+export interface VolumeSpec {
+  mount_path?: string;
+  host_path?: string;
+  description?: string;
+  readonly?: boolean;
+}
+
+export interface BuildSpec {
+  context?: string;
+  args?: Dictionary<string>;
+  dockerfile?: string;
+}
+
+export interface DeployModuleSpec {
+  path: string;
+  inputs: Dictionary<string>;
+}
+
+export interface DeploySpec {
+  strategy: string;
+  modules: Dictionary<DeployModuleSpec>;
+}
+
+export interface ResourceConfig extends ConfigSpec {
+  __version?: string;
+  getName(): string;
+  getDescription(): string;
+  getLanguage(): string;
+  getImage(): string;
+  setImage(image: string): void;
+  getCommand(): string[];
+  getEntrypoint(): string[];
+
+  getEnvironmentVariables(): Dictionary<string>;
+  setEnvironmentVariables(value: Dictionary<string>): void;
+  setEnvironmentVariable(key: string, value: string): void;
+
+  getDebugOptions(): ResourceConfig | undefined;
+  setDebugOptions(value: ResourceConfig): void;
+
+  getPlatforms(): Dictionary<any>;
+
+  getVolumes(): Dictionary<VolumeSpec>;
+  setVolumes(value: Dictionary<VolumeSpec | string>): void;
+  setVolume(key: string, value: VolumeSpec | string): void;
+
+  getBuild(): BuildSpec;
+
+  getCpu(): string | undefined;
+  getMemory(): string | undefined;
+
+  getDeploy(): DeploySpec | undefined;
+}

--- a/src/dependency-manager/src/common/v1.ts
+++ b/src/dependency-manager/src/common/v1.ts
@@ -1,0 +1,312 @@
+import { plainToClass } from 'class-transformer';
+import { Transform, Type } from 'class-transformer/decorators';
+import { Allow, IsBoolean, IsEmpty, IsInstance, IsNotEmpty, IsObject, IsOptional, IsString, Matches, ValidatorOptions } from 'class-validator';
+import { parse as shell_parse } from 'shell-quote';
+import { ParameterDefinitionSpecV1 } from '../component-config/v1';
+import { BaseConfig, ValidatableConfig } from '../utils/base-spec';
+import { Dictionary } from '../utils/dictionary';
+import { validateDictionary, validateNested } from '../utils/validation';
+import { ResourceConfig } from './base';
+
+export class ServiceVolumeV1 extends ValidatableConfig {
+  @IsOptional({ always: true })
+  @IsString({ always: true })
+  mount_path?: string;
+
+  @IsOptional({ groups: ['developer', 'operator'] })
+  @IsNotEmpty({
+    groups: ['debug'],
+    message: 'Debug volumes require a host path to mount the volume to',
+  })
+  @IsEmpty({
+    groups: ['developer'],
+    message: 'Cannot hardcode a host mount path in a component outside of the debug block',
+  })
+  @IsString({ always: true })
+  host_path?: string;
+
+  @IsOptional({ always: true })
+  @IsString({ always: true })
+  description?: string;
+
+  @IsOptional({ always: true })
+  @IsBoolean({ always: true })
+  readonly?: boolean;
+}
+
+export class BuildSpecV1 extends ValidatableConfig {
+  @IsOptional({ always: true })
+  @IsString({ always: true })
+  context?: string;
+
+  @IsOptional({ always: true })
+  @IsObject({ always: true })
+  @Transform(value => {
+    if (value) {
+      if (!(value instanceof Object)) {
+        return value;
+      }
+      const output: Dictionary<string> = {};
+      for (const [k, v] of Object.entries(value)) {
+        output[k] = `${v}`;
+      }
+      return output;
+    }
+  })
+  args?: Dictionary<string>;
+
+  @IsOptional({ always: true })
+  @IsString({ always: true })
+  dockerfile?: string;
+}
+
+export class DeployModuleSpecV1 extends ValidatableConfig {
+  @IsString({ always: true })
+  path!: string;
+
+  @IsObject({ always: true })
+  inputs!: Dictionary<string>;
+}
+
+export class DeploySpecV1 extends ValidatableConfig {
+  @IsString({ always: true })
+  strategy!: string;
+
+  @IsObject({ always: true })
+  modules!: Dictionary<DeployModuleSpecV1>;
+}
+
+export const transformParameters = (input?: Dictionary<any>): Dictionary<ParameterDefinitionSpecV1> | undefined => {
+  if (!input) {
+    return {};
+  }
+  if (!(input instanceof Object)) {
+    return input;
+  }
+
+  const output: Dictionary<ParameterDefinitionSpecV1> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (value && typeof value === 'object') {
+      output[key] = plainToClass(ParameterDefinitionSpecV1, value);
+    } else {
+      output[key] = plainToClass(ParameterDefinitionSpecV1, {
+        default: value,
+      });
+    }
+  }
+  return output;
+};
+
+export const transformVolumes = (input?: Dictionary<string | Dictionary<any>>): Dictionary<ServiceVolumeV1> | undefined => {
+  if (!input) {
+    return {};
+  }
+  if (!(input instanceof Object)) {
+    return input;
+  }
+
+  const output: Dictionary<ServiceVolumeV1> = {};
+
+  for (const [key, value] of Object.entries(input)) {
+    output[key] = value instanceof Object
+      ? plainToClass(ServiceVolumeV1, value)
+      : plainToClass(ServiceVolumeV1, { host_path: value });
+  }
+  return output;
+};
+
+export class ResourceConfigV1 extends BaseConfig implements ResourceConfig {
+  @Allow({ always: true })
+  __version?: string;
+
+  @IsOptional({ always: true })
+  @IsString({ always: true })
+  @Matches(/^[a-zA-Z0-9-_]+$/, {
+    message: 'Names must only include letters, numbers, dashes, and underscores',
+  })
+  name?: string;
+
+  @IsOptional({ always: true })
+  @IsString({ always: true })
+  description?: string;
+
+  @IsOptional({ always: true })
+  @IsString({ always: true })
+  image?: string;
+
+  @IsOptional({ always: true })
+  @IsString({ always: true, each: true })
+  command?: string | string[];
+
+  @IsOptional({ always: true })
+  @IsString({ always: true, each: true })
+  entrypoint?: string | string[];
+
+  @IsOptional({ always: true })
+  @IsString({ always: true })
+  language?: string;
+
+  @Type(() => ResourceConfigV1)
+  @IsOptional({ always: true })
+  @IsInstance(ResourceConfigV1, { always: true })
+  @IsEmpty({ groups: ['debug'] })
+  debug?: ResourceConfigV1;
+
+  @IsOptional({ always: true })
+  @IsObject({ always: true })
+  environment?: Dictionary<string>;
+
+  @IsOptional({ always: true })
+  platforms?: Dictionary<any>;
+
+  @IsOptional({ always: true })
+  @IsObject({ always: true })
+  volumes?: Dictionary<ServiceVolumeV1 | string>;
+
+  @IsOptional({ always: true })
+  @Type(() => BuildSpecV1)
+  build?: BuildSpecV1;
+
+  @IsOptional({ always: true })
+  @Type(() => String)
+  cpu?: string;
+
+  @IsOptional({ always: true })
+  @Type(() => String)
+  memory?: string;
+
+  @IsOptional({ always: true })
+  deploy?: DeploySpecV1;
+
+  async validate(options?: ValidatorOptions) {
+    if (!options) { options = {}; }
+    let errors = await super.validate(options);
+    if (errors.length) return errors;
+    const expanded = this.expand();
+    errors = await validateNested(expanded, 'debug', errors, { ...options, groups: (options.groups || []).concat('debug') });
+    errors = await validateNested(expanded, 'liveness_probe', errors, options);
+    // Hack to overcome conflicting IsEmpty vs IsNotEmpty with developer vs debug
+    const volumes_options = { ...options };
+    if (volumes_options.groups && volumes_options.groups.includes('debug')) {
+      volumes_options.groups = ['debug'];
+    }
+    errors = await validateDictionary(expanded, 'environment', errors, undefined, options, /^[a-zA-Z0-9_]+$/);
+    errors = await validateDictionary(expanded, 'volumes', errors, undefined, volumes_options);
+    errors = await validateDictionary(expanded, 'interfaces', errors, undefined, options);
+    return errors;
+  }
+
+  getName(): string {
+    return this.name || '';
+  }
+
+  getImage(): string {
+    return this.image || '';
+  }
+
+  setImage(image: string) {
+    this.image = image;
+  }
+
+  getCommand() {
+    if (!this.command) return [];
+    return this.command instanceof Array ? this.command : shell_parse(this.command).map(e => `${e}`);
+  }
+
+  getEntrypoint() {
+    if (!this.entrypoint) return [];
+    return this.entrypoint instanceof Array ? this.entrypoint : shell_parse(this.entrypoint).map(e => `${e}`);
+  }
+
+  getEnvironmentVariables(): Dictionary<string> {
+    const output: Dictionary<string> = {};
+    for (const [k, v] of Object.entries(this.environment || {})) {
+      output[k] = `${v}`;
+    }
+    return output;
+  }
+
+  setEnvironmentVariables(value: Dictionary<string>) {
+    this.environment = value;
+  }
+
+  setEnvironmentVariable(key: string, value: string) {
+    if (!this.environment) {
+      this.environment = {};
+    }
+    this.environment[key] = value;
+  }
+
+  getDebugOptions(): ResourceConfigV1 | undefined {
+    return this.debug;
+  }
+
+  setDebugOptions(value: ResourceConfigV1) {
+    this.debug = value;
+  }
+
+  getLanguage(): string {
+    if (!this.language) {
+      throw new Error(`Missing language for service, ${this.name}`);
+    }
+
+    return this.language;
+  }
+
+  getDescription() {
+    return this.description || '';
+  }
+
+  getPlatforms(): Dictionary<any> {
+    return this.platforms || {};
+  }
+
+  getVolumes(): Dictionary<ServiceVolumeV1> {
+    return transformVolumes(this.volumes) || {};
+  }
+
+  setVolumes(value: Dictionary<ServiceVolumeV1 | string>) {
+    this.volumes = value;
+  }
+
+  setVolume(key: string, value: ServiceVolumeV1 | string) {
+    if (!this.volumes) {
+      this.volumes = {};
+    }
+    this.volumes[key] = value;
+  }
+
+  getBuild() {
+    if (!this.build && !this.image) {
+      this.build = new BuildSpecV1();
+      this.build.context = '.';
+    }
+    return this.build || {};
+  }
+
+  getCpu() {
+    return this.cpu;
+  }
+
+  getMemory() {
+    return this.memory;
+  }
+
+  getDeploy(): DeploySpecV1 | undefined {
+    return this.deploy;
+  }
+
+  /** @return New expanded copy of the current config */
+  expand() {
+    const config = this.copy();
+
+    const debug = config.getDebugOptions();
+    if (debug) {
+      config.setDebugOptions(debug.expand());
+    }
+    for (const [key, value] of Object.entries(this.getVolumes())) {
+      config.setVolume(key, value);
+    }
+    return config;
+  }
+}

--- a/src/dependency-manager/src/component-config/base.ts
+++ b/src/dependency-manager/src/component-config/base.ts
@@ -1,6 +1,6 @@
 import { InterfaceSpec, ServiceConfig } from '../service-config/base';
 import { TaskConfig } from '../task-config/base';
-import { ConfigSpec } from '../utils/base-spec';
+import { BaseConfig } from '../utils/base-spec';
 import { Dictionary } from '../utils/dictionary';
 import { ComponentSlug, ComponentTag, ComponentVersionSlug, ComponentVersionSlugUtils, InterfaceSlugUtils, ServiceVersionSlug, ServiceVersionSlugUtils } from '../utils/slugs';
 
@@ -14,7 +14,7 @@ export interface ParameterDefinitionSpec {
 
 export type ParameterValueSpec = ParameterValue | ParameterDefinitionSpec;
 
-export abstract class ComponentConfig extends ConfigSpec {
+export abstract class ComponentConfig extends BaseConfig {
   abstract __version?: string;
 
   abstract getName(): ComponentSlug;

--- a/src/dependency-manager/src/component-config/builder.ts
+++ b/src/dependency-manager/src/component-config/builder.ts
@@ -4,7 +4,7 @@ import { plainToClass } from 'class-transformer';
 import fs from 'fs-extra';
 import yaml from 'js-yaml';
 import path from 'path';
-import { DeploySpec } from '../service-config/base';
+import { DeploySpec } from '../common/base';
 import { Dictionary } from '../utils/dictionary';
 import { flattenValidationErrorsWithLineNumbers, ValidationErrors } from '../utils/errors';
 import { insertFileDataFromRefs } from '../utils/files';

--- a/src/dependency-manager/src/environment-config/base.ts
+++ b/src/dependency-manager/src/environment-config/base.ts
@@ -1,6 +1,6 @@
 import { InterfaceSpec } from '..';
 import { ComponentConfig, ParameterDefinitionSpec, ParameterValueSpec } from '../component-config/base';
-import { ConfigSpec } from '../utils/base-spec';
+import { BaseConfig } from '../utils/base-spec';
 import { Dictionary } from '../utils/dictionary';
 
 export interface EnvironmentVault {
@@ -17,7 +17,7 @@ export interface DnsConfig {
 }
 
 // TODO investigate extending ComponentConfig
-export abstract class EnvironmentConfig extends ConfigSpec {
+export abstract class EnvironmentConfig extends BaseConfig {
   abstract __version?: string;
   abstract getParameters(): Dictionary<ParameterDefinitionSpec>;
   abstract setParameters(value: Dictionary<ParameterValueSpec>): void;

--- a/src/dependency-manager/src/environment-config/v1.ts
+++ b/src/dependency-manager/src/environment-config/v1.ts
@@ -1,9 +1,10 @@
 import { Allow, IsObject, IsOptional, ValidatorOptions } from 'class-validator';
 import { InterfaceSpec, ParameterValue } from '..';
+import { transformParameters } from '../common/v1';
 import { ComponentConfig } from '../component-config/base';
 import { ComponentConfigBuilder } from '../component-config/builder';
 import { ComponentContextV1, ParameterValueSpecV1, transformInterfaces } from '../component-config/v1';
-import { InterfaceSpecV1, transformParameters } from '../service-config/v1';
+import { InterfaceSpecV1 } from '../service-config/v1';
 import { Dictionary } from '../utils/dictionary';
 import { normalizeInterpolation } from '../utils/interpolation';
 import { ComponentVersionSlugUtils, Slugs } from '../utils/slugs';

--- a/src/dependency-manager/src/graph/node/task.ts
+++ b/src/dependency-manager/src/graph/node/task.ts
@@ -28,7 +28,7 @@ export class TaskNode extends DependencyNode implements TaskNodeOptions {
   }
 
   get interfaces(): { [key: string]: any } {
-    return this.node_config.getInterfaces();
+    return {};
   }
 
   get ports(): string[] {

--- a/src/dependency-manager/src/index.ts
+++ b/src/dependency-manager/src/index.ts
@@ -1,6 +1,7 @@
 import DependencyManager from './manager';
 
 export default DependencyManager;
+export * from './common/base';
 export * from './component-config/base';
 export * from './component-config/builder';
 export * from './environment-config/base';

--- a/src/dependency-manager/src/service-config/base.ts
+++ b/src/dependency-manager/src/service-config/base.ts
@@ -1,4 +1,4 @@
-import { ConfigSpec } from '../utils/base-spec';
+import { ResourceConfig } from '../common/base';
 import { Dictionary } from '../utils/dictionary';
 
 export interface InterfaceSpec {
@@ -21,79 +21,14 @@ export interface ServiceLivenessProbe {
   initial_delay?: string;
 }
 
-export interface VolumeSpec {
-  mount_path?: string;
-  host_path?: string;
-  description?: string;
-  readonly?: boolean;
-}
+export interface ServiceConfig extends ResourceConfig {
+  getInterfaces(): Dictionary<InterfaceSpec>;
+  setInterfaces(value: Dictionary<InterfaceSpec | string>): void;
+  setInterface(key: string, value: InterfaceSpec | string): void;
 
-export interface BuildSpec {
-  context?: string;
-  args?: Dictionary<string>;
-  dockerfile?: string;
-}
+  getDebugOptions(): ServiceConfig | undefined;
+  setDebugOptions(value: ServiceConfig): void;
 
-export interface DeployModuleSpec {
-  path: string;
-  inputs: Dictionary<string>;
-}
-
-export interface DeploySpec {
-  strategy: string;
-  modules: Dictionary<DeployModuleSpec>;
-}
-
-export abstract class ServiceConfig extends ConfigSpec {
-  abstract __version?: string;
-  abstract getName(): string;
-  abstract getDescription(): string;
-  abstract getLanguage(): string;
-  abstract getImage(): string;
-  abstract setImage(image: string): void;
-  abstract getCommand(): string[];
-  abstract getEntrypoint(): string[];
-
-  abstract getEnvironmentVariables(): Dictionary<string>;
-  abstract setEnvironmentVariables(value: Dictionary<string>): void;
-  abstract setEnvironmentVariable(key: string, value: string): void;
-
-  abstract getInterfaces(): Dictionary<InterfaceSpec>;
-  abstract setInterfaces(value: Dictionary<InterfaceSpec | string>): void;
-  abstract setInterface(key: string, value: InterfaceSpec | string): void;
-
-  abstract getDebugOptions(): ServiceConfig | undefined;
-  abstract setDebugOptions(value: ServiceConfig): void;
-
-  abstract getPlatforms(): Dictionary<any>;
-
-  abstract getVolumes(): Dictionary<VolumeSpec>;
-  abstract setVolumes(value: Dictionary<VolumeSpec | string>): void;
-  abstract setVolume(key: string, value: VolumeSpec | string): void;
-
-  abstract getReplicas(): string;
-  abstract getLivenessProbe(): ServiceLivenessProbe | undefined;
-  abstract getBuild(): BuildSpec;
-
-  abstract getCpu(): string | undefined;
-  abstract getMemory(): string | undefined;
-
-  abstract getDeploy(): DeploySpec | undefined;
-
-  /** @return New expanded copy of the current config */
-  expand() {
-    const config = this.copy();
-
-    const debug = config.getDebugOptions();
-    if (debug) {
-      config.setDebugOptions(debug.expand());
-    }
-    for (const [key, value] of Object.entries(this.getInterfaces())) {
-      config.setInterface(key, value);
-    }
-    for (const [key, value] of Object.entries(this.getVolumes())) {
-      config.setVolume(key, value);
-    }
-    return config;
-  }
+  getReplicas(): string;
+  getLivenessProbe(): ServiceLivenessProbe | undefined;
 }

--- a/src/dependency-manager/src/service-config/v1.ts
+++ b/src/dependency-manager/src/service-config/v1.ts
@@ -1,15 +1,15 @@
 import { plainToClass } from 'class-transformer';
 import { Transform, Type } from 'class-transformer/decorators';
-import { Allow, ArrayUnique, IsArray, IsBoolean, IsEmpty, IsInstance, IsNotEmpty, IsObject, IsOptional, IsString, IsUrl, Matches, ValidateIf, ValidatorOptions } from 'class-validator';
+import { ArrayUnique, IsArray, IsEmpty, IsInstance, IsNotEmpty, IsObject, IsOptional, IsString, IsUrl, ValidateIf, ValidatorOptions } from 'class-validator';
 import { parse as shell_parse } from 'shell-quote';
-import { ParameterDefinitionSpecV1 } from '../component-config/v1';
-import { BaseSpec } from '../utils/base-spec';
+import { ResourceConfigV1 } from '../common/v1';
+import { ValidatableConfig } from '../utils/base-spec';
 import { Dictionary } from '../utils/dictionary';
 import { validateDictionary, validateNested } from '../utils/validation';
 import { Exclusive } from '../utils/validators/exclusive';
-import { DeploySpec, ServiceConfig, ServiceLivenessProbe, VolumeSpec } from './base';
+import { ServiceConfig, ServiceLivenessProbe } from './base';
 
-class LivenessProbeV1 extends BaseSpec {
+class LivenessProbeV1 extends ValidatableConfig {
   @IsOptional({ always: true })
   @Type(() => String)
   success_threshold?: string;
@@ -47,7 +47,7 @@ class LivenessProbeV1 extends BaseSpec {
   port?: string;
 }
 
-export class InterfaceSpecV1 extends BaseSpec {
+export class InterfaceSpecV1 extends ValidatableConfig {
   @IsOptional({ always: true })
   @IsString({ always: true })
   description?: string;
@@ -80,113 +80,6 @@ export class InterfaceSpecV1 extends BaseSpec {
   domains?: string[];
 }
 
-export class ServiceVolumeV1 extends BaseSpec {
-  @IsOptional({ always: true })
-  @IsString({ always: true })
-  mount_path?: string;
-
-  @IsOptional({ groups: ['developer', 'operator'] })
-  @IsNotEmpty({
-    groups: ['debug'],
-    message: 'Debug volumes require a host path to mount the volume to',
-  })
-  @IsEmpty({
-    groups: ['developer'],
-    message: 'Cannot hardcode a host mount path in a component outside of the debug block',
-  })
-  @IsString({ always: true })
-  host_path?: string;
-
-  @IsOptional({ always: true })
-  @IsString({ always: true })
-  description?: string;
-
-  @IsOptional({ always: true })
-  @IsBoolean({ always: true })
-  readonly?: boolean;
-}
-
-export class BuildSpecV1 extends BaseSpec {
-  @IsOptional({ always: true })
-  @IsString({ always: true })
-  context?: string;
-
-  @IsOptional({ always: true })
-  @IsObject({ always: true })
-  @Transform(value => {
-    if (value) {
-      if (!(value instanceof Object)) {
-        return value;
-      }
-      const output: Dictionary<string> = {};
-      for (const [k, v] of Object.entries(value)) {
-        output[k] = `${v}`;
-      }
-      return output;
-    }
-  })
-  args?: Dictionary<string>;
-
-  @IsOptional({ always: true })
-  @IsString({ always: true })
-  dockerfile?: string;
-}
-
-export class DeployModuleSpecV1 extends BaseSpec {
-  @IsString({ always: true })
-  path!: string;
-
-  @IsObject({ always: true })
-  inputs!: Dictionary<string>;
-}
-
-export class DeploySpecV1 extends BaseSpec {
-  @IsString({ always: true })
-  strategy!: string;
-
-  @IsObject({ always: true })
-  modules!: Dictionary<DeployModuleSpecV1>;
-}
-
-export const transformParameters = (input?: Dictionary<any>): Dictionary<ParameterDefinitionSpecV1> | undefined => {
-  if (!input) {
-    return {};
-  }
-  if (!(input instanceof Object)) {
-    return input;
-  }
-
-  const output: Dictionary<ParameterDefinitionSpecV1> = {};
-  for (const [key, value] of Object.entries(input)) {
-    if (value && typeof value === 'object') {
-      output[key] = plainToClass(ParameterDefinitionSpecV1, value);
-    } else {
-      output[key] = plainToClass(ParameterDefinitionSpecV1, {
-        default: value,
-      });
-    }
-  }
-  return output;
-};
-
-const transformVolumes = (input?: Dictionary<string | Dictionary<any>>): Dictionary<ServiceVolumeV1> | undefined => {
-  if (!input) {
-    return {};
-  }
-  if (!(input instanceof Object)) {
-    return input;
-  }
-
-  const output: Dictionary<ServiceVolumeV1> = {};
-
-  for (const [key, value] of Object.entries(input)) {
-    output[key] = value instanceof Object
-      ? plainToClass(ServiceVolumeV1, value)
-      : plainToClass(ServiceVolumeV1, { host_path: value });
-  }
-  return output;
-};
-
 export const transformInterfaces = function (input?: Dictionary<string | Dictionary<any>>): Dictionary<InterfaceSpecV1> | undefined {
   if (!input) {
     return {};
@@ -204,49 +97,15 @@ export const transformInterfaces = function (input?: Dictionary<string | Diction
   return output;
 };
 
-export class ServiceConfigV1 extends ServiceConfig {
-  @Allow({ always: true })
-  __version?: string;
-
-  @IsOptional({ always: true })
-  @IsString({ always: true })
-  @Matches(/^[a-zA-Z0-9-_]+$/, {
-    message: 'Names must only include letters, numbers, dashes, and underscores',
-  })
-  name?: string;
-
-  @IsOptional({ always: true })
-  @IsString({ always: true })
-  description?: string;
-
-  @IsOptional({ always: true })
-  @IsString({ always: true })
-  image?: string;
-
-  @IsOptional({ always: true })
-  @IsString({ always: true, each: true })
-  command?: string | string[];
-
-  @IsOptional({ always: true })
-  @IsString({ always: true, each: true })
-  entrypoint?: string | string[];
-
-  @IsOptional({ always: true })
-  @IsString({ always: true })
-  language?: string;
-
+export class ServiceConfigV1 extends ResourceConfigV1 implements ServiceConfig {
   @Type(() => ServiceConfigV1)
   @IsOptional({ always: true })
   @IsInstance(ServiceConfigV1, { always: true })
   @IsEmpty({ groups: ['debug'] })
   debug?: ServiceConfigV1;
 
-  @IsOptional({ always: true })
-  @IsObject({ always: true })
-  environment?: Dictionary<string>;
-
   @IsOptional({ groups: ['operator', 'debug'] })
-  @IsObject({ groups: ['developer'], message: 'interfaces must be defined even if it is empty since the majority of services need to expose ports' }) //TODO:84: this assumption becomes less applicable with tasks
+  @IsObject({ groups: ['developer'], message: 'interfaces must be defined even if it is empty since the majority of services need to expose ports' })
   @Transform((value) => !value ? {} : value)
   interfaces?: Dictionary<InterfaceSpecV1 | string>;
 
@@ -256,13 +115,6 @@ export class ServiceConfigV1 extends ServiceConfig {
   liveness_probe?: LivenessProbeV1;
 
   @IsOptional({ always: true })
-  platforms?: Dictionary<any>;
-
-  @IsOptional({ always: true })
-  @IsObject({ always: true })
-  volumes?: Dictionary<ServiceVolumeV1 | string>;
-
-  @IsOptional({ always: true })
   @IsEmpty({
     groups: ['developer'],
     message: 'Cannot hardcode a replica count when registering services',
@@ -270,41 +122,14 @@ export class ServiceConfigV1 extends ServiceConfig {
   @Type(() => String)
   replicas?: string;
 
-  @IsOptional({ always: true })
-  @Type(() => BuildSpecV1)
-  build?: BuildSpecV1;
-
-  @IsOptional({ always: true })
-  @Type(() => String)
-  cpu?: string;
-
-  @IsOptional({ always: true })
-  @Type(() => String)
-  memory?: string;
-
-  @IsOptional({ always: true })
-  deploy?: DeploySpecV1;
-
   async validate(options?: ValidatorOptions) {
     if (!options) { options = {}; }
     let errors = await super.validate(options);
     if (errors.length) return errors;
     const expanded = this.expand();
-    errors = await validateNested(expanded, 'debug', errors, { ...options, groups: (options.groups || []).concat('debug') });
     errors = await validateNested(expanded, 'liveness_probe', errors, options);
-    // Hack to overcome conflicting IsEmpty vs IsNotEmpty with developer vs debug
-    const volumes_options = { ...options };
-    if (volumes_options.groups && volumes_options.groups.includes('debug')) {
-      volumes_options.groups = ['debug'];
-    }
-    errors = await validateDictionary(expanded, 'environment', errors, undefined, options, /^[a-zA-Z0-9_]+$/);
-    errors = await validateDictionary(expanded, 'volumes', errors, undefined, volumes_options);
     errors = await validateDictionary(expanded, 'interfaces', errors, undefined, options);
     return errors;
-  }
-
-  getName(): string {
-    return this.name || '';
   }
 
   getInterfaces() {
@@ -341,44 +166,7 @@ export class ServiceConfigV1 extends ServiceConfig {
     return liveness_probe as ServiceLivenessProbe;
   }
 
-  getImage(): string {
-    return this.image || '';
-  }
-
-  setImage(image: string) {
-    this.image = image;
-  }
-
-  getCommand() {
-    if (!this.command) return [];
-    return this.command instanceof Array ? this.command : shell_parse(this.command).map(e => `${e}`);
-  }
-
-  getEntrypoint() {
-    if (!this.entrypoint) return [];
-    return this.entrypoint instanceof Array ? this.entrypoint : shell_parse(this.entrypoint).map(e => `${e}`);
-  }
-
-  getEnvironmentVariables(): Dictionary<string> {
-    const output: Dictionary<string> = {};
-    for (const [k, v] of Object.entries(this.environment || {})) {
-      output[k] = `${v}`;
-    }
-    return output;
-  }
-
-  setEnvironmentVariables(value: Dictionary<string>) {
-    this.environment = value;
-  }
-
-  setEnvironmentVariable(key: string, value: string) {
-    if (!this.environment) {
-      this.environment = {};
-    }
-    this.environment[key] = value;
-  }
-
-  getDebugOptions(): ServiceConfig | undefined {
+  getDebugOptions(): ServiceConfigV1 | undefined {
     return this.debug;
   }
 
@@ -386,58 +174,16 @@ export class ServiceConfigV1 extends ServiceConfig {
     this.debug = value;
   }
 
-  getLanguage(): string {
-    if (!this.language) {
-      throw new Error(`Missing language for service, ${this.name}`);
-    }
-
-    return this.language;
-  }
-
-  getDescription() {
-    return this.description || '';
-  }
-
-  getPlatforms(): Dictionary<any> {
-    return this.platforms || {};
-  }
-
-  getVolumes(): Dictionary<VolumeSpec> {
-    return transformVolumes(this.volumes) || {};
-  }
-
-  setVolumes(value: Dictionary<ServiceVolumeV1 | string>) {
-    this.volumes = value;
-  }
-
-  setVolume(key: string, value: ServiceVolumeV1 | string) {
-    if (!this.volumes) {
-      this.volumes = {};
-    }
-    this.volumes[key] = value;
-  }
-
   getReplicas() {
     return this.replicas || '1';
   }
 
-  getBuild() {
-    if (!this.build && !this.image) {
-      this.build = new BuildSpecV1();
-      this.build.context = '.';
+  /** @return New expanded copy of the current config */
+  expand() {
+    const config = super.expand();
+    for (const [key, value] of Object.entries(this.getInterfaces())) {
+      config.setInterface(key, value);
     }
-    return this.build || {};
-  }
-
-  getCpu() {
-    return this.cpu;
-  }
-
-  getMemory() {
-    return this.memory;
-  }
-
-  getDeploy(): DeploySpec | undefined {
-    return this.deploy;
+    return config;
   }
 }

--- a/src/dependency-manager/src/task-config/base.ts
+++ b/src/dependency-manager/src/task-config/base.ts
@@ -1,9 +1,10 @@
-import { ServiceConfig } from '../service-config/base';
+import { ResourceConfig } from '../common/base';
 
-export abstract class TaskConfig extends ServiceConfig {
-  abstract __version?: string;
-  abstract getSchedule(): string;
+export interface TaskConfig extends ResourceConfig {
+  __version?: string;
 
-  abstract getDebugOptions(): TaskConfig | undefined;
-  abstract setDebugOptions(value: TaskConfig): void;
+  getDebugOptions(): TaskConfig | undefined;
+  setDebugOptions(value: TaskConfig): void;
+
+  getSchedule(): string;
 }

--- a/src/dependency-manager/src/utils/base-spec.ts
+++ b/src/dependency-manager/src/utils/base-spec.ts
@@ -2,7 +2,7 @@ import { classToClass, plainToClassFromExist } from 'class-transformer';
 import { ClassType } from 'class-transformer/ClassTransformer';
 import { validate, ValidationError, ValidatorOptions } from 'class-validator';
 
-export abstract class BaseSpec {
+export abstract class ValidatableConfig {
   async validate(options?: ValidatorOptions): Promise<ValidationError[]> {
     options = { whitelist: true, forbidNonWhitelisted: true, forbidUnknownValues: true, ...(options || {}) };
     return validate(this, options);
@@ -19,7 +19,7 @@ export abstract class BaseSpec {
   }
 }
 
-export abstract class ConfigSpec extends BaseSpec {
+export abstract class BaseConfig extends ValidatableConfig implements ConfigSpec {
   /** @return New copy of the current config */
   copy(): this {
     return classToClass(this);
@@ -35,4 +35,19 @@ export abstract class ConfigSpec extends BaseSpec {
 
   /** @return New expanded copy of the current config */
   abstract expand(): this;
+}
+
+
+export interface ConfigSpec {
+  validate(options?: ValidatorOptions): Promise<ValidationError[]>;
+
+  validateOrReject(options?: ValidatorOptions): Promise<undefined>;
+
+  getClass(): ClassType<any>;
+
+  copy(): this;
+
+  merge(config: this): this;
+
+  expand(): this;
 }

--- a/src/dependency-manager/src/utils/validation.ts
+++ b/src/dependency-manager/src/utils/validation.ts
@@ -1,5 +1,5 @@
 import { isObject, matches, ValidationError, ValidatorOptions } from 'class-validator';
-import { BaseSpec } from './base-spec';
+import { ValidatableConfig } from './base-spec';
 import { interpolateString, InterpolationErrors } from './interpolation';
 
 export const validateNested = async <T extends Record<string, any>>(
@@ -27,7 +27,7 @@ export const validateNested = async <T extends Record<string, any>>(
     for (const index in value) {
       error.children = await validateNested(value, index, error.children, options);
     }
-  } else if (value instanceof BaseSpec) {
+  } else if (value instanceof ValidatableConfig) {
     error.children = await value.validate(options) || [];
   }
 
@@ -38,7 +38,7 @@ export const validateNested = async <T extends Record<string, any>>(
   return errors;
 };
 
-export const validateDictionary = async <T extends BaseSpec>(
+export const validateDictionary = async <T extends ValidatableConfig>(
   target: T,
   property: string,
   errors: ValidationError[] = [],
@@ -123,7 +123,7 @@ export const validateInterpolation = (param_value: string, context: any, ignore_
 };
 
 // validates that property1 and property2 do not share any common keys
-export const validateCrossDictionaryCollisions = async <T extends BaseSpec>(
+export const validateCrossDictionaryCollisions = async <T extends ValidatableConfig>(
   target: T,
   property1: string,
   property2: string,

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -4,8 +4,8 @@ import fs from 'fs';
 import yaml from 'js-yaml';
 import path from 'path';
 import sinon from 'sinon';
+import { BuildSpecV1 } from '../../src/dependency-manager/src/common/v1';
 import { ComponentConfigV1 } from '../../src/dependency-manager/src/component-config/v1';
-import { BuildSpecV1 } from '../../src/dependency-manager/src/service-config/v1';
 import { mockArchitectAuth, MOCK_API_HOST } from '../utils/mocks';
 
 describe('init', function () {

--- a/test/commands/login.test.ts
+++ b/test/commands/login.test.ts
@@ -7,7 +7,7 @@ describe('login', () => {
   const print = false;
 
   test
-    .timeout(10000)
+    .timeout(20000)
     .stderr({ print })
     .command(['login', '-e', 'test-email'])
     .catch(ctx => {
@@ -16,6 +16,7 @@ describe('login', () => {
     .it('requires both email and password when not in a tty environment');
 
   test
+    .timeout(20000)
     .stderr({ print })
     .command(['login'])
     .catch(ctx => {

--- a/test/dependency-manager/examples-validation.test.ts
+++ b/test/dependency-manager/examples-validation.test.ts
@@ -1,3 +1,4 @@
+import fs from 'fs-extra';
 import mock_fs from 'mock-fs';
 import moxios from 'moxios';
 import sinon from 'sinon';
@@ -6,7 +7,6 @@ import PortUtil from '../../src/common/utils/port';
 import { ComponentConfigBuilder } from '../../src/dependency-manager/src';
 
 // This test validates the architect.yml file for each of our example components to ensure that none go out of date
-// TODO:84: add validation for all the other example architect.ymls
 describe('example component validation', function () {
   beforeEach(async () => {
     // Stub the logger
@@ -33,14 +33,24 @@ describe('example component validation', function () {
   });
 
   describe('example components', function () {
-    it('passes validOrReject for the developer group', async () => {
-      const component_config = await ComponentConfigBuilder.buildFromPath('examples/basic-task/architect.yml');
+    const EXAMPLES_DIR = 'examples';
+    var example_architect_dirs = fs.readdirSync(EXAMPLES_DIR);
 
-      try {
-        await component_config.validateOrReject({ groups: ['developer'] });
-      } catch (err) {
-        console.log(err);
+    for (const example_dir of example_architect_dirs) {
+      if (fs.existsSync(`${EXAMPLES_DIR}/${example_dir}/architect.yml`)) {
+
+        it(`${EXAMPLES_DIR}/${example_dir}/architect.yml passes validOrReject for the developer group`, async () => {
+          const component_config = await ComponentConfigBuilder.buildFromPath(`${EXAMPLES_DIR}/${example_dir}/architect.yml`);
+
+          try {
+            await component_config.validateOrReject({ groups: ['developer'] });
+          } catch (err) {
+            console.log('An example architect file is failing the #validateOrReject() method', err);
+            throw err;
+          }
+        });
+
       }
-    });
+    }
   });
 });


### PR DESCRIPTION
@tjhiggins this refactors the TaskConfig and the ServiceConfig to both implement a ResourceSpec interface with common properties, rather than having the TaskConfig extend the ServiceConfig.

I'm open to alternative OO patterns here to achieve the competing goals of using inheritance for versioning but also wanting to keep track of common properties.