### PR TITLE
Added typescript interface representing the component spec

### DIFF
--- a/src/dependency-manager/README.md
+++ b/src/dependency-manager/README.md
@@ -1,4 +1,38 @@
-architect dependency graph
+Architect dependency-manager
 =============
 
-Library used to consolidate service dependencies into a consistent graph format.
+Library used for ingesting component specs and converting them to application graphs.
+
+## Generating and using json schema
+
+This project uses the [JSON schema](https://json-schema.org/) spec to help validate `architect.yml` files describing components. In order to make this schema easier to manage, we use the [typescript-json-schema]() library to generate the schema definition from a typescript interface.
+
+After you've made changes to the typescript files representing the schema(s), run the associated generate:schema command:
+
+```sh
+$ npm run generate:schema:v1
+```
+
+This will write the schema file to `./v1-component-schema.json`.
+
+### Testing the schema in VS Code
+
+The first thing you'll need to do is install [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) for VS Code. This is needed to allow your editor to respond to json schema templates found locally or in the json schema store, a public repository of json schemas associated with filenames.
+
+Once you have the extension installed, ppen your [VS Code settings.json file](https://code.visualstudio.com/docs/getstarted/settings#_settings-file-locations) and associate the generated schema file with the `architect.yml` and `architect.yaml` file types:
+
+```json
+{
+  "yaml.schemas": {
+    "<path-to-cli>/src/dependency-manager/v1-component-schema.json": ["architect.yaml", "architect.yml"]
+  }
+}
+```
+
+_Be sure to replace `<path-to-cli>` with the directory where you checked out the Architect CLI project._
+
+### Publishing schema to public store
+
+Unfortunately this can't be automated. You'll have to submit a PR to the repository and follow the contributing guidelines:
+
+https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

--- a/src/dependency-manager/package-lock.json
+++ b/src/dependency-manager/package-lock.json
@@ -19,6 +19,12 @@
       "integrity": "sha512-otRe77JNNWzoVGLKw8TCspKswRoQToys4tuL6XYVBFxjgeM0RUrx7m3jkaTdxILxeGry3zM8mGYkGXMeQ02guA==",
       "dev": true
     },
+    "@types/json-schema": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "dev": true
+    },
     "@types/mustache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.0.1.tgz",
@@ -42,6 +48,21 @@
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.0.0.tgz",
       "integrity": "sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw=="
     },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -56,6 +77,22 @@
       "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "requires": {
         "follow-redirects": "1.5.10"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "class-transformer": {
@@ -74,6 +111,38 @@
         "validator": "13.0.0"
       }
     },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -81,6 +150,18 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "esprima": {
       "version": "4.0.1",
@@ -105,6 +186,32 @@
         "universalify": "^0.1.0"
       }
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
     "google-libphonenumber": {
       "version": "3.2.9",
       "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.9.tgz",
@@ -115,6 +222,28 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -124,12 +253,36 @@
         "esprima": "^4.0.0"
       }
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
       }
     },
     "ms": {
@@ -142,10 +295,31 @@
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
       "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "shell-quote": {
       "version": "1.7.2",
@@ -157,6 +331,26 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -167,6 +361,27 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
       "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
       "dev": true
+    },
+    "typescript-json-schema": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.45.1.tgz",
+      "integrity": "sha512-Iz1NKVtJi09iZSzXj3J350GekBrZ1TiNw6Cbf42jLOGyooh9BWoi8XP6XlTIMOI3aMD8XxuL9hEvIEq8FD/WUw==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.6",
+        "glob": "^7.1.6",
+        "json-stable-stringify": "^1.0.1",
+        "typescript": "^4.1.3",
+        "yargs": "^16.2.0"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+          "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+          "dev": true
+        }
+      }
     },
     "universalify": {
       "version": "0.1.2",
@@ -182,6 +397,50 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.0.0.tgz",
       "integrity": "sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA=="
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true
     }
   }
 }

--- a/src/dependency-manager/package.json
+++ b/src/dependency-manager/package.json
@@ -29,7 +29,8 @@
   },
   "scripts": {
     "lint": "eslint --ext .ts,.js .",
-    "build": "rm -rf lib && tsc -b"
+    "build": "rm -rf lib && tsc -b",
+    "generate:schema:v1": "typescript-json-schema ./src/spec/v1-component-spec.ts ComponentSpecV1 > ./v1-component-schema.json"
   },
   "main": "lib/index.js",
   "files": [
@@ -43,6 +44,7 @@
     "@types/js-yaml": "^3.12.3",
     "@types/mustache": "^4.0.1",
     "@types/shell-quote": "^1.6.2",
-    "typescript": "^3.7.2"
+    "typescript": "^3.7.2",
+    "typescript-json-schema": "^0.45.1"
   }
 }

--- a/src/dependency-manager/src/spec/v1-component-spec.ts
+++ b/src/dependency-manager/src/spec/v1-component-spec.ts
@@ -1,0 +1,188 @@
+export default interface ComponentSpecV1 {
+  /**
+   * Unique name of the component. Must be of the format, <account-name>/<component-name>
+   */
+  name: string;
+
+  /**
+   * A human-readable description of the component and what it should be used for
+   */
+  description?: string;
+
+  /**
+   * An array of keywords that can be used to index the component and make it discoverable for others
+   */
+  keywords?: string[];
+
+  /**
+   * A dictionary of named parameters that this component uses to configure services.
+   *
+   * Parameters can either be an object describing the parameter or a string shorthand that directly applies to the `default` value.
+   */
+  parameters?: {
+    [key: string]: string | {
+      /**
+       * The default value to apply to the parameter when one wasn't provided by the operator
+       */
+      default?: string;
+
+      /**
+       * A boolean indicating whether or not an operator is required ot provide a value
+       * @default false
+       */
+      required?: boolean;
+
+      /**
+       * A human-readable description of the parameter, how it should be used, and what kinds of values it supports.
+       */
+      description?: string;
+    };
+  };
+
+  /**
+   * A dictionary of named interfaces that the component makes available to upstreams, including other components via dependencies or environments via interface mapping.
+   *
+   * Interfaces can either be an object describing the interface, or a string shorthand that directly applies to the `url` value.
+   */
+  interfaces?: {
+    [key: string]: string | {
+      /**
+       * The url of the downstream interfaces that should be exposed. This will usually be a reference to one of your services interfaces.
+       */
+      url: string;
+
+      /**
+       * A human-readable description of the interface and how it should be used.
+       */
+      description?: string;
+    };
+  };
+
+  /**
+   * A set of named services that need to be run and persisted in order to power this component.
+   */
+  services?: {
+    [key: string]: ResourceSpecV1 & {
+      /**
+       * A set of name interfaces that the service listens for traffic on. Interface definitions consist of either an object or a numerical shorthand that directly applies to the `port` field.
+       */
+      interfaces?: {
+        [key: string]: number | {
+          /**
+           * The port that the service is listening for requests on
+           * @minimum 1
+           */
+          port: number;
+
+          /**
+           * The protocol that the interface responds to
+           * @default http
+           */
+          protocol?: string;
+
+          /**
+           * A fixed host address that represents an existing location for the service. Using this field will make this service 'virtual' and will not trigger provisioning.
+           */
+          host?: string;
+        };
+      };
+    };
+  };
+
+  /**
+   * A set of scheduled and triggerable tasks that get registered alongside the component. Tasks are great for data translation, reporting, and much more.
+   */
+  tasks?: {
+    [key: string]: ResourceSpecV1 & {
+      /**
+       * A cron string indicating the schedule at which the task will run. Architect will ensure the cron jobs are instrumented correctly regardless of where the task is deployed.
+       */
+      schedule: string;
+    };
+  };
+}
+
+interface ResourceSpecV1 {
+  /**
+   * Specify settings for the component that apply only at build-time.
+   *
+   * When registering a component with build settings, Architect will build the container, publish it to a registry, and replace the build settings with the new image reference before completing registration.
+   */
+  build?: {
+    /**
+     * The path to the source context to mount to the container. Must be relative to this configuration file.
+     */
+    context: string;
+
+    /**
+     * A path to a Dockerfile that describes how the image should be built.
+     * @default Dockerfile
+     */
+    dockerfile?: string;
+  };
+
+  /**
+   * Name and location of a docker image that powers this runtime. This field cannot be used in conjunction with the `build` field.
+   */
+  image?: string;
+
+  /**
+   * A command to be used to start up the service inside the container. If no value is specified, the default CMD from the associated image will be used.
+   */
+  command?: string | string[];
+
+  /**
+   * An entrypoint to be used to start up the service inside the container. If no value is specified, the default ENTRYPOINT from the associated image will be used.
+   */
+  entrypoint?: string | string[];
+
+  /**
+   * The number of vCPUs that should be allocated to each instance of this runtime.
+   */
+  cpu?: number;
+
+  /**
+   * The target amount of memory to allocate for each instance of this runtime. Valid values includes things like 0.5GB, 2GB, 8GB, etc.
+   */
+  memory?: string;
+
+  /**
+   * A key/value dictionary of environment parameters to apply to this runtime.
+   */
+  environment?: {
+    [key: string]: string;
+  };
+
+  /**
+   * A set of named volumes that the service will request and mount to each service instance.
+   *
+   * Volumes can either be an object describing the volume or a string shorthand that maps to the `mount_path` value.
+   */
+  volumes?: {
+    [key: string]: string | {
+      /**
+       * A path inside the container OS that the volume should mount to
+       */
+      mount_path: string;
+
+      /**
+       * The path on the host OS that should be mounted to the container OS. (Note: this is primarily used for application debugging)
+       */
+      host_path?: string;
+
+      /**
+       * A human-readable description of the volume and what kind of data gets stored on it
+       */
+      description?: string;
+    };
+  };
+}
+
+interface DebuggableResourceSpecV1 extends ResourceSpecV1 {
+  /**
+   * A set of values for the runtime that will override the others when the service
+   * is being run locally. All values that are supported by the top-level service
+   * are also supported inside the debug object.
+   */
+  debug?: ResourceSpecV1;
+}


### PR DESCRIPTION
This includes everything needed to generate a json schema file from a typescript interface that I've included in the repo. 

Some things that could be done once this gets merged in:
* Publish a PR to the schemastore that uses the generated schema spec (must be done manually, and I will do once this gets merged in)
* Extend the interface that powers this schema gen as part of our config classes so that the interface becomes functionally useful
* Use something like AJV to validate incoming yaml files instead of having to use the class-validator annotations. AJV uses json schema and has sponsorship from Mozilla ensuring its stability: https://github.com/ajv-validator/ajv/