### PR TITLE
[WIP] a node cannot be determined to actually be external until its value is either set directly or interpolated

### DIFF
--- a/src/dependency-manager/src/graph/node/service.ts
+++ b/src/dependency-manager/src/graph/node/service.ts
@@ -40,7 +40,7 @@ export class ServiceNode extends DependencyNode implements ServiceNodeOptions {
   }
 
   get is_external() {
-    return Object.keys(this.interfaces).length > 0 && Object.values(this.interfaces).every((i) => i.host);
+    return Object.keys(this.interfaces).length > 0 && Object.values(this.interfaces).every((i) => i.host && !i.host.startsWith('${{')); // a node cannot be determined to actually be external until its value is either set directly or interpolated
   }
 
   get is_local() {

--- a/src/dependency-manager/src/graph/node/task.ts
+++ b/src/dependency-manager/src/graph/node/task.ts
@@ -37,7 +37,7 @@ export class TaskNode extends DependencyNode implements TaskNodeOptions {
   }
 
   get is_external() {
-    return Object.keys(this.interfaces).length > 0 && Object.values(this.interfaces).every((i) => i.host);
+    return Object.keys(this.interfaces).length > 0 && Object.values(this.interfaces).every((i) => i.host && !i.host.startsWith('${{')); // a node cannot be determined to actually be external until its value is either set directly or interpolated
   }
 
   get is_local() {


### PR DESCRIPTION
Example case:
```yml
web-db:
    image: postgres:11
    interfaces:
      postgres:
        host: ${{ parameters.POSTGRES_HOST }}
        port: 5432
        protocol: postgresql
    environment:
      POSTGRES_USER: postgres
      POSTGRES_PASSWORD: architect
      POSTGRES_DB: concourse
      HOST: ${{ services.web-db.interfaces.postgres.host }}
      PORT: ${{ services.web-db.interfaces.postgres.port }}
```

The host might be filled in by interpolation, but it also might not. In the case that the host isn't filled in, we use the image to build the container ourselves