### PR TITLE
Added support for HTTP basic auth on interfaces

### DIFF
--- a/src/dependency-manager/src/manager.ts
+++ b/src/dependency-manager/src/manager.ts
@@ -510,13 +510,23 @@ export default abstract class DependencyManager {
       internal_protocol = interface_details.protocol || 'http';
     }
 
-    const internal_url = internal_protocol + '://' + internal_host + ':' + internal_port;
+    const internal_user = interface_details.username;
+    const internal_pass = interface_details.password;
+
+    let auth_slug = '';
+    if (internal_user || internal_pass) {
+      auth_slug = `${internal_user}:${internal_pass}@`
+    }
+
+    const internal_url = `${internal_protocol}://${auth_slug}${internal_host}:${internal_port}`;
 
     return {
       host: internal_host,
       port: internal_port,
       protocol: internal_protocol,
       url: internal_url,
+      username: internal_user,
+      password: internal_pass,
     };
   }
 

--- a/src/dependency-manager/src/spec/common/interface-spec.ts
+++ b/src/dependency-manager/src/spec/common/interface-spec.ts
@@ -4,5 +4,7 @@ export interface InterfaceSpec {
   port: string;
   url?: string;
   protocol?: string;
+  username?: string;
+  password?: string;
   domains?: string[];
 }

--- a/src/dependency-manager/src/spec/common/interface-v1.ts
+++ b/src/dependency-manager/src/spec/common/interface-v1.ts
@@ -26,6 +26,12 @@ export class InterfaceSpecV1 extends ValidatableConfig {
   protocol?: string;
 
   @IsOptional({ always: true })
+  username?: string;
+
+  @IsOptional({ always: true })
+  password?: string;
+
+  @IsOptional({ always: true })
   url?: string;
 
   @IsEmpty({

--- a/src/dependency-manager/src/spec/v1-component-spec.ts
+++ b/src/dependency-manager/src/spec/v1-component-spec.ts
@@ -62,7 +62,7 @@ export default interface ComponentSpecV1 {
    * A set of named services that need to be run and persisted in order to power this component.
    */
   services?: {
-    [key: string]: ResourceSpecV1 & {
+    [key: string]: DebuggableResourceSpecV1 & {
       /**
        * A set of name interfaces that the service listens for traffic on. Interface definitions consist of either an object or a numerical shorthand that directly applies to the `port` field.
        */
@@ -84,6 +84,16 @@ export default interface ComponentSpecV1 {
            * A fixed host address that represents an existing location for the service. Using this field will make this service 'virtual' and will not trigger provisioning.
            */
           host?: string;
+
+          /**
+           * A username used to authenticate with the interface via HTTP basic auth
+           */
+          username?: string;
+
+          /**
+           * A password used to authenticate with the interface via HTTP basic auth
+           */
+          password?: string;
         };
       };
     };
@@ -93,7 +103,7 @@ export default interface ComponentSpecV1 {
    * A set of scheduled and triggerable tasks that get registered alongside the component. Tasks are great for data translation, reporting, and much more.
    */
   tasks?: {
-    [key: string]: ResourceSpecV1 & {
+    [key: string]: DebuggableResourceSpecV1 & {
       /**
        * A cron string indicating the schedule at which the task will run. Architect will ensure the cron jobs are instrumented correctly regardless of where the task is deployed.
        */


### PR DESCRIPTION
Added optional support for HTTP basic auth `username` and `password` on service interfaces, both statically and as parameters. This allows us to carve out things like SMTP or database services that require username and password for authentication into separate components. That way the credentials can live with the component and upstream can get access to a fully resolvable `url` value that includes said credentials (e.g. `smtp://user:pass@host:port` or `postgres://user:pass@host:port`, etc.).