### PR TITLE
Stripped the default browser ports from url value

### DIFF
--- a/src/dependency-manager/src/manager.ts
+++ b/src/dependency-manager/src/manager.ts
@@ -518,7 +518,12 @@ export default abstract class DependencyManager {
       auth_slug = `${internal_user}:${internal_pass}@`
     }
 
-    const internal_url = `${internal_protocol}://${auth_slug}${internal_host}:${internal_port}`;
+    let hostname = internal_host;
+    if (!(internal_protocol === 'http' && internal_port === '80') && !(internal_protocol === 'https' && internal_port === '443')) {
+      hostname += `:${internal_port}`;
+    }
+
+    const internal_url = `${internal_protocol}://${auth_slug}${hostname}`;
 
     return {
       host: internal_host,

--- a/test/dependency-manager/external.test.ts
+++ b/test/dependency-manager/external.test.ts
@@ -118,7 +118,7 @@ describe('external interfaces spec v1', () => {
               interfaces: {
                 main: {
                   host: 'external.locahost',
-                  port: 80
+                  port: 443,
                 }
               }
             }
@@ -152,8 +152,8 @@ describe('external interfaces spec v1', () => {
         'architect--cloud--app--latest--kavtrukr': {
           depends_on: [],
           environment: {
-            API_ADDR: 'https://external.locahost:80',
-            EXTERNAL_API_ADDR: 'https://external.locahost:80'
+            API_ADDR: 'https://external.locahost',
+            EXTERNAL_API_ADDR: 'https://external.locahost'
           },
           ports: [
             '50000:8080'


### PR DESCRIPTION
The port values `80` and `443` are already the defaults for HTTP and HTTPS requests coming from any HTTP client and they don't need to be cited explicitly. Furthermore, including them causes weird behavior when storing and retrieving cookies. Funny enough, cookies associated with `http://app.localhost:80` are not retrievable by `http://app.localhost`. Since the browser already strips these ports, browsers are NEVER able to retrieve cookies associated with URLs that include the default port values. 

This ticket strips the port from the interface `url` value whenever they match the default for the HTTP or HTTPS protocol respectively. 