### PR TITLE
Ensured that dependency calls support basic auth where applicable

### DIFF
--- a/src/dependency-manager/src/manager.ts
+++ b/src/dependency-manager/src/manager.ts
@@ -510,8 +510,8 @@ export default abstract class DependencyManager {
       internal_protocol = interface_details.protocol || 'http';
     }
 
-    const internal_user = interface_details.username;
-    const internal_pass = interface_details.password;
+    const internal_user = interface_details.username || '';
+    const internal_pass = interface_details.password || '';
 
     let auth_slug = '';
     if (internal_user || internal_pass) {

--- a/src/dependency-manager/src/spec/component/component-transformer.ts
+++ b/src/dependency-manager/src/spec/component/component-transformer.ts
@@ -47,7 +47,7 @@ export const transformComponentInterfaces = function (input?: Dictionary<string 
     if (value instanceof Object && 'host' in value && 'port' in value) {
       output[key] = plainToClass(InterfaceSpecV1, value);
     } else {
-      let host, port, protocol;
+      let host, port, protocol, username, password;
       let url = value instanceof Object ? value.url : value;
 
       const url_regex = new RegExp(`\\\${{\\s*(.*?)\\.url\\s*}}`, 'g');
@@ -56,11 +56,15 @@ export const transformComponentInterfaces = function (input?: Dictionary<string 
         host = `\${{ ${matches[1]}.host }}`;
         port = `\${{ ${matches[1]}.port }}`;
         protocol = `\${{ ${matches[1]}.protocol }}`;
-        url = `\${{ ${matches[1]}.protocol }}://\${{ ${matches[1]}.host }}:\${{ ${matches[1]}.port }}`;
+        username = `\${{ ${matches[1]}.username }}`;
+        password = `\${{ ${matches[1]}.password }}`;
+        url = `\${{ ${matches[1]}.url }}`;
 
         output[key] = plainToClass(InterfaceSpecV1, {
           host,
           port,
+          username,
+          password,
           protocol,
           url,
           ...(value instanceof Object && value.domains ? { domains: value.domains } : {}),

--- a/src/dependency-manager/src/spec/component/component-v1.ts
+++ b/src/dependency-manager/src/spec/component/component-v1.ts
@@ -241,6 +241,8 @@ export class ComponentConfigV1 extends ComponentConfig {
     const interface_filler = {
       port: '',
       host: '',
+      username: '',
+      password: '',
       protocol: '',
       url: '',
     };

--- a/src/dependency-manager/src/utils/interpolation.ts
+++ b/src/dependency-manager/src/utils/interpolation.ts
@@ -103,8 +103,8 @@ export const interpolateString = (param_value: string, context: any, ignore_keys
     if (errors.size > 0) {
       const interpolation_errors: Set<string> = new Set();
       for (const error of errors) {
-        // Dedupe host/port/protocol into url
-        if (error.endsWith('.host') || error.endsWith('.port') || error.endsWith('.protocol')) {
+        // Dedupe host/port/protocol/username/password into url
+        if (error.endsWith('.host') || error.endsWith('.port') || error.endsWith('.protocol') || error.endsWith('.username') || error.endsWith('.password')) {
           const keys = error.split('.');
           const key = keys.slice(0, keys.length - 1).join('.');
           if (errors.has(`${key}.host`) && errors.has(`${key}.port`) && errors.has(`${key}.protocol`)) {


### PR DESCRIPTION
Noticed that the recent basic auth interfaces feature didn't work for calling dependency interfaces. Added that in and added test coverage. 