### PR TITLE
change .localhost to .arc.localhost; hotfix back-port

### DIFF
--- a/docs/0-getting-started/0-introduction.md
+++ b/docs/0-getting-started/0-introduction.md
@@ -134,7 +134,7 @@ services:
           host_path: ./frontend/src
 
 # Maps the frontend application to an external interface. Once running, it can
-# be resolved at http://app.localhost
+# be resolved at http://app.arc.localhost
 interfaces:
   app: ${{ services.app.interfaces.main.url }}
 ```
@@ -149,7 +149,7 @@ Now that we have a better understanding of what we're deploying, let's go ahead 
 $ architect deploy --local examples/react-app:latest -i app:app
 
 Using locally linked examples/react-app found at /architect-cli/examples/react-app
-http://app.localhost:80/ => examples--react-app--app--latest--aklmrtvo
+http://app.arc.localhost:80/ => examples--react-app--app--latest--aklmrtvo
 
 http://localhost:50000/ => examples--react-app--api-db--latest--arrm58dc
 http://localhost:50001/ => examples--react-app--api--latest--1dzvo47x
@@ -158,7 +158,7 @@ http://localhost:80/ => gateway
 # begin log stream...
 ```
 
-The command above will transform the component into a fully enriched docker-compose template and then execute it automatically. After a few seconds you should see the each application indicate that its ready for traffic, and at that point you can open http://app.localhost in your browser!
+The command above will transform the component into a fully enriched docker-compose template and then execute it automatically. After a few seconds you should see the each application indicate that its ready for traffic, and at that point you can open http://app.arc.localhost in your browser!
 
 ## Make your own changes
 

--- a/docs/2-deployments/0-local-development.md
+++ b/docs/2-deployments/0-local-development.md
@@ -25,7 +25,7 @@ Once you've registered a component locally or remotely, that component can then 
 $ architect deploy --local examples/react-app:latest -i app:app -p world_text="dude"
 
 Using locally linked examples/react-app found at /architect-cli/examples/react-app
-http://app.localhost:80/ => examples--react-app--app--latest--aklmrtvo
+http://app.arc.localhost:80/ => examples--react-app--app--latest--aklmrtvo
 
 http://localhost:50000/ => examples--react-app--api-db--latest--arrm58dc
 http://localhost:50001/ => examples--react-app--api--latest--1dzvo47x

--- a/examples/database-seeding/README.md
+++ b/examples/database-seeding/README.md
@@ -30,7 +30,7 @@ $ architect link .
 $ architect deploy --local examples/database-seeding:latest -i main:main -p AUTO_DDL=migrate
 ```
 
-Once the deploy has completed, you can reach your new service by going to http://main.localhost/.
+Once the deploy has completed, you can reach your new service by going to http://main.arc.localhost/.
 
 ## Deploying to the cloud
 

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -30,7 +30,7 @@ $ architect link .
 $ architect deploy --local examples/hello-world:latest -i hello:hello
 ```
 
-Once the deploy has completed, you can reach your new service by going to http://hello.localhost/.
+Once the deploy has completed, you can reach your new service by going to http://hello.arc.localhost/.
 
 ## Deploying to the cloud
 

--- a/examples/hot-reloading/README.md
+++ b/examples/hot-reloading/README.md
@@ -30,7 +30,7 @@ $ architect link .
 $ architect deploy --local examples/hot-reloading:latest -i http:http
 ```
 
-Once the deploy has completed, you can reach your new service by going to http://http.localhost/. Whenever you make changes to code in the `./src` directory, you'll see the logs indicating that the service has restart automatically.
+Once the deploy has completed, you can reach your new service by going to http://http.arc.localhost/. Whenever you make changes to code in the `./src` directory, you'll see the logs indicating that the service has restart automatically.
 
 ## Deploying to the cloud
 

--- a/examples/nestjs-microservices/simple/README.md
+++ b/examples/nestjs-microservices/simple/README.md
@@ -45,7 +45,7 @@ The REST client service cites the TCP server as a dependency. This means that Ar
 $ architect deploy --local examples/nestjs-simple-client:latest -i main:client
 ```
 
-Once the application is done booting, the REST client will be available on http://app.localhost/hello/Name
+Once the application is done booting, the REST client will be available on http://app.arc.localhost/hello/Name
 
 ## Deploying to the cloud
 

--- a/examples/react-app/README.md
+++ b/examples/react-app/README.md
@@ -32,7 +32,7 @@ $ architect link .
 $ architect deploy --local examples/react-app:latest -i app:app
 ```
 
-Once the deploy has completed, you can reach your new service by going to http://app.localhost/.
+Once the deploy has completed, you can reach your new service by going to http://app.arc.localhost/.
 
 ## Deploying to the cloud
 

--- a/examples/stateful-component/README.md
+++ b/examples/stateful-component/README.md
@@ -30,7 +30,7 @@ $ architect link .
 $ architect deploy --local examples/stateful-component:latest -i frontend:frontend
 ```
 
-Once the deploy has completed, you can reach your new service by going to http://frontend.localhost/.
+Once the deploy has completed, you can reach your new service by going to http://frontend.arc.localhost/.
 
 ## Deploying to the cloud
 

--- a/examples/stateless-component/README.md
+++ b/examples/stateless-component/README.md
@@ -32,7 +32,7 @@ $ architect link .
 $ architect deploy --local examples/stateless-component:latest -i frontend:frontend
 ```
 
-Once the deploy has completed, you can reach your new service by going to http://frontend.localhost/.
+Once the deploy has completed, you can reach your new service by going to http://frontend.arc.localhost/.
 
 ## Deploying to the cloud
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6099,7 +6099,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -6266,7 +6266,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {

--- a/src/common/dependency-manager/local-manager.ts
+++ b/src/common/dependency-manager/local-manager.ts
@@ -132,7 +132,7 @@ export default class LocalDependencyManager extends DependencyManager {
   }
 
   toExternalHost() {
-    return 'localhost';
+    return 'arc.localhost';
   }
 
   toExternalProtocol() {

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -38,7 +38,7 @@ export class DockerComposeUtils {
     }
     const available_ports = (await Promise.all(port_promises)).sort();
 
-    const gateway_links = Object.keys(environment.getInterfaces()).map((ik) => `gateway:${ik}.localhost`);
+    const gateway_links = Object.keys(environment.getInterfaces()).map((ik) => `gateway:${ik}.arc.localhost`);
 
     // Enrich base service details
     for (const node of graph.nodes) {
@@ -188,7 +188,7 @@ export class DockerComposeUtils {
           const node_to_interface = node_to.interfaces[node_to_interface_name];
           service_to.environment = service_to.environment || {};
 
-          const interface_host = `${interface_name}.localhost`;
+          const interface_host = `${interface_name}.arc.localhost`;
           if (service_to.environment.VIRTUAL_HOST) {
             service_to.environment.VIRTUAL_HOST += `,${interface_host}`;
           } else {

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -334,9 +334,9 @@ describe('local deploy environment', function () {
           "DATABASE_PASSWORD": "architect",
           "DATABASE_SCHEMA": "test-db",
           "AUTO_DDL": "seed",
-          "VIRTUAL_HOST": "app.localhost",
+          "VIRTUAL_HOST": "app.arc.localhost",
           "VIRTUAL_PORT": "3000",
-          "VIRTUAL_PORT_app_localhost": "3000",
+          "VIRTUAL_PORT_app_arc_localhost": "3000",
           "VIRTUAL_PROTO": "http"
         },
         "build": {
@@ -344,7 +344,7 @@ describe('local deploy environment', function () {
           "dockerfile": "Dockerfile"
         },
         "external_links": [
-          "gateway:app.localhost"
+          "gateway:app.arc.localhost"
         ]
       },
       "examples--database-seeding--my-demo-db--latest--uimfmkw0": {
@@ -359,7 +359,7 @@ describe('local deploy environment', function () {
         },
         "image": "postgres:11",
         "external_links": [
-          "gateway:app.localhost"
+          "gateway:app.arc.localhost"
         ]
       },
       "gateway": {
@@ -412,13 +412,13 @@ describe('local deploy environment', function () {
           "gateway"
         ],
         "environment": {
-          "VIRTUAL_HOST": "test.localhost",
+          "VIRTUAL_HOST": "test.arc.localhost",
           "VIRTUAL_PORT": "3000",
-          "VIRTUAL_PORT_test_localhost": "3000",
+          "VIRTUAL_PORT_test_arc_localhost": "3000",
           "VIRTUAL_PROTO": "http"
         },
         "external_links": [
-          "gateway:test.localhost"
+          "gateway:test.arc.localhost"
         ],
         "image": "heroku/nodejs-hello-world",
       },
@@ -547,8 +547,8 @@ describe('local deploy environment', function () {
       const runCompose = Deploy.prototype.runCompose as sinon.SinonStub;
       expect(runCompose.calledOnce).to.be.true;
       const hello_world_service = Object.values(runCompose.firstCall.args[0].services)[0] as any;
-      expect(hello_world_service.external_links).to.contain('gateway:test.localhost');
-      expect(hello_world_service.environment.VIRTUAL_HOST).to.equal('test.localhost');
+      expect(hello_world_service.external_links).to.contain('gateway:test.arc.localhost');
+      expect(hello_world_service.environment.VIRTUAL_HOST).to.equal('test.arc.localhost');
       expect(hello_world_service.environment.a_required_key).to.equal('some_value');
       expect(hello_world_service.environment.another_required_key).to.equal('required_value');
       expect(hello_world_service.environment.one_more_required_param).to.equal('one_more_value');

--- a/test/dependency-manager/interfaces.test.ts
+++ b/test/dependency-manager/interfaces.test.ts
@@ -228,9 +228,9 @@ describe('interfaces spec v1', () => {
       const branch_api_node = graph.getNodeByRef('test/branch/api:latest') as ServiceNode;
       expect(Object.entries(branch_api_node.node_config.getEnvironmentVariables()).map(([k, v]) => `${k}=${v}`)).has.members([
         'LEAF_PROTOCOL=http',
-        'LEAF_HOST=public.localhost',
+        'LEAF_HOST=public.arc.localhost',
         'LEAF_PORT=80',
-        'LEAF_URL=http://public.localhost:80'
+        'LEAF_URL=http://public.arc.localhost:80'
       ])
 
       const template = await DockerComposeUtils.generate(manager);
@@ -246,15 +246,15 @@ describe('interfaces spec v1', () => {
       expect(template.services[test_branch_url_safe_ref]).to.be.deep.equal({
         depends_on: [test_leaf_api_latest_url_safe_ref],
         environment: {
-          LEAF_HOST: 'public.localhost',
+          LEAF_HOST: 'public.arc.localhost',
           LEAF_PORT: '80',
           LEAF_PROTOCOL: 'http',
-          LEAF_URL: 'http://public.localhost:80'
+          LEAF_URL: 'http://public.arc.localhost:80'
         },
         image: 'branch:latest',
         external_links: [
-          'gateway:public.localhost',
-          'gateway:publicv1.localhost'
+          'gateway:public.arc.localhost',
+          'gateway:publicv1.arc.localhost'
         ],
         ports: []
       });
@@ -265,8 +265,8 @@ describe('interfaces spec v1', () => {
         image: 'postgres:11',
         ports: ['50000:5432'],
         external_links: [
-          'gateway:public.localhost',
-          'gateway:publicv1.localhost'
+          'gateway:public.arc.localhost',
+          'gateway:publicv1.arc.localhost'
         ],
       });
 
@@ -277,17 +277,17 @@ describe('interfaces spec v1', () => {
           DB_PORT: '5432',
           DB_PROTOCOL: 'postgres',
           DB_URL: `postgres://${test_leaf_db_latest_url_safe_ref}:5432`,
-          VIRTUAL_HOST: 'public.localhost',
+          VIRTUAL_HOST: 'public.arc.localhost',
           VIRTUAL_PORT: '8080',
-          VIRTUAL_PORT_public_localhost: '8080',
+          VIRTUAL_PORT_public_arc_localhost: '8080',
           VIRTUAL_PROTO: 'http'
         },
         image: 'api:latest',
         ports: ['50001:8080'],
         restart: 'always',
         external_links: [
-          'gateway:public.localhost',
-          'gateway:publicv1.localhost'
+          'gateway:public.arc.localhost',
+          'gateway:publicv1.arc.localhost'
         ],
       });
 
@@ -297,8 +297,8 @@ describe('interfaces spec v1', () => {
         image: 'postgres:11',
         ports: ['50002:5432'],
         external_links: [
-          'gateway:public.localhost',
-          'gateway:publicv1.localhost'
+          'gateway:public.arc.localhost',
+          'gateway:publicv1.arc.localhost'
         ],
       });
 
@@ -309,17 +309,17 @@ describe('interfaces spec v1', () => {
           DB_PORT: '5432',
           DB_PROTOCOL: 'postgres',
           DB_URL: `postgres://${test_leaf_db_v1_url_safe_ref}:5432`,
-          VIRTUAL_HOST: 'publicv1.localhost',
+          VIRTUAL_HOST: 'publicv1.arc.localhost',
           VIRTUAL_PORT: '8080',
-          VIRTUAL_PORT_publicv1_localhost: '8080',
+          VIRTUAL_PORT_publicv1_arc_localhost: '8080',
           VIRTUAL_PROTO: 'http'
         },
         image: 'api:latest',
         ports: ['50003:8080'],
         restart: 'always',
         external_links: [
-          'gateway:public.localhost',
-          'gateway:publicv1.localhost'
+          'gateway:public.arc.localhost',
+          'gateway:publicv1.arc.localhost'
         ],
       });
     });
@@ -377,15 +377,15 @@ describe('interfaces spec v1', () => {
     expect(template.services[architect_cloud_api_url_safe_ref]).to.be.deep.equal({
       "depends_on": ["gateway"],
       "environment": {
-        "VIRTUAL_HOST": "app.localhost,admin.localhost",
+        "VIRTUAL_HOST": "app.arc.localhost,admin.arc.localhost",
         "VIRTUAL_PORT": "8081",
-        "VIRTUAL_PORT_admin_localhost": "8081",
-        "VIRTUAL_PORT_app_localhost": "8080",
+        "VIRTUAL_PORT_admin_arc_localhost": "8081",
+        "VIRTUAL_PORT_app_arc_localhost": "8080",
         "VIRTUAL_PROTO": "http"
       },
       "external_links": [
-        "gateway:app.localhost",
-        "gateway:admin.localhost"
+        "gateway:app.arc.localhost",
+        "gateway:admin.arc.localhost"
       ],
       "ports": [
         "50000:8080",
@@ -475,8 +475,8 @@ describe('interfaces spec v1', () => {
 
     const dashboard_node = graph.getNodeByRef('voic/admin-ui/dashboard:latest') as ServiceNode;
     expect(dashboard_node.node_config.getEnvironmentVariables()).to.deep.eq({
-      ADMIN_ADDR: 'http://admin2.localhost:80',
-      API_ADDR: 'http://public2.localhost:80',
+      ADMIN_ADDR: 'http://admin2.arc.localhost:80',
+      API_ADDR: 'http://public2.arc.localhost:80',
       PRIVATE_ADDR: 'http://voic--product-catalog--api--latest--afhqqu3p:8082'
     });
 
@@ -486,12 +486,12 @@ describe('interfaces spec v1', () => {
 
     const template = await DockerComposeUtils.generate(manager);
     expect(template.services[Refs.url_safe_ref('voic/product-catalog/api:latest')].environment).to.deep.eq({
-      VIRTUAL_HOST: 'public2.localhost,admin2.localhost,dep2.localhost',
-      VIRTUAL_PORT_public2_localhost: '8080',
+      VIRTUAL_HOST: 'public2.arc.localhost,admin2.arc.localhost,dep2.arc.localhost',
+      VIRTUAL_PORT_public2_arc_localhost: '8080',
       VIRTUAL_PORT: '8080',
       VIRTUAL_PROTO: 'http',
-      VIRTUAL_PORT_admin2_localhost: '8081',
-      VIRTUAL_PORT_dep2_localhost: '8080'
+      VIRTUAL_PORT_admin2_arc_localhost: '8081',
+      VIRTUAL_PORT_dep2_arc_localhost: '8080'
     })
   });
 });

--- a/test/dependency-manager/interpolation.test.ts
+++ b/test/dependency-manager/interpolation.test.ts
@@ -163,13 +163,13 @@ describe('interpolation spec v1', () => {
     expect(public_template.services['concourse--web--web--latest--62arnmmt']).to.be.deep.equal({
       'depends_on': ['gateway'],
       'environment': {
-        'VIRTUAL_HOST': 'public.localhost',
+        'VIRTUAL_HOST': 'public.arc.localhost',
         'VIRTUAL_PORT': '8080',
-        VIRTUAL_PORT_public_localhost: '8080',
+        'VIRTUAL_PORT_public_arc_localhost': '8080',
         'VIRTUAL_PROTO': 'http'
       },
       external_links: [
-        'gateway:public.localhost'
+        'gateway:public.arc.localhost'
       ],
       'ports': [
         '50001:8080'
@@ -182,16 +182,16 @@ describe('interpolation spec v1', () => {
     expect(public_template.services['concourse--worker--worker--latest--umjxggst']).to.be.deep.equal({
       'depends_on': [],
       'environment': {
-        'REGULAR': 'public.localhost:2222',
-        'SINGLE_QUOTE': 'public.localhost:2222',
-        'DOUBLE_QUOTE': 'public.localhost:2222',
+        'REGULAR': 'public.arc.localhost:2222',
+        'SINGLE_QUOTE': 'public.arc.localhost:2222',
+        'DOUBLE_QUOTE': 'public.arc.localhost:2222',
       },
       'ports': [],
       'build': {
         'context': path.resolve('/stack')
       },
       external_links: [
-        'gateway:public.localhost'
+        'gateway:public.arc.localhost'
       ],
     })
   });
@@ -247,7 +247,7 @@ describe('interpolation spec v1', () => {
 
     const manager = await LocalDependencyManager.createFromPath(axios.create(), '/environment.yml');
     const graph = await manager.getGraph();
-    const backend_external_url = 'http://backend.localhost:80'
+    const backend_external_url = 'http://backend.arc.localhost:80'
     const backend_ref = 'examples/backend/api:latest';
     const backend_node = graph.getNodeByRef(backend_ref) as ServiceNode;
     expect(backend_node.node_config.getEnvironmentVariables()).to.deep.eq({


### PR DESCRIPTION
Backport for: https://gitlab.com/architect-io/architect-cli/-/issues/213

@tjhiggins- I made the branch `hotfix/v0.8` off of the commit with the `v0.8.6` tag. Once you merge this you should just be able to tag the resulting commit for the new release. I'm assuming `v0.8.7`.

I named this branch with the above naming assumption and that all subsequent releases from the master branch should probably increment the minor version (ie. our traefik CLI release will be `v0.9.0`). Any subsequent `0.8.n` hotfixes (god forbid there are any more) should end up on this `hotfix/v0.8` branch.