### PR TITLE
fix task:exec bug, fix tests

### DIFF
--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -79,14 +79,11 @@ export default class TaskExec extends Command {
       throw new Error(`Error parsing component: ${err}`);
     }
 
-    let service_name;
     const slug = ServiceVersionSlugUtils.build(parsed_slug.component_account_name, parsed_slug.component_name, args.task, parsed_slug.tag);
     const ref = ComponentConfig.getNodeRef(slug);
-    const matching_names = Object.keys(compose.services).find(name => name === ref);
-    if (!matching_names?.length) {
+    const service_name = Object.keys(compose.services).find(name => name === ref);
+    if (!service_name) {
       throw new Error(`Could not find ${args.component}/${args.task} running in your local ${project_name} environment. See ${compose_file} for available tasks and services.`);
-    } else {
-      service_name = matching_names[0];
     }
 
     this.log(chalk.blue(`Running task ${args.component}/${args.task} in the local ${project_name} environment...`));

--- a/test/commands/task.test.ts
+++ b/test/commands/task.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { DockerComposeUtils } from '../../src/common/docker-compose/index';
 import * as Docker from '../../src/common/utils/docker';
 import PortUtil from '../../src/common/utils/port';
-import { ComponentConfig, ComponentSlugUtils, ComponentVersionSlugUtils, Refs, ServiceVersionSlugUtils, Slugs } from '../../src/dependency-manager/src';
+import { ComponentConfig, ComponentSlugUtils, ComponentVersionSlugUtils, ServiceVersionSlugUtils, Slugs } from '../../src/dependency-manager/src';
 import { mockArchitectAuth, MOCK_API_HOST } from '../utils/mocks';
 
 describe('task:exec', async function () {
@@ -170,10 +170,11 @@ describe('task:exec', async function () {
     .it('fails with a useful message if given a bad component name');
 
   const mock_docker_compose_service: { [key: string]: {} } = {};
-  const ref = Refs.safeRef(ServiceVersionSlugUtils.build(mock_account.name, mock_component.name, mock_task.name, Slugs.DEFAULT_TAG));
-  mock_docker_compose_service[ComponentConfig.getNodeRef(ref)] = {};
+  const mock_slug = ServiceVersionSlugUtils.build(mock_account.name, mock_component.name, mock_task.name, Slugs.DEFAULT_TAG);
+  const mock_ref = ComponentConfig.getNodeRef(mock_slug);
+  mock_docker_compose_service[mock_ref] = {};
   const mock_docker_compose = {
-    services: mock_docker_compose_service
+    services: mock_docker_compose_service,
   };
 
   mockArchitectAuth
@@ -204,7 +205,7 @@ describe('task:exec', async function () {
       const loadDockerCompose = DockerComposeUtils.loadDockerCompose as sinon.SinonStub;
       const runDockerCompose = DockerComposeUtils.run as sinon.SinonStub;
       expect(runDockerCompose.calledOnce).to.be.true;
-      expect(runDockerCompose.args[0]).to.deep.equal(['examples-basic-task-curler-latest-suxxccsa', 'architect', path.join('test', 'docker-compose', 'architect.yml')]);
+      expect(runDockerCompose.args[0]).to.deep.equal([mock_ref, 'architect', path.join('test', 'docker-compose', 'architect.yml')]);
       expect(loadDockerCompose.calledOnce).to.be.true;
     });
 


### PR DESCRIPTION
@tjhiggins fixed the local task:exec and the tests here.

Note the mocha issue is still outstanding: if an exception occurs in the `describe` block, that test exits without any warning and the remainder of the tests in that files simply don't run.

There are several mocha github issues related (looks like error handling has historically been a a problem in various situations), but none for this specific situation. Should we create an issue there?