### PR TITLE
395 explicit depends on

### DIFF
--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -125,10 +125,7 @@ export class DockerComposeUtils {
           compose.services[safe_ref].extra_hosts = ['host.docker.internal:host-gateway'];
         }
 
-        const depends_on = graph.nodes
-          .filter(n => n.instance_id === node.instance_id && node.config.getDependsOn().includes((n as ServiceNode | TaskNode)?.config?.getName()))
-          .filter(n => n instanceof ServiceNode)
-          .map(n => n.ref);
+        const depends_on = graph.getExplicitDependsOn(node).map(n => n.ref);
 
         if (depends_on?.length) {
           compose.services[safe_ref].depends_on = depends_on;

--- a/src/dependency-manager/src/index.ts
+++ b/src/dependency-manager/src/index.ts
@@ -18,4 +18,5 @@ export * from './spec/service/service-config';
 export * from './spec/task/task-config';
 export * from './utils/refs';
 export * from './utils/slugs';
+export * from './utils/validation';
 

--- a/src/dependency-manager/src/manager.ts
+++ b/src/dependency-manager/src/manager.ts
@@ -12,6 +12,7 @@ import { ComponentConfig } from './spec/component/component-config';
 import { Dictionary } from './utils/dictionary';
 import { flattenValidationErrors, ValidationErrors } from './utils/errors';
 import { interpolateString, replaceBrackets } from './utils/interpolation';
+import { Refs } from './utils/refs';
 import { ComponentSlugUtils, Slugs } from './utils/slugs';
 import { validateInterpolation } from './utils/validation';
 
@@ -28,6 +29,7 @@ export default abstract class DependencyManager {
         local_path: component.getLocalPath(),
         artifact_image: component.getArtifactImage(),
       });
+      node.instance_id = `${Refs.safeRef(component.getRef())}-local`;
       nodes.push(node);
     }
 
@@ -38,6 +40,7 @@ export default abstract class DependencyManager {
         config: task_config,
         local_path: component.getLocalPath(),
       });
+      node.instance_id = `${Refs.safeRef(component.getRef())}-local`;
       nodes.push(node);
     }
     return nodes;

--- a/src/dependency-manager/src/spec/component/component-v1.ts
+++ b/src/dependency-manager/src/spec/component/component-v1.ts
@@ -2,7 +2,7 @@ import { plainToClass, serialize, Transform } from 'class-transformer';
 import { Allow, IsObject, IsOptional, IsString, IsUrl, Matches, ValidatorOptions } from 'class-validator';
 import { Dictionary } from '../../utils/dictionary';
 import { ComponentSlug, ComponentSlugUtils, ComponentVersionSlug, ComponentVersionSlugUtils, Slugs } from '../../utils/slugs';
-import { validateCrossDictionaryCollisions, validateDictionary, validateInterpolation } from '../../utils/validation';
+import { validateCrossDictionaryCollisions, validateDependsOn, validateDictionary, validateInterpolation } from '../../utils/validation';
 import { DictionaryType } from '../../utils/validators/dictionary_type';
 import { InterfaceSpec } from '../common/interface-spec';
 import { InterfaceSpecV1 } from '../common/interface-v1';
@@ -364,6 +364,7 @@ export class ComponentConfigV1 extends ComponentConfig {
     errors = await validateDictionary(expanded, 'tasks', errors, undefined, { ...options, groups: (options.groups || []).concat('component') }, new RegExp(`^${Slugs.ArchitectSlugRegexNoMaxLength}$`));
     errors = await validateDictionary(expanded, 'interfaces', errors, undefined, options);
     errors = await validateCrossDictionaryCollisions(expanded, 'services', 'tasks', errors); // makes sure services and tasks don't have any common keys
+    errors = await validateDependsOn(expanded, errors); // makes sure service depends_on refers to valid other services
     if ((options.groups || []).includes('developer')) {
       errors = errors.concat(validateInterpolation(serialize(expanded), this.getContext(), ['architect.', 'dependencies.', 'environment.']));
     }

--- a/src/dependency-manager/src/spec/resource/resource-config.ts
+++ b/src/dependency-manager/src/spec/resource/resource-config.ts
@@ -36,4 +36,6 @@ export interface ResourceConfig extends ConfigSpec {
   getMemory(): string | undefined;
 
   getDeploy(): DeploySpec | undefined;
+
+  getDependsOn(): string[];
 }

--- a/src/dependency-manager/src/spec/resource/resource-v1.ts
+++ b/src/dependency-manager/src/spec/resource/resource-v1.ts
@@ -74,6 +74,10 @@ export class ResourceConfigV1 extends BaseConfig implements ResourceConfig {
   @IsOptional({ always: true })
   deploy?: DeploySpecV1;
 
+  @IsOptional({ always: true })
+  @IsString({ always: true, each: true })
+  depends_on?: string[];
+
   async validate(options?: ValidatorOptions) {
     if (!options) { options = {}; }
     let errors = await super.validate(options);
@@ -200,6 +204,10 @@ export class ResourceConfigV1 extends BaseConfig implements ResourceConfig {
 
   getDeploy(): DeploySpecV1 | undefined {
     return this.deploy;
+  }
+
+  getDependsOn(): string[] {
+    return this.depends_on || [];
   }
 
   /** @return New expanded copy of the current config */

--- a/src/dependency-manager/src/utils/validation.ts
+++ b/src/dependency-manager/src/utils/validation.ts
@@ -157,6 +157,31 @@ export const validateCrossDictionaryCollisions = async <T extends ValidatableCon
   return errors;
 };
 
+export const isPartOfCircularReference = (search_name: string, depends_on_map: { [name: string]: string[] }, current_name?: string, seen_names: string[] = []) => {
+  const next_name = current_name || search_name;
+  const dependencies = depends_on_map[next_name];
+
+  if (seen_names.includes(next_name)) {
+    return false;
+  }
+
+  seen_names.push(next_name);
+
+  if (!dependencies?.length) {
+    return false;
+  }
+
+  for (const dependency of dependencies) {
+    if (dependency === search_name) {
+      return true;
+    } else if (isPartOfCircularReference(search_name, depends_on_map, dependency, seen_names)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 // validates that property1 and property2 do not share any common keys
 export const validateDependsOn = async <T extends ValidatableConfig>(
   target: ComponentConfig,
@@ -200,28 +225,3 @@ export const validateDependsOn = async <T extends ValidatableConfig>(
 
   return errors;
 };
-
-export const isPartOfCircularReference = (search_name: string, depends_on_map: { [name: string]: string[] }, current_name?: string, seen_names: string[] = []) => {
-  const next_name = current_name || search_name;
-  const dependencies = depends_on_map[next_name];
-
-  if (seen_names.includes(next_name)) {
-    return false;
-  }
-
-  seen_names.push(next_name);
-
-  if (!dependencies?.length) {
-    return false;
-  }
-
-  for (const dependency of dependencies) {
-    if (dependency === search_name) {
-      return true;
-    } else if (isPartOfCircularReference(search_name, depends_on_map, dependency, seen_names)) {
-      return true;
-    }
-  }
-
-  return false;
-}

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -243,6 +243,7 @@ describe('local deploy environment', function () {
         "interfaces": {
           "main": "3000"
         },
+        "depends_on": ["my-demo-db"],
         "environment": {
           "DATABASE_HOST": "${{ services.my-demo-db.interfaces.postgres.host }}",
           "DATABASE_PORT": "${{ services.my-demo-db.interfaces.postgres.port }}",
@@ -382,9 +383,6 @@ describe('local deploy environment', function () {
           "80:80",
           "8080:8080"
         ],
-        "depends_on": [
-          seed_app_ref,
-        ],
         "restart": "always",
         "volumes": [
           "/var/run/docker.sock:/var/run/docker.sock"
@@ -427,9 +425,6 @@ describe('local deploy environment', function () {
         "ports": [
           "80:80",
           "8080:8080"
-        ],
-        "depends_on": [
-          hello_api_ref,
         ],
         "restart": "always",
         "volumes": [

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -330,7 +330,6 @@ describe('local deploy environment', function () {
         "ports": [
           "50000:3000"
         ],
-        "restart": "always",
         "depends_on": [
           seed_db_ref
         ],
@@ -383,7 +382,6 @@ describe('local deploy environment', function () {
           "80:80",
           "8080:8080"
         ],
-        "restart": "always",
         "volumes": [
           "/var/run/docker.sock:/var/run/docker.sock"
         ]
@@ -400,7 +398,6 @@ describe('local deploy environment', function () {
         "ports": [
           "50000:3000",
         ],
-        "restart": "always",
         "environment": {},
         "labels": [
           "traefik.enable=true",
@@ -426,7 +423,6 @@ describe('local deploy environment', function () {
           "80:80",
           "8080:8080"
         ],
-        "restart": "always",
         "volumes": [
           "/var/run/docker.sock:/var/run/docker.sock"
         ]

--- a/test/dependency-manager/components.test.ts
+++ b/test/dependency-manager/components.test.ts
@@ -184,6 +184,7 @@ describe('components spec v1', function () {
             interfaces: {
               main: 8080
             },
+            depends_on: ['api'],
             environment: {
               API_ADDR: '${{ services.api.interfaces.main.url }}'
             }
@@ -192,6 +193,7 @@ describe('components spec v1', function () {
             interfaces: {
               main: 8080
             },
+            depends_on: ['db'],
             environment: {
               DB_ADDR: '${{ services.db.interfaces.main.url }}'
             }

--- a/test/dependency-manager/interfaces.test.ts
+++ b/test/dependency-manager/interfaces.test.ts
@@ -59,6 +59,7 @@ describe('interfaces spec v1', () => {
             interfaces: {
               main: 8080
             },
+            depends_on: ['db'],
             environment: {
               DB_PROTOCOL: '${{ services.db.interfaces.postgres.protocol }}',
               DB_HOST: '${{ services.db.interfaces.postgres.host }}',
@@ -187,6 +188,7 @@ describe('interfaces spec v1', () => {
           },
           api: {
             image: 'api:latest',
+            depends_on: ['db'],
             interfaces: {
               main: 8080
             },
@@ -269,7 +271,6 @@ describe('interfaces spec v1', () => {
       ]);
 
       const expected_leaf_compose: DockerService = {
-        depends_on: [leaf_api_ref],
         environment: {
           LEAF_HOST: leaf_api_ref,
           LEAF_PORT: '8080',

--- a/test/dependency-manager/interfaces.test.ts
+++ b/test/dependency-manager/interfaces.test.ts
@@ -315,7 +315,6 @@ describe('interfaces spec v1', () => {
         ],
         image: 'api:latest',
         ports: ['50001:8080'],
-        restart: 'always',
         external_links: [
           'gateway:public.arc.localhost',
           'gateway:publicv1.arc.localhost'
@@ -351,7 +350,6 @@ describe('interfaces spec v1', () => {
         ],
         image: 'api:latest',
         ports: ['50003:8080'],
-        restart: 'always',
         external_links: [
           'gateway:public.arc.localhost',
           'gateway:publicv1.arc.localhost'
@@ -427,7 +425,6 @@ describe('interfaces spec v1', () => {
       "build": {
         "context": path.resolve("/stack")
       },
-      "restart": "always"
     };
     expect(template.services[api_ref]).to.be.deep.equal(expected_compose);
   });

--- a/test/dependency-manager/interpolation.test.ts
+++ b/test/dependency-manager/interpolation.test.ts
@@ -174,7 +174,6 @@ describe('interpolation spec v1', () => {
       'ports': [
         '50001:8080'
       ],
-      'restart': 'always',
       'build': {
         'context': path.resolve('/stack')
       }

--- a/test/dependency-manager/interpolation.test.ts
+++ b/test/dependency-manager/interpolation.test.ts
@@ -130,9 +130,6 @@ describe('interpolation spec v1', () => {
           'build': {
             'context': path.resolve('/stack')
           },
-          'depends_on': [
-            web_ref
-          ]
         },
       },
       'version': '3',
@@ -193,7 +190,6 @@ describe('interpolation spec v1', () => {
       'build': {
         'context': path.resolve('/stack')
       },
-      depends_on: [web_ref],
       external_links: [
         'gateway:public.arc.localhost'
       ],

--- a/test/dependency-manager/sidecar.test.ts
+++ b/test/dependency-manager/sidecar.test.ts
@@ -61,6 +61,7 @@ describe('sidecar spec v1', () => {
             interfaces: {
               main: 8080
             },
+            depends_on: ['db'],
             environment: {
               DB_PROTOCOL: '${{ services.db.interfaces.postgres.protocol }}',
               DB_HOST: '${{ services.db.interfaces.postgres.host }}',
@@ -194,6 +195,7 @@ describe('sidecar spec v1', () => {
             interfaces: {
               main: 8080
             },
+            depends_on: ['db'],
             environment: {
               DB_PROTOCOL: '${{ services.db.interfaces.postgres.protocol }}',
               DB_HOST: '${{ services.db.interfaces.postgres.host }}',
@@ -274,7 +276,6 @@ describe('sidecar spec v1', () => {
       ]);
 
       const expected_leaf_compose: DockerService = {
-        depends_on: [leaf_api_ref],
         environment: {
           LEAF_HOST: '127.0.0.1',
           LEAF_PORT: '12345',

--- a/test/dependency-manager/sidecar.test.ts
+++ b/test/dependency-manager/sidecar.test.ts
@@ -320,7 +320,6 @@ describe('sidecar spec v1', () => {
         ],
         image: 'api:latest',
         ports: ['50001:8080'],
-        restart: 'always',
         external_links: [
           'gateway:public.arc.localhost',
           'gateway:publicv1.arc.localhost'
@@ -356,7 +355,6 @@ describe('sidecar spec v1', () => {
         ],
         image: 'api:latest',
         ports: ['50003:8080'],
-        restart: 'always',
         external_links: [
           'gateway:public.arc.localhost',
           'gateway:publicv1.arc.localhost'
@@ -433,7 +431,6 @@ describe('sidecar spec v1', () => {
       "build": {
         "context": path.resolve("/stack")
       },
-      "restart": "always"
     };
     expect(template.services[api_ref]).to.be.deep.equal(expected_compose);
   });

--- a/test/dependency-manager/validation.test.ts
+++ b/test/dependency-manager/validation.test.ts
@@ -113,6 +113,160 @@ describe('validation spec v1', () => {
         }
       })
     });
+
+    it('valid service depends_on', async () => {
+      const component_config = `
+      name: test/component
+      services:
+        stateful-app:
+          depends_on:
+            - backend
+          interfaces:
+            main: 8080
+        backend:
+          interfaces:
+            main: 5432
+      interfaces:
+        frontend: \${{ services['stateful-app'].interfaces.main.url }}
+      `
+      mock_fs({ '/architect.yml': component_config });
+      await ComponentConfigBuilder.buildFromPath('/architect.yml')
+    });
+
+    it('invalid service self reference', async () => {
+      const component_config = `
+      name: test/component
+      services:
+        stateless-app:
+          depends_on:
+            - stateless-app
+          interfaces:
+            main: 8080
+      interfaces:
+        frontend: \${{ services['stateless-app'].interfaces.main.url }}
+      `
+      mock_fs({ '/architect.yml': component_config });
+      let validation_err;
+      try {
+        await ComponentConfigBuilder.buildFromPath('/architect.yml')
+      } catch (err) {
+        validation_err = err;
+      }
+      expect(validation_err).instanceOf(ValidationErrors)
+      expect(validation_err.errors).to.deep.eq({
+        "depends_on": {
+          "circular-reference": "services.stateless-app.depends_on must not contain a circular reference",
+          "value": "stateless-app",
+          "line": 5,
+          "column": 21
+        }
+      })
+    });
+
+    it('invalid service reference', async () => {
+      const component_config = `
+      name: test/component
+      services:
+        stateless-app:
+          depends_on:
+            - non-existant
+          interfaces:
+            main: 8080
+      interfaces:
+        frontend: \${{ services['stateless-app'].interfaces.main.url }}
+      `
+      mock_fs({ '/architect.yml': component_config });
+      let validation_err;
+      try {
+        await ComponentConfigBuilder.buildFromPath('/architect.yml')
+      } catch (err) {
+        validation_err = err;
+      }
+      expect(validation_err).instanceOf(ValidationErrors)
+      expect(validation_err.errors).to.deep.eq({
+        "depends_on": {
+          "invalid-reference": "services.stateless-app.depends_on[non-existant] must refer to a valid service",
+          "value": "stateless-app",
+          "line": 5,
+          "column": 21
+        }
+      })
+    });
+
+    it('invalid circular service reference', async () => {
+      const component_config = `
+      name: test/component
+      services:
+        stateful-app:
+          depends_on:
+            - backend
+          interfaces:
+            main: 8080
+        backend:
+          depends_on:
+            - stateful-app
+          interfaces:
+            main: 5432
+      interfaces:
+        frontend: \${{ services['stateful-app'].interfaces.main.url }}
+      `
+      mock_fs({ '/architect.yml': component_config });
+      let validation_err;
+      try {
+        await ComponentConfigBuilder.buildFromPath('/architect.yml')
+      } catch (err) {
+        validation_err = err;
+      }
+      expect(validation_err).instanceOf(ValidationErrors)
+      expect(validation_err.errors).to.deep.eq({
+        "depends_on": {
+          "circular-reference": "services.backend.depends_on must not contain a circular reference",
+          "value": "backend",
+          "line": 5,
+          "column": 21
+        }
+      })
+    });
+
+    it('invalid deep circular service reference', async () => {
+      const component_config = `
+      name: test/component
+      services:
+        stateful-app:
+          depends_on:
+            - api
+          interfaces:
+            main: 8080
+        api:
+          depends_on:
+            - backend
+          interfaces:
+            main: 8081
+        backend:
+          depends_on:
+            - stateful-app
+          interfaces:
+            main: 5432
+      interfaces:
+        frontend: \${{ services['stateful-app'].interfaces.main.url }}
+      `
+      mock_fs({ '/architect.yml': component_config });
+      let validation_err;
+      try {
+        await ComponentConfigBuilder.buildFromPath('/architect.yml')
+      } catch (err) {
+        validation_err = err;
+      }
+      expect(validation_err).instanceOf(ValidationErrors)
+      expect(validation_err.errors).to.deep.eq({
+        "depends_on": {
+          "circular-reference": "services.backend.depends_on must not contain a circular reference",
+          "value": "backend",
+          "line": 5,
+          "column": 21
+        }
+      })
+    });
   })
 
   // Component Validation


### PR DESCRIPTION
CLI/dependency-manager component of: https://gitlab.com/architect-io/hub-api/-/issues/395

I'll test and open a PR for the cloud-api when this is merged.

Note: this also contains some `"restart": "always",` fixes for tests that were failing.