### PR TITLE
add docs for depends_on; tweak instance_id for components

### DIFF
--- a/docs/1-configuration/0-architect-yml.md
+++ b/docs/1-configuration/0-architect-yml.md
@@ -34,6 +34,8 @@ services:
       POSTGRES_PASSWORD: ${{ parameters.db_pass }}
       POSTGRES_DATABASE: ${{ parameters.db_name }}
   my-api:
+    depends_on:
+      - database
     build:
       context: ./path/to/docker/build/context
       dockerfile: ./relative/to/context/Dockerfile

--- a/docs/1-configuration/1-services.md
+++ b/docs/1-configuration/1-services.md
@@ -168,3 +168,27 @@ When deploying to platforms of type ECS, there are constraints in the underlying
 | 1  | 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB |
 | 2 | 4GB - 16GB (in increments of 1GB) |
 | 4 | 8GB - 30GB (in increments of 1GB) |
+
+### depends_on
+
+`depends_on` takes an array of references to other services within the component. These dictate startup order: at deployment time, services will not be started until any of their listed dependents have already started.
+
+```yaml
+services:
+  app: # here, app will not start until my-api and db have started
+    depends_on:
+      - my-api
+      - db
+    interfaces:
+      postgres: 5432
+  my-api: # here, my-api will not start until db has started
+    depends_on:
+      - db
+    interfaces:
+      admin: 8081
+  db:
+    interfaces:
+      postgres: 5432
+```
+
+Note: Circular dependencies and self-references are detected and rejected at component registration time.

--- a/src/common/dependency-manager/local-manager.ts
+++ b/src/common/dependency-manager/local-manager.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from 'axios';
 import chalk from 'chalk';
-import DependencyManager, { ComponentVersionSlugUtils, DependencyNode } from '../../dependency-manager/src';
+import DependencyManager, { ComponentVersionSlugUtils, DependencyNode, Refs } from '../../dependency-manager/src';
 import DependencyGraph from '../../dependency-manager/src/graph';
 import DependencyEdge from '../../dependency-manager/src/graph/edge';
 import IngressEdge from '../../dependency-manager/src/graph/edge/ingress';
@@ -43,6 +43,7 @@ export default class LocalDependencyManager extends DependencyManager {
       }
 
       for (const node of nodes) {
+        node.instance_id = `${Refs.safeRef(component_config.getRef())}-component`;
         graph.addNode(node);
       }
     }

--- a/src/dependency-manager/src/manager.ts
+++ b/src/dependency-manager/src/manager.ts
@@ -12,7 +12,6 @@ import { ComponentConfig } from './spec/component/component-config';
 import { Dictionary } from './utils/dictionary';
 import { flattenValidationErrors, ValidationErrors } from './utils/errors';
 import { interpolateString, replaceBrackets } from './utils/interpolation';
-import { Refs } from './utils/refs';
 import { ComponentSlugUtils, Slugs } from './utils/slugs';
 import { validateInterpolation } from './utils/validation';
 
@@ -29,7 +28,6 @@ export default abstract class DependencyManager {
         local_path: component.getLocalPath(),
         artifact_image: component.getArtifactImage(),
       });
-      node.instance_id = `${Refs.safeRef(component.getRef())}-component`;
       nodes.push(node);
     }
 
@@ -40,7 +38,6 @@ export default abstract class DependencyManager {
         config: task_config,
         local_path: component.getLocalPath(),
       });
-      node.instance_id = `${Refs.safeRef(component.getRef())}-component`;
       nodes.push(node);
     }
     return nodes;

--- a/src/dependency-manager/src/manager.ts
+++ b/src/dependency-manager/src/manager.ts
@@ -29,7 +29,7 @@ export default abstract class DependencyManager {
         local_path: component.getLocalPath(),
         artifact_image: component.getArtifactImage(),
       });
-      node.instance_id = `${Refs.safeRef(component.getRef())}-local`;
+      node.instance_id = `${Refs.safeRef(component.getRef())}-component`;
       nodes.push(node);
     }
 
@@ -40,7 +40,7 @@ export default abstract class DependencyManager {
         config: task_config,
         local_path: component.getLocalPath(),
       });
-      node.instance_id = `${Refs.safeRef(component.getRef())}-local`;
+      node.instance_id = `${Refs.safeRef(component.getRef())}-component`;
       nodes.push(node);
     }
     return nodes;


### PR DESCRIPTION
@tjhiggins note: I tweaked the instance_id. I didn't realize this gets used for the component graph too, not just on local deployments. I don't think it matters but I figured `*-component` makes more sense than `*-local`