### PR TITLE
integer retries for compose v2 compatibility

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -196,11 +196,6 @@ export default class Deploy extends DeployCommand {
     this.log('Starting containers...');
     this.log('');
 
-    const compose_args = ['-f', compose_file, '-p', project_name, '--compatibility', 'up', '--timeout', '0'];
-    if (flags.detached) {
-      compose_args.push('-d');
-    }
-
     if (!isCi && flags.browser) {
       let open_browser_attempts = 0;
       const poll_interval = 2000;
@@ -236,6 +231,10 @@ export default class Deploy extends DeployCommand {
       }, poll_interval);
     }
 
+    const compose_args = ['-f', compose_file, '-p', project_name, 'up', '--timeout', '0'];
+    if (flags.detached) {
+      compose_args.push('-d');
+    }
     await execa('docker-compose', compose_args, { stdio: 'inherit' });
   }
 

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -91,9 +91,12 @@ export class DockerComposeUtils {
         formatted_environment_variables[var_key] = var_value.replace(/\$/g, '$$$'); // https://docs.docker.com/compose/compose-file/compose-file-v3/#variable-substitution
       }
       let service = {
-        ports,
         environment: formatted_environment_variables,
       } as DockerService;
+
+      if (ports.length) {
+        service.ports = ports;
+      }
 
       if (gateway_links.length) {
         service.external_links = gateway_links;

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -135,7 +135,7 @@ export class DockerComposeUtils {
             test: liveness_probe.command,
             interval: liveness_probe.interval,
             timeout: liveness_probe.timeout,
-            retries: liveness_probe.failure_threshold,
+            retries: parseInt(liveness_probe.failure_threshold),
             start_period: liveness_probe.initial_delay,
           };
           if (!service.labels) {

--- a/src/common/docker-compose/template.ts
+++ b/src/common/docker-compose/template.ts
@@ -26,7 +26,7 @@ export interface DockerComposeHealthCheck {
   test: string[];
   interval: string;
   timeout: string;
-  retries: string;
+  retries: number;
   start_period: string;
 }
 


### PR DESCRIPTION
Related to this in testing compose v2, I found that the `--compatibility` flag that we use is no longer supported and the command will fail if we leave that in there. It looks like that's required for Windows or something? What are your thoughts on that conflict @tjhiggins?