### PR TITLE
282 localized timestamps

### DIFF
--- a/src/base-table.ts
+++ b/src/base-table.ts
@@ -3,12 +3,12 @@ import Table from 'cli-table3';
 
 const default_style: CliTable3.TableConstructorOptions = {
   style: {
-    head: ['green']
-  }
+    head: ['green'],
+  },
 };
 
 export default class BaseTable extends Table {
   constructor(opts: CliTable3.TableConstructorOptions) {
-    super({ ...default_style, ...opts })
+    super({ ...default_style, ...opts });
   }
 }

--- a/src/commands/environments/index.ts
+++ b/src/commands/environments/index.ts
@@ -1,5 +1,6 @@
 import Command from '../../base-command';
 import Table from '../../base-table';
+import localizedTimestamp from '../../common/utils/localized-timestamp';
 
 export default class Environments extends Command {
   static aliases = ['environments', 'envs', 'env', 'environments:search', 'envs:search', 'env:search'];
@@ -28,7 +29,13 @@ export default class Environments extends Command {
     for (const env of environments) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore
-      table.push([env.name, env.account.name, env.namespace, env.created_at, env.updated_at]);
+      table.push([
+        env.name,
+        env.account.name,
+        env.namespace,
+        localizedTimestamp(env.created_at),
+        localizedTimestamp(env.updated_at)
+      ]);
     }
 
     this.log(table.toString());

--- a/src/commands/environments/index.ts
+++ b/src/commands/environments/index.ts
@@ -34,7 +34,7 @@ export default class Environments extends Command {
         env.account.name,
         env.namespace,
         localizedTimestamp(env.created_at),
-        localizedTimestamp(env.updated_at)
+        localizedTimestamp(env.updated_at),
       ]);
     }
 

--- a/src/commands/platforms/destroy.ts
+++ b/src/commands/platforms/destroy.ts
@@ -70,7 +70,7 @@ export default class PlatformDestroy extends Command {
     cli.action.start(chalk.blue('Deregistering platform'));
     const params: any = {};
     if (answers.force) {
-      params.force = 1
+      params.force = 1;
     }
     await this.app.api.delete(`/platforms/${account_platform.id}`, { params });
     cli.action.stop();

--- a/src/commands/platforms/index.ts
+++ b/src/commands/platforms/index.ts
@@ -1,5 +1,6 @@
 import Command from '../../base-command';
 import Table from '../../base-table';
+import localizedTimestamp from '../../common/utils/localized-timestamp';
 
 export default class Platforms extends Command {
   static aliases = ['platform', 'platform:search', 'platforms', 'platforms:search'];
@@ -29,7 +30,15 @@ export default class Platforms extends Command {
     for (const row of platforms) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore
-      table.push([row.name, row.account.name, row.properties.host, row.type, 'Encrypted on Server', row.created_at, row.updated_at]);
+      table.push([
+        row.name,
+        row.account.name,
+        row.properties.host,
+        row.type,
+        'Encrypted on Server',
+        localizedTimestamp(row.created_at),
+        localizedTimestamp(row.updated_at)
+      ]);
     }
 
     this.log(table.toString());

--- a/src/commands/platforms/index.ts
+++ b/src/commands/platforms/index.ts
@@ -37,7 +37,7 @@ export default class Platforms extends Command {
         row.type,
         'Encrypted on Server',
         localizedTimestamp(row.created_at),
-        localizedTimestamp(row.updated_at)
+        localizedTimestamp(row.updated_at),
       ]);
     }
 

--- a/src/common/utils/localized-timestamp.ts
+++ b/src/common/utils/localized-timestamp.ts
@@ -1,0 +1,15 @@
+const locale = Intl.DateTimeFormat().resolvedOptions().locale;
+// Following line is ts-ignored because typing for DateTimeFormatOptions was broken.
+// This has since been resolved in es2020, but there were other issues with mocha
+// after updating the target from es2017. Easiest to just ignore the check for now.
+const format_options: Intl.DateTimeFormatOptions = { // @ts-ignore
+  dateStyle: 'short',
+  timeStyle: 'long'
+};
+
+const localizedTimestamp = (timestamp: string): string => {
+    const date = Date.parse(timestamp);
+    return new Intl.DateTimeFormat(locale, format_options).format(date);
+}
+
+export default localizedTimestamp;

--- a/src/common/utils/localized-timestamp.ts
+++ b/src/common/utils/localized-timestamp.ts
@@ -2,14 +2,15 @@ const locale = Intl.DateTimeFormat().resolvedOptions().locale;
 // Following line is ts-ignored because typing for DateTimeFormatOptions was broken.
 // This has since been resolved in es2020, but there were other issues with mocha
 // after updating the target from es2017. Easiest to just ignore the check for now.
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 const format_options: Intl.DateTimeFormatOptions = { // @ts-ignore
   dateStyle: 'short',
-  timeStyle: 'long'
+  timeStyle: 'long',
 };
 
 const localizedTimestamp = (timestamp: string): string => {
     const date = Date.parse(timestamp);
     return new Intl.DateTimeFormat(locale, format_options).format(date);
-}
+};
 
 export default localizedTimestamp;


### PR DESCRIPTION
This change makes timestamps a little more human readable:

```
% architect platforms                               
┌───────────┬──────┬────────────┬─────────────────────┬────────────────────────────┬────────────────────────────┐
│ Name      │ Host │ Type       │ Credentials         │ Created                    │ Updated                    │
├───────────┼──────┼────────────┼─────────────────────┼────────────────────────────┼────────────────────────────┤
│ local-dev │      │ KUBERNETES │ Encrypted on Server │ 08/11/2021, 3:49:18 PM PDT │ 08/11/2021, 3:49:18 PM PDT │
└───────────┴──────┴────────────┴─────────────────────┴────────────────────────────┴────────────────────────────┘
```

vs the current

```
% architect platforms
┌───────────┬──────┬────────────┬─────────────────────┬──────────────────────────┬──────────────────────────┐
│ Name      │ Host │ Type       │ Credentials         │ Created                  │ Updated                  │
├───────────┼──────┼────────────┼─────────────────────┼──────────────────────────┼──────────────────────────┤
│ local-dev │      │ KUBERNETES │ Encrypted on Server │ 2021-08-11T22:49:18.956Z │ 2021-08-11T22:49:18.956Z │
└───────────┴──────┴────────────┴─────────────────────┴──────────────────────────┴──────────────────────────┘
```