### PR TITLE
281 include account on platform list

### DIFF
--- a/src/commands/platforms/index.ts
+++ b/src/commands/platforms/index.ts
@@ -29,7 +29,7 @@ export default class Platforms extends Command {
     for (const row of platforms) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore
-      table.push([row.name, row.account.name, row.host, row.type, 'Encrypted on Server', row.created_at, row.updated_at]);
+      table.push([row.name, row.account.name, row.properties.host, row.type, 'Encrypted on Server', row.created_at, row.updated_at]);
     }
 
     this.log(table.toString());

--- a/src/commands/platforms/index.ts
+++ b/src/commands/platforms/index.ts
@@ -25,11 +25,11 @@ export default class Platforms extends Command {
       return;
     }
 
-    const table = new Table({ head: ['Name', 'Host', 'Type', 'Credentials', 'Created', 'Updated'] });
+    const table = new Table({ head: ['Name', 'Account', 'Host', 'Type', 'Credentials', 'Created', 'Updated'] });
     for (const row of platforms) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore
-      table.push([row.name, row.host, row.type, 'Encrypted on Server', row.created_at, row.updated_at]);
+      table.push([row.name, row.account.name, row.host, row.type, 'Encrypted on Server', row.created_at, row.updated_at]);
     }
 
     this.log(table.toString());


### PR DESCRIPTION
This PR includes the Account column on the list of platforms

```
% architect platforms
┌───────────┬────────────┬─────────────────────────────────────────┬────────────┬─────────────────────┬──────────────────────────┬──────────────────────────┐
│ Name      │ Account    │ Host                                    │ Type       │ Credentials         │ Created                  │ Updated                  │
├───────────┼────────────┼─────────────────────────────────────────┼────────────┼─────────────────────┼──────────────────────────┼──────────────────────────┤
│ local-dev │ my-account │ https://kubernetes.docker.internal:6443 │ KUBERNETES │ Encrypted on Server │ 2021-08-11T22:49:18.956Z │ 2021-08-11T22:49:18.956Z │
└───────────┴────────────┴─────────────────────────────────────────┴────────────┴─────────────────────┴──────────────────────────┴──────────────────────────┘
```

vs the current
```
% architect platforms
┌───────────┬──────┬────────────┬─────────────────────┬──────────────────────────┬──────────────────────────┐
│ Name      │ Host │ Type       │ Credentials         │ Created                  │ Updated                  │
├───────────┼──────┼────────────┼─────────────────────┼──────────────────────────┼──────────────────────────┤
│ local-dev │      │ KUBERNETES │ Encrypted on Server │ 2021-08-11T22:49:18.956Z │ 2021-08-11T22:49:18.956Z │
└───────────┴──────┴────────────┴─────────────────────┴──────────────────────────┴──────────────────────────┘
```