### PR TITLE
Local deploy maps all available interfaces

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -380,7 +380,7 @@ export default class Deploy extends DeployCommand {
     // so that we can disable automatic interface mapping since we can't map a single interface to
     // multiple components at this time
     const onlyUnique = <T>(value: T, index: number, self: T[]) => self.indexOf(value) === index;
-    const uniqe_names = component_versions.map(name => name.split('@')[0]).filter(onlyUnique)
+    const uniqe_names = component_versions.map(name => name.split('@')[0]).filter(onlyUnique);
     const duplicates = uniqe_names.length !== component_versions.length;
 
     const component_options = { map_all_interfaces: !flags.production && !duplicates };

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -375,8 +375,18 @@ export default class Deploy extends DeployCommand {
     );
 
     const component_configs: ComponentConfig[] = [];
+
+    // Check if multiple instances of the same component are being deployed. This check is needed
+    // so that we can disable automatic interface mapping since we can't map a single interface to
+    // multiple components at this time
+    const onlyUnique = <T>(value: T, index: number, self: T[]) => self.indexOf(value) === index;
+    const uniqe_names = component_versions.map(name => name.split('@')[0]).filter(onlyUnique)
+    const duplicates = uniqe_names.length !== component_versions.length;
+
+    const component_options = { map_all_interfaces: !flags.production && !duplicates };
+
     for (const component_version of component_versions) {
-      const component_config = await dependency_manager.loadComponentConfig(component_version, interfaces_map);
+      const component_config = await dependency_manager.loadComponentConfig(component_version, interfaces_map, component_options);
 
       if (flags.recursive) {
         const dependency_configs = await dependency_manager.loadComponentConfigs(component_config);

--- a/src/common/dependency-manager/local-manager.ts
+++ b/src/common/dependency-manager/local-manager.ts
@@ -15,8 +15,8 @@ interface ComponentConfigOpts {
 }
 
 const defaultConfigOptions = {
-  map_all_interfaces: false
-}
+  map_all_interfaces: false,
+};
 
 const interfaceObjBuilder = (config: any, component_ref: any) => (interface_from: string, interface_to: string): any => {
   const interface_obj = config.interfaces[interface_to];

--- a/src/common/dependency-manager/local-manager.ts
+++ b/src/common/dependency-manager/local-manager.ts
@@ -1,3 +1,4 @@
+import { boolean } from '@oclif/parser/lib/flags';
 import { AxiosInstance } from 'axios';
 import chalk from 'chalk';
 import deepmerge from 'deepmerge';
@@ -8,6 +9,27 @@ import DependencyGraph from '../../dependency-manager/src/graph';
 import { buildConfigFromPath, buildConfigFromYml, buildSpecFromYml } from '../../dependency-manager/src/spec/utils/component-builder';
 import { Dictionary } from '../../dependency-manager/src/utils/dictionary';
 import PortUtil from '../utils/port';
+
+interface ComponentConfigOpts {
+  map_all_interfaces: boolean;
+}
+
+const defaultConfigOptions = {
+  map_all_interfaces: false
+}
+
+const interfaceObjBuilder = (config: any, component_ref: any) => (interface_from: string, interface_to: string): any => {
+  const interface_obj = config.interfaces[interface_to];
+  if (!interface_obj) {
+    throw new Error(`${component_ref} does not have an interface named ${interface_to}`);
+  }
+  if (!interface_obj.ingress) {
+    interface_obj.ingress = {};
+  }
+  interface_obj.ingress.subdomain = interface_from;
+  interface_obj.ingress.enabled = true;
+  return interface_obj;
+};
 
 export default class LocalDependencyManager extends DependencyManager {
   api: AxiosInstance;
@@ -22,7 +44,7 @@ export default class LocalDependencyManager extends DependencyManager {
     this.production = production;
   }
 
-  async loadComponentConfig(component_string: string, interfaces?: Dictionary<string>): Promise<ComponentConfig> {
+  async loadComponentConfig(component_string: string, interfaces?: Dictionary<string>, options?: ComponentConfigOpts): Promise<ComponentConfig> {
     const { component_account_name, component_name, tag, instance_name } = ComponentVersionSlugUtils.parse(component_string);
     const component_slug = ComponentSlugUtils.build(component_account_name, component_name);
     const component_ref = ComponentVersionSlugUtils.build(component_account_name, component_name, tag, instance_name);
@@ -57,24 +79,28 @@ export default class LocalDependencyManager extends DependencyManager {
     // Set debug values
     const merged_spec = buildSpecFromYml(config.source_yml);
 
-    for (const [interface_from, interface_to] of Object.entries(interfaces || {})) {
-      const interface_obj = config.interfaces[interface_to];
-      if (!interface_obj) {
-        throw new Error(`${component_ref} does not have an interface named ${interface_to}`);
-      }
-      if (!interface_obj.ingress) {
-        interface_obj.ingress = {};
-      }
-      interface_obj.ingress.subdomain = interface_from;
-      interface_obj.ingress.enabled = true;
-      config.interfaces[interface_to] = interface_obj;
+    const toInterfaceObj = interfaceObjBuilder(config, component_ref);
+    const inverted_interfaces: Dictionary<string> = Object
+      .entries(interfaces || {})
+      .reduce((acc, [from, to]) => ({ ...acc, [to]: from }), {});
+    Object.keys(config.interfaces).forEach(interface_to => {
+      const interface_from = inverted_interfaces[interface_to];
 
+      // If the interface hasn't been explictely mapped and we aren't configured
+      // to implicitely map all interfaces, then just skip this interface
+      if (!interface_from && !(options || defaultConfigOptions).map_all_interfaces) return;
+
+      const interface_obj = interface_from
+        ? toInterfaceObj(interface_from, interface_to)
+        : toInterfaceObj(interface_to, interface_to);
+
+      config.interfaces[interface_to] = interface_obj;
       // TODO:269:new-ticket find way to avoid modifying source_yml - def non-trivial with interpolation
       // potentially create a "deployConfig": a merged source_yml prior to interpolation
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       merged_spec.interfaces[interface_to] = interface_obj;
-    }
+    });
 
     if (config.instance_metadata?.local_path && !this.production) {
       for (const [sk, sv] of Object.entries(config.services)) {


### PR DESCRIPTION
This will automatically map any unmapped interfaces when deployed locally. Implicit interface mapping is disabled if you deploy locally with the `--production` flag. Deploying multiple instances of a component will also cause implicit interface mappings to be disabled since we can't map a single interface to multiple components. 