### PR TITLE
allow build args with newline

### DIFF
--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -201,7 +201,7 @@ export default class ComponentRegister extends Command {
       }
       const build_args_map: Dictionary<string | null> = { ...resource_spec.build?.args };
       for (const arg of flags.arg || []) {
-        const [key, value] = arg.split(/=(.+)/);
+        const [key, value] = arg.split(/=([^]+)/);
         if (!value) {
           throw new Error(`--arg must be in the format key=value: ${arg}`);
         }

--- a/test/commands/register.test.ts
+++ b/test/commands/register.test.ts
@@ -418,10 +418,10 @@ describe('register', function () {
     )
     .stdout({ print })
     .stderr({ print })
-    .command(['register', 'examples/stateful-component/architect.yml', '--arg', 'NODE_ENV=dev', '--arg', 'SSH_PUB_KEY="abc==test.architect.io"'])
+    .command(['register', 'examples/stateful-component/architect.yml', '--arg', 'NODE_ENV=dev', '--arg', 'SSH_PUB_KEY="abc==\ntest.architect.io"'])
     .it('set build arg not specified in architect.yml', ctx => {
       const buildImage = Docker.buildImage as sinon.SinonStub;
       expect(buildImage.callCount).to.eq(2);
-      expect(buildImage.firstCall.lastArg).to.deep.equal(['NODE_ENV=dev', 'SSH_PUB_KEY="abc==test.architect.io"'])
+      expect(buildImage.firstCall.lastArg).to.deep.equal(['NODE_ENV=dev', 'SSH_PUB_KEY="abc==\ntest.architect.io"'])
     });
 });


### PR DESCRIPTION
@tjhiggins the regex was not matching newlines so build args with newlines (ie an ssh private key) were being cut off.