### PR TITLE
Add the "account" configuration so users can set a default account

### DIFF
--- a/src/app-config/config.ts
+++ b/src/app-config/config.ts
@@ -11,6 +11,7 @@ export default class AppConfig {
   app_host: string;
   oauth_host: string;
   oauth_client_id: string;
+  account: string;
 
   constructor(config_dir: string, partial?: Partial<AppConfig>) {
     this.config_dir = config_dir;
@@ -26,6 +27,7 @@ export default class AppConfig {
     this.app_host = 'https://cloud.architect.io';
     this.oauth_host = 'https://auth.architect.io';
     this.oauth_client_id = '079Kw3UOB5d2P6yZlyczP9jMNNq8ixds';
+    this.account = '';
 
     // Override defaults with input values
     Object.assign(this, partial);
@@ -34,6 +36,10 @@ export default class AppConfig {
     if (this.app_host.includes('app.architect.io')) {
       this.app_host = 'https://cloud.architect.io';
     }
+  }
+
+  defaultAccount(): string | null {
+    return this.account === '' ? null : this.account;
   }
 
   getConfigDir(): string {
@@ -53,6 +59,7 @@ export default class AppConfig {
       app_host: this.app_host,
       oauth_host: this.oauth_host,
       oauth_client_id: this.oauth_client_id,
+      account: this.account,
     };
   }
 }

--- a/src/commands/components/index.ts
+++ b/src/commands/components/index.ts
@@ -32,7 +32,7 @@ export default class Components extends Command {
 
     let account: Account | undefined = undefined;
     if (flags.account) {
-      account = await AccountUtils.getAccount(this.app.api, flags.account);
+      account = await AccountUtils.getAccount(this.app, flags.account);
     }
 
     const params = {

--- a/src/commands/components/versions.ts
+++ b/src/commands/components/versions.ts
@@ -29,7 +29,7 @@ export default class ComponentVersions extends Command {
       return;
     }
 
-    const account: Account = await AccountUtils.getAccount(this.app.api, flags.account);
+    const account: Account = await AccountUtils.getAccount(this.app, flags.account);
 
     const { data: component } = await this.app.api.get(`/accounts/${account.name}/components/${args.component_name}`);
     const { data: { rows: component_versions } } = await this.app.api.get(`/components/${component.component_id}/versions`);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -418,7 +418,7 @@ export default class Deploy extends DeployCommand {
     const interfaces_map = this.getInterfacesMap();
     const component_secrets = this.getComponentSecrets();
 
-    const account = await AccountUtils.getAccount(this.app.api, flags.account);
+    const account = await AccountUtils.getAccount(this.app, flags.account);
     const environment = await EnvironmentUtils.getEnvironment(this.app.api, account, flags.environment);
 
     const deployment_dtos = [];

--- a/src/commands/destroy.ts
+++ b/src/commands/destroy.ts
@@ -30,7 +30,7 @@ export default class Destroy extends DeployCommand {
   async run(): Promise<void> {
     const { flags } = this.parse(Destroy);
 
-    const account = await AccountUtils.getAccount(this.app.api, flags.account);
+    const account = await AccountUtils.getAccount(this.app, flags.account);
     const environment = await EnvironmentUtils.getEnvironment(this.app.api, account, flags.environment);
 
     cli.action.start(chalk.blue('Creating pipeline'));

--- a/src/commands/environments/create.ts
+++ b/src/commands/environments/create.ts
@@ -58,7 +58,7 @@ export default class EnvironmentCreate extends Command {
       throw new Error(`environment ${Slugs.ArchitectSlugDescription}`);
     }
 
-    const account = await AccountUtils.getAccount(this.app.api, flags.account, 'Select an account to register the environment with');
+    const account = await AccountUtils.getAccount(this.app, flags.account, 'Select an account to register the environment with');
     const platform = await PlatformUtils.getPlatform(this.app.api, account, flags.platform);
 
     cli.action.start(chalk.blue('Registering environment with Architect'));

--- a/src/commands/environments/destroy.ts
+++ b/src/commands/environments/destroy.ts
@@ -48,7 +48,7 @@ export default class EnvironmentDestroy extends Command {
   async run(): Promise<void> {
     const { args, flags } = this.parse(EnvironmentDestroy);
 
-    const account = await AccountUtils.getAccount(this.app.api, flags.account);
+    const account = await AccountUtils.getAccount(this.app, flags.account);
     const environment = await EnvironmentUtils.getEnvironment(this.app.api, account, args.environment);
 
     let answers = await inquirer.prompt([{

--- a/src/commands/environments/index.ts
+++ b/src/commands/environments/index.ts
@@ -22,7 +22,7 @@ export default class Environments extends Command {
 
     let account: Account | undefined = undefined;
     if (flags.account) {
-      account = await AccountUtils.getAccount(this.app.api, flags.account);
+      account = await AccountUtils.getAccount(this.app, flags.account);
     }
 
     const params = {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -65,7 +65,7 @@ export abstract class InitCommand extends Command {
     const from_path = path.resolve(untildify(flags['from-compose']));
     const docker_compose = DockerComposeUtils.loadDockerCompose(from_path);
 
-    const account = await AccountUtils.getAccount(this.app.api, flags.account);
+    const account = await AccountUtils.getAccount(this.app, flags.account);
     const answers: any = await inquirer.prompt([
       {
         type: 'input',

--- a/src/commands/platforms/create.ts
+++ b/src/commands/platforms/create.ts
@@ -108,7 +108,7 @@ export default class PlatformCreate extends Command {
       flags_map[flag] = true;
     }
 
-    const account = await AccountUtils.getAccount(this.app.api, flags.account, 'Select an account to register the platform with');
+    const account = await AccountUtils.getAccount(this.app, flags.account, 'Select an account to register the platform with');
 
     const platform = await this.createArchitectPlatform(flags);
 

--- a/src/commands/platforms/destroy.ts
+++ b/src/commands/platforms/destroy.ts
@@ -48,7 +48,7 @@ export default class PlatformDestroy extends Command {
   async run(): Promise<void> {
     const { args, flags } = this.parse(PlatformDestroy);
 
-    const account = await AccountUtils.getAccount(this.app.api, flags.account);
+    const account = await AccountUtils.getAccount(this.app, flags.account);
     const platform = await PlatformUtils.getPlatform(this.app.api, account, args.platform);
 
     let answers = await inquirer.prompt([{

--- a/src/commands/platforms/index.ts
+++ b/src/commands/platforms/index.ts
@@ -23,7 +23,7 @@ export default class Platforms extends Command {
 
     let account: Account | undefined = undefined;
     if (flags.account) {
-      account = await AccountUtils.getAccount(this.app.api, flags.account);
+      account = await AccountUtils.getAccount(this.app, flags.account);
     }
 
     const params = {

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -89,7 +89,7 @@ export default class ComponentRegister extends Command {
     }
 
     const account_name = new_spec.name.split('/')[0];
-    const selected_account = await AccountUtils.getAccount(this.app.api, account_name);
+    const selected_account = await AccountUtils.getAccount(this.app, account_name);
 
     const tmpobj = tmp.dirSync({ mode: 0o750, prefix: Refs.safeRef(`${new_spec.name}:${tag}`), unsafeCleanup: true });
     let set_artifact_image = false;

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -114,7 +114,7 @@ export default class TaskExec extends Command {
   async runRemote(): Promise<void> {
     const { flags, args } = this.parse(TaskExec);
 
-    const selected_account = await AccountUtils.getAccount(this.app.api, flags.account);
+    const selected_account = await AccountUtils.getAccount(this.app, flags.account);
     const environment = await EnvironmentUtils.getEnvironment(this.app.api, selected_account, flags.environment);
 
     let parsed_slug;

--- a/src/common/utils/account.ts
+++ b/src/common/utils/account.ts
@@ -1,7 +1,7 @@
 import { flags } from '@oclif/command';
-import { AxiosInstance } from 'axios';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
+import AppService from '../../app-config/service';
 
 export interface Account {
   id: string;
@@ -17,14 +17,20 @@ export class AccountUtils {
     }),
   };
 
-  static async getAccount(api: AxiosInstance, account_name?: string, account_message?: string): Promise<Account> {
+  static async getAccount(app: AppService, account_name?: string, account_message?: string): Promise<Account> {
+    const config_account = app.config.defaultAccount();
+    // Set the account name from the config only if an account name wasn't set as cli flag
+    if (config_account && !account_name) {
+      account_name = config_account;
+    }
+
     if (process.env.ARCHITECT_ACCOUNT === account_name && process.env.ARCHITECT_ACCOUNT) {
       console.log(chalk.blue(`Using account from environment variables: `) + account_name);
     }
 
     let account: Account;
     if (account_name) {
-      account = (await api.get(`/accounts/${account_name}`)).data;
+      account = (await app.api.get(`/accounts/${account_name}`)).data;
       if (!account) {
         throw new Error(`Could not find account=${account_name}`);
       }
@@ -38,7 +44,7 @@ export class AccountUtils {
           message: account_message || 'Select an account',
           filter: (x) => x, // api filters
           source: async (answers_so_far: any, input: string) => {
-            const { data } = await api.get('/accounts', { params: { q: input, limit: 10 } });
+            const { data } = await app.api.get('/accounts', { params: { q: input, limit: 10 } });
             accounts = data.rows;
             return accounts;
           },

--- a/test/commands/config/get.test.ts
+++ b/test/commands/config/get.test.ts
@@ -27,6 +27,7 @@ const expectConfigValues = async (config_dir: string, config: AppConfig) => {
   await expectValueForField(config_dir, 'api_host', config.api_host);
   await expectValueForField(config_dir, 'oauth_host', config.oauth_host);
   await expectValueForField(config_dir, 'oauth_client_id', config.oauth_client_id);
+  await expectValueForField(config_dir, 'account', config.account);
 };
 
 describe('config:get', function () {


### PR DESCRIPTION
Now you can set an account config to use by default:
```
architect config:set account my-org
```

This behaves similarly to the `ARCHITECT_ACCOUNT` environment variable, and can be overwritten by providing the account flag.