### PR TITLE
Fix issue preventing logs from being pipable.

### DIFF
--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -123,7 +123,7 @@ export default class Logs extends Command {
       return chunks;
     }
 
-    const displayRawLogs = flags.raw || !process.stdout.isTTY
+    const displayRawLogs = flags.raw || !process.stdout.isTTY;
     const log = (txt: string) => {
       if (displayRawLogs) {
         this.log(txt);

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -123,8 +123,9 @@ export default class Logs extends Command {
       return chunks;
     }
 
+    const displayRawLogs = flags.raw || !process.stdout.isTTY
     const log = (txt: string) => {
-      if (flags.raw) {
+      if (displayRawLogs) {
         this.log(txt);
       } else {
         if (show_header) {


### PR DESCRIPTION
## Issue
When piping log output to a downstream command, the current application will crash unless the raw flag is set. This is due to the nodejs not setting the stdout columns data in. Without this data the formatting system produces a NaN for the allowed column length and breaks.

## Solution
The easy solution is to force the raw mode if we detect the caller is not in tty mode. This does cause a flag to be set when the user did not explicitly set it, but in this instance I think that's okay.