### PR TITLE
Allow empty string for scheudle.

### DIFF
--- a/src/dependency-manager/src/spec/utils/spec-validator.ts
+++ b/src/dependency-manager/src/spec/utils/spec-validator.ts
@@ -118,7 +118,7 @@ export const validateSpec = (parsed_yml: ParsedYaml): ValidationError[] => {
     const ajv = new Ajv({ allErrors: true, unicodeRegExp: false });
     addFormats(ajv);
     ajv.addFormat('cidrv4', /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)(?:\/(?:3[0-2]|[12]?[0-9]))?$/);
-    ajv.addFormat('cron', (value: string): boolean => cron(value, cron_options).isValid());
+    ajv.addFormat('cron', (value: string): boolean => value === "" || cron(value, cron_options).isValid());
     ajv.addKeyword('externalDocs');
     // https://github.com/ajv-validator/ajv-errors
     ajv_errors(ajv);


### PR DESCRIPTION
## Overview
According to the docs, the current task spec allows a task with an empty schedule. This allows a user to register a task that they will trigger manually. However at the moment the architect validate command fails if you use an empty schedule. However it does work if the schedule is removed completely.

## Solution
When checking for a valid cron in the schema we also pass an empty string now.

## Caveats
This changes the default behavior of what a valid cron schedule is. At the moment it appears that only the task spec uses this, but if another part of the spec requires a cron and uses the cron field, it could lead to weird behavior. 