### PR TITLE
Updated all the docs and examples that used deploy -l

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,36 @@ ALIASES
 
 _See code: [src/commands/config/view.ts](https://github.com/architect-team/architect-cli/blob/v1.13.1/src/commands/config/view.ts)_
 
+## `architect dev [CONFIGS_OR_COMPONENTS]`
+
+Run your stacks locally
+
+```
+USAGE
+  $ architect dev [CONFIGS_OR_COMPONENTS]
+
+ARGUMENTS
+  CONFIGS_OR_COMPONENTS  Path to an architect.yml file or component `account/component:latest`. Multiple components are
+                         accepted.
+
+OPTIONS
+  -e, --environment=environment    Architect environment
+  -h, --help                       show CLI help
+  -i, --interface=interface        [default: ] Component interfaces
+  -o, --compose-file=compose-file  Path where the compose file should be written to
+  -p, --parameter=parameter        [default: ] Component parameters
+  -r, --[no-]recursive             [default: true] Toggle to automatically deploy all dependencies
+  -s, --secrets=secrets            Path of secrets file
+  --[no-]browser                   [default: true] Automatically open urls in the browser for local deployments
+  --build-parallel                 [default: false] Build docker images in parallel
+  --production                     Build and run components without debug blocks
+```
+
+_See code: [src/commands/dev.ts](https://github.com/architect-team/architect-cli/blob/v1.13.1/src/commands/dev.ts)_
+
 ## `architect deploy [CONFIGS_OR_COMPONENTS]`
 
-Create a deploy job on Architect Cloud or run stacks locally
+Create a deploy job on Architect Cloud
 
 ```
 USAGE
@@ -207,7 +234,6 @@ OPTIONS
   -e, --environment=environment    Architect environment
   -h, --help                       show CLI help
   -i, --interface=interface        [default: ] Component interfaces
-  -l, --local                      Deploy the stack locally instead of via Architect Cloud
   -o, --compose-file=compose-file  Path where the compose file should be written to
   -p, --parameter=parameter        [default: ] Component parameters
   -r, --[no-]recursive             [default: true] Toggle to automatically deploy all dependencies

--- a/docs/0-getting-started/0-introduction.md
+++ b/docs/0-getting-started/0-introduction.md
@@ -151,7 +151,7 @@ This `architect.yml` describes each of our three `services`, exposes the fronten
 Now that we have a better understanding of what we're deploying, let's go ahead and start it up!
 
 ```sh
-$ architect deploy --local examples/react-app:latest -i app:app
+$ architect dev examples/react-app:latest -i app:app
 
 Using locally linked examples/react-app found at /architect-cli/examples/react-app
 http://app.arc.localhost:80/ => examples--react-app--app--latest--aklmrtvo

--- a/docs/0-getting-started/2-working-with-tasks.md
+++ b/docs/0-getting-started/2-working-with-tasks.md
@@ -94,12 +94,12 @@ To run this locally, we'll need to link the component by running:
 Successfully linked brahm-testing/my-task to local system at /Users/brahmlower/development/my-task/architect.yml.
 ```
 
-Now that the component is linked, we can deploy it locally using the normal `architect deploy`
-command with the `--local` flag. Under the hood, this creates a docker-compose file which will be used
+Now that the component is linked, we can deploy it locally using the `architect dev`
+command. Under the hood, this creates a docker-compose file which will be used
 as we execute the task.
 
 ```shell
-% architect deploy --local brahm-testing/my-task
+% architect dev brahm-testing/my-task
 ...
 ```
 
@@ -122,7 +122,7 @@ friction during development.
 
 ## Local Task Development
 
-Development generally requires rapid iteration, and needing to run `deploy` and `task:exec` each time you
+Development generally requires rapid iteration, and needing to run `dev` and `task:exec` each time you
 want to test can be a tedious experience. To alleviate this, we can make use of the `debug` feature to mount
 our source code when we run the task without having to re-deploy. This can be achieved by updating the
 component with a debug block, re-deploying (just the once) to update the component configuration. We will
@@ -149,7 +149,7 @@ We will have to redeploy the component because we change its definition, so lets
 again to make sure everything is still working as expected.
 
 ```shell
-% architect deploy --local brahm-testing/my-task
+% architect dev brahm-testing/my-task
 ...
 % architect task:exec --local brahm-testing/my-task hello-world
 ...
@@ -210,7 +210,7 @@ when we execute the task.
 
 
 ```shell
-% architect deploy --local brahm-testing/my-task -p greeting=Hola
+% architect dev brahm-testing/my-task -p greeting=Hola
 ...
 % architect task:exec --local brahm-testing/my-task hello-world
 Hola, world! 👋
@@ -291,11 +291,10 @@ the environment variable we reference in the script:
          src:
 ```
 
-Great! Now lets deploy this, but with the `--detached` flag to run the service in the background so we can continue using
-this same terminal to execute the task.
+Great! Now lets deploy our changes.
 
 ```shell
-% architect deploy --local --detached brahm-testing/my-task -p greeting=Hola
+% architect dev --detached brahm-testing/my-task -p greeting=Hola
 Building containers... done
 
 Once the containers are running they will be accessible via the following urls:

--- a/docs/1-components/7-local-configuration.md
+++ b/docs/1-components/7-local-configuration.md
@@ -97,7 +97,7 @@ The debug block is used whenever local source code is leveraged instead of built
 
 ```sh
 # Deploying a component from source
-$ architect deploy --local ./architect.yml
+$ architect dev ./architect.yml
 
 # Linking a component and using by name
 $ architect link ./architect.yml
@@ -106,8 +106,10 @@ $ architect deploy component/name
 
 ## How can I test non-debugging behavior locally?
 
-Sometimes you might want to test out the production deployment process before registering the component. To simulate the regular deployment flow, use the `--production` flag:
+Sometimes you might want to test out the production deployment process before registering the component. To simulate the regular deployment flow, use the `--environment` flag:
 
 ```sh
-$ architect deploy --local ./architect.yml --production
+$ architect dev ./architect.yml --environment=production
 ```
+
+This will cause ```${{ if architect.environment == 'local' }}``` to return false, which in return will not set the environment variable  ```PGDATA``` or mount the volume.

--- a/examples/database-seeding/README.md
+++ b/examples/database-seeding/README.md
@@ -26,8 +26,8 @@ $ cd ./architect-cli/examples/database-seeding
 # Register the component to the local registry
 $ architect link .
 
-# Deploy using the --local flag
-$ architect deploy --local examples/database-seeding:latest -i main:main -p AUTO_DDL=migrate
+# Deploy using the dev command
+$ architect dev examples/database-seeding:latest -i main:main -p AUTO_DDL=migrate
 ```
 
 Once the deploy has completed, you can reach your new service by going to http://main.arc.localhost/.

--- a/examples/gcp-pubsub/README.md
+++ b/examples/gcp-pubsub/README.md
@@ -11,5 +11,5 @@
 With event-driven architectures, applications are dependent on both the component publishing a topic they need to consume as well as the broker facilitating the request. The subscriber component has a dependency on the GCP pub/sub component as well as the publisher component, so that means we can simply deploy the subscriber to see the whole stack materialize:
 
 ```sh
-$ architect deploy --local ./subscriber --values values.yml
+$ architect dev ./subscriber --values values.yml
 ```

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -26,8 +26,8 @@ $ cd ./architect-cli/examples/hello-world
 # Register the component to the local registry
 $ architect link .
 
-# Deploy using the --local flag
-$ architect deploy --local examples/hello-world:latest -i hello:hello
+# Deploy using the dev command
+$ architect dev examples/hello-world:latest -i hello:hello
 ```
 
 Once the deploy has completed, you can reach your new service by going to http://hello.arc.localhost/.

--- a/examples/hot-reloading/README.md
+++ b/examples/hot-reloading/README.md
@@ -26,8 +26,8 @@ $ cd ./architect-cli/examples/hot-reloading
 # Register the component to the local registry
 $ architect link .
 
-# Deploy using the --local flag
-$ architect deploy --local examples/hot-reloading:latest -i http:http
+# Deploy using the dev command
+$ architect dev examples/hot-reloading:latest -i http:http
 ```
 
 Once the deploy has completed, you can reach your new service by going to http://http.arc.localhost/. Whenever you make changes to code in the `./src` directory, you'll see the logs indicating that the service has restart automatically.

--- a/examples/nestjs-microservices/simple/README.md
+++ b/examples/nestjs-microservices/simple/README.md
@@ -42,7 +42,7 @@ Successfully linked examples/nestjs-simple-client to local system at /architect-
 The REST client service cites the TCP server as a dependency. This means that Architect can automatically deploy and connect to it whenever the client is deployed, and all we have to do is deploy the client component:
 
 ```bash
-$ architect deploy --local examples/nestjs-simple-client:latest -i main:client
+$ architect dev examples/nestjs-simple-client:latest -i main:client
 ```
 
 Once the application is done booting, the REST client will be available on http://app.arc.localhost/hello/Name

--- a/examples/react-app/README.md
+++ b/examples/react-app/README.md
@@ -28,8 +28,8 @@ $ cd ./architect-cli/examples/react-app
 # Register the component to the local registry
 $ architect link .
 
-# Deploy using the --local flag
-$ architect deploy --local examples/react-app:latest -i app:app
+# Deploy using the dev command
+$ architect dev examples/react-app:latest -i app:app
 ```
 
 Once the deploy has completed, you can reach your new service by going to http://app.arc.localhost/.

--- a/examples/scheduled-tasks/README.md
+++ b/examples/scheduled-tasks/README.md
@@ -25,7 +25,7 @@ When you run the component locally the task will be configured but won't run on 
 $ architect link .
 
 # Deploy the component locally
-$ architect deploy --local examples/scheduled-tasks:latest
+$ architect dev examples/scheduled-tasks:latest
 
 # In another terminal session, execute the task
 $ architect task:exec --local examples/basic-task:latest curler

--- a/examples/stateful-component/README.md
+++ b/examples/stateful-component/README.md
@@ -26,8 +26,8 @@ $ cd ./architect-cli/examples/stateful-component
 # Register the component to the local registry
 $ architect link .
 
-# Deploy using the --local flag
-$ architect deploy --local examples/stateful-component:latest -i frontend:frontend
+# Deploy using the dev command
+$ architect dev examples/stateful-component:latest -i frontend:frontend
 ```
 
 Once the deploy has completed, you can reach your new service by going to http://frontend.arc.localhost/.

--- a/examples/stateless-component/README.md
+++ b/examples/stateless-component/README.md
@@ -28,8 +28,8 @@ $ cd ./architect-cli/examples/stateful-component
 # Register the component to the local registry
 $ architect link .
 
-# Deploy using the --local flag
-$ architect deploy --local examples/stateless-component:latest -i frontend:frontend
+# Deploy using the dev command
+$ architect dev examples/stateless-component:latest -i frontend:frontend
 ```
 
 Once the deploy has completed, you can reach your new service by going to http://frontend.arc.localhost/.

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -86,7 +86,7 @@ export default class TaskExec extends Command {
     try {
       compose = DockerComposeUtils.loadDockerCompose(compose_file);
     } catch (err) {
-      throw new Error(`Could not find docker compose file at ${compose_file}. Please run \`architect deploy -l -e ${project_name} ${args.component}\` before executing any tasks in your local ${project_name} environment.`);
+      throw new Error(`Could not find docker compose file at ${compose_file}. Please run \`architect dev -e ${project_name} ${args.component}\` before executing any tasks in your local ${project_name} environment.`);
     }
 
     let parsed_slug;

--- a/test/commands/task.test.ts
+++ b/test/commands/task.test.ts
@@ -276,7 +276,7 @@ describe('task:exec', async function () {
     .stderr({ print })
     .command(['task:exec', '-l', namespaced_component_name, mock_task.name])
     .catch(err => {
-      expect(err.message).to.contain(`Could not find docker compose file at ${DockerComposeUtils.buildComposeFilepath('test', DockerComposeUtils.DEFAULT_PROJECT)}. Please run \`architect deploy -l -e ${DockerComposeUtils.DEFAULT_PROJECT} ${namespaced_component_name}\` before executing any tasks in your local ${DockerComposeUtils.DEFAULT_PROJECT} environment.`);
+      expect(err.message).to.contain(`Could not find docker compose file at ${DockerComposeUtils.buildComposeFilepath('test', DockerComposeUtils.DEFAULT_PROJECT)}. Please run \`architect dev -e ${DockerComposeUtils.DEFAULT_PROJECT} ${namespaced_component_name}\` before executing any tasks in your local ${DockerComposeUtils.DEFAULT_PROJECT} environment.`);
     })
     .it('fails with a useful message if no docker compose file is found');
 
@@ -288,7 +288,7 @@ describe('task:exec', async function () {
     .stderr({ print })
     .command(['task:exec', '-l', '-e', mock_local_env_name, namespaced_component_name, mock_task.name])
     .catch(err => {
-      expect(err.message).to.contain(`Could not find docker compose file at ${DockerComposeUtils.buildComposeFilepath('test', mock_local_env_name)}. Please run \`architect deploy -l -e ${mock_local_env_name} ${namespaced_component_name}\` before executing any tasks in your local ${mock_local_env_name} environment.`);
+      expect(err.message).to.contain(`Could not find docker compose file at ${DockerComposeUtils.buildComposeFilepath('test', mock_local_env_name)}. Please run \`architect dev -e ${mock_local_env_name} ${namespaced_component_name}\` before executing any tasks in your local ${mock_local_env_name} environment.`);
     })
     .it('fails with a useful message if no docker compose file is found');
 


### PR DESCRIPTION
## Overview
This PR follows up the changes made to the CLI to remove the --local flag. 

All docs/examples have been updated to remove the usage of the ``` architect deploy --local``` command and replace it with the ```architect dev``` command. At the same time I removed some of the deprecated flags such as ```--production```.

## Testing
Viewed each change in a Markdown viewer to make sure the formatting looked correct. Otherwise discussed any possible confusion a user may have over the intent of the documentation with @tjhiggins.