### PR TITLE
Added support for local logs.

### DIFF
--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -215,7 +215,7 @@ export default class Logs extends Command {
     // If no account is default to local first.
     if (!flags.account && flags.environment) {
       // If the env exists locally then just assume local
-      const is_local_env = DockerComposeUtils.isLocalEnvironment(this.app.config.getConfigDir(), flags.environment);
+      const is_local_env = await DockerComposeUtils.isLocalEnvironment(this.app.config.getConfigDir(), flags.environment);
       if (is_local_env) {
         return await this.runLocal();
       }

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -114,7 +114,7 @@ export default class Logs extends Command {
         // can display it the same way regardless of where the logs
         // came from.
         if (!flags.raw) {
-          line = line.substr(line.indexOf('|') + 1);
+          line = line.substring(line.indexOf('|') + 1);
         }
         log(line);
       });

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -100,23 +100,21 @@ export default class Logs extends Command {
       compose_args.push(flags.tail.toString());
     }
     compose_args.push(service_name);
-    const cmd = execa('docker-compose', compose_args);
 
-    const log = this.createLogger(service_name);
+    const cmd = execa('docker-compose', compose_args);
 
     const logger = new Transform({
       decodeStrings: false,
     });
 
+    const this_log = this.log;
+    const prefix = flags.raw ? '' : `${chalk.cyan(chalk.bold(service_name))} ${chalk.hex('#D3D3D3')('|')}`;
     logger._transform = function (chunk, _encoding, done) {
       chunk.toString().split('\n').forEach((line: string) => {
-        // This removes the service name so that the logger
-        // can display it the same way regardless of where the logs
-        // came from.
         if (!flags.raw) {
           line = line.substring(line.indexOf('|') + 1);
         }
-        log(line);
+        this_log(prefix, chalk.cyan(line));
       });
       done(null, chunk.toString());
     };

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -393,7 +393,11 @@ export class DockerComposeUtils {
       name = name.substring(0, name.lastIndexOf('_'));
       const service = new LocalService();
       // Remove the slug for the display name and add the status of the service
-      service.display_name = name.substring(0, name.lastIndexOf('-')) + ` (${line_parts[3].toUpperCase()})`;
+      const slugless_name = name.substring(0, name.lastIndexOf('-'));
+      if (!slugless_name) {
+        return service;
+      }
+      service.display_name = slugless_name + ` (${line_parts[3].toUpperCase()})`;
       service.service_name = name;
       return service;
     }).filter((service) => {

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -385,13 +385,15 @@ export class DockerComposeUtils {
     lines.shift();
     lines.shift();
     const services = lines.map(line => {
-      let name = line.split(' ')[0];
+      // Split the line by space but not if the space is in double qoutes
+      const line_parts = line.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
+      let name = line_parts[0];
       // Remove env name and counter: cloud_gateway_1
       name = name.substring(name.indexOf('_') + 1);
       name = name.substring(0, name.lastIndexOf('_'));
       const service = new LocalService();
-      // Remove the slug for the display name
-      service.display_name = name.substr(0, name.lastIndexOf('-'));
+      // Remove the slug for the display name and add the status of the service
+      service.display_name = name.substring(0, name.lastIndexOf('-')) + ` (${line_parts[3].toUpperCase()})`;
       service.service_name = name;
       return service;
     }).filter((service) => {

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -379,7 +379,6 @@ export class DockerComposeUtils {
   }
 
   public static async getLocalServiceForEnvironment(environment: string, compose_file: string, service_name?: string): Promise<string> {
-    console.log(compose_file);
     const cmd = await execa('docker-compose', ['-f', compose_file, '-p', environment, 'ps']);
     const lines = cmd.stdout.split('\n');
     //Remove the headers

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -1,5 +1,6 @@
 import execa, { Options } from 'execa';
 import fs from 'fs-extra';
+import inquirer from 'inquirer';
 import yaml from 'js-yaml';
 import os from 'os';
 import pLimit from 'p-limit';
@@ -15,6 +16,11 @@ import { Dictionary } from '../../dependency-manager/src/utils/dictionary';
 import LocalPaths from '../../paths';
 import PortUtil from '../utils/port';
 import DockerComposeTemplate, { DockerService, DockerServiceBuild } from './template';
+
+class LocalService {
+  display_name!: string;
+  service_name!: string;
+}
 
 export class DockerComposeUtils {
 
@@ -341,6 +347,75 @@ export class DockerComposeUtils {
       }
       throw err;
     }
+  }
+
+  public static async getLocalEnvironments(config_dir: string): Promise<string[]> {
+    const search_directory = path.join(config_dir, LocalPaths.LOCAL_DEPLOY_PATH);
+    const files = await fs.readdir(path.join(search_directory));
+    return files.map((file) => file.split('.')[0]);
+  }
+
+  public static async isLocalEnvironment(config_dir: string, environment_name: string): Promise<boolean> {
+    const local_enviromments = await DockerComposeUtils.getLocalEnvironments(config_dir);
+    return !!(local_enviromments.find(env => env == environment_name));
+  }
+
+  public static async getLocalEnvironment(config_dir: string, environment_name?: string): Promise<string> {
+    const search_directory = path.join(config_dir, LocalPaths.LOCAL_DEPLOY_PATH);
+    const files = await fs.readdir(path.join(search_directory));
+    const local_enviromments = files.map((file) => file.split('.')[0]);
+    const answers: any = await inquirer.prompt([
+      {
+        when: !environment_name,
+        type: 'autocomplete',
+        name: 'environment',
+        message: 'Select a environment',
+        source: async () => {
+          return local_enviromments;
+        },
+      },
+    ]);
+    return environment_name || answers.environment;
+  }
+
+  public static async getLocalServiceForEnvironment(environment: string, compose_file: string, service_name?: string): Promise<string> {
+    console.log(compose_file);
+    const cmd = await execa('docker-compose', ['-f', compose_file, '-p', environment, 'ps']);
+    const lines = cmd.stdout.split('\n');
+    //Remove the headers
+    lines.shift();
+    lines.shift();
+    const services = lines.map(line => {
+      let name = line.split(' ')[0];
+      // Remove env name and counter: cloud_gateway_1
+      name = name.substr(name.indexOf('_') + 1);
+      name = name.substr(0, name.lastIndexOf('_'));
+      const service = new LocalService();
+      // Remove the slug for the display name
+      service.display_name = name.substr(0, name.lastIndexOf('-'));
+      service.service_name = name;
+      return service;
+    }).filter((service) => {
+      // Our services do not have a slug attached and have an empty display name at this point
+      return service.display_name;
+    });
+    const answers: any = await inquirer.prompt([
+      {
+        when: !service_name,
+        type: 'autocomplete',
+        name: 'service',
+        message: 'Select a service',
+        source: async () => {
+          return services.map(service => service.display_name);
+        },
+      },
+    ]);
+    const display_service_name = service_name || answers.service;
+    const full_service_name = services.find((service) => service.display_name == display_service_name)?.service_name;
+    if (!full_service_name) {
+      throw new Error(`Could not find service=${display_service_name}`);
+    }
+    return full_service_name;
   }
 
   public static async run(service_name: string, project_name: string, compose_file?: string): Promise<void> {

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -387,8 +387,8 @@ export class DockerComposeUtils {
     const services = lines.map(line => {
       let name = line.split(' ')[0];
       // Remove env name and counter: cloud_gateway_1
-      name = name.substr(name.indexOf('_') + 1);
-      name = name.substr(0, name.lastIndexOf('_'));
+      name = name.substring(name.indexOf('_') + 1);
+      name = name.substring(0, name.lastIndexOf('_'));
       const service = new LocalService();
       // Remove the slug for the display name
       service.display_name = name.substr(0, name.lastIndexOf('-'));


### PR DESCRIPTION
## Overview
This PR adds support for querying logs for a local service. The following assumptions are now made.

1. If an environment flag is set then we check if it matches a local env first. If it does we assume the user is looking for a local service.
2. If an account flag is set we automatically assume the user is looking for a remote service.
3. If no flags are set we ask for the account the user is looking for. We add a new option called "dev (Local Machine)" that the user can select for a local service.

NOTES: The since flag does not work locally and is ignored. While kubernetes supports since, docker does not. We could implement this feature ourselves but it did not seem worthwhile in the short term.

## Changes
1. Added the concept of a local account and the ability to check if an account is a local account.
2. Added support for getting a list of local environments.
3. Added support for detecting if an environment is a local one.
4. Added support for getting list of local services for a particular environment
5. Added support for getting logs from a local service.

## Testing
1. Setup a local env with the ```architect dev``` command.
2. Deploy a service to a remote platform with the ```architect deploy```` command.
3. Run ```architect logs``` and interact with the autocomplete options to test the functionality.
4.  Test the following flags. --tail --follow --raw --since

## Sample Output
<img width="1210" alt="Logs" src="https://user-images.githubusercontent.com/532523/151071743-820670f7-26c5-4d3e-9e2b-5ed709671725.PNG">

