### PR TITLE
Add a more readable environment ref method

### DIFF
--- a/src/dependency-manager/src/config/component-config.ts
+++ b/src/dependency-manager/src/config/component-config.ts
@@ -109,6 +109,18 @@ export const buildNodeRef = (component_config: ComponentConfig, service_name: st
   return resourceRefToNodeRef(service_ref, component_config.metadata?.instance_id, max_length);
 };
 
+export const environmentRef = (current_account: string, ref: string): string => {
+  const { component_account_name, component_name, service_name, instance_name } = ServiceVersionSlugUtils.parse(ref);
+  let environment_ref = `${component_name}.${service_name}`;
+  if (current_account !== component_account_name) {
+    environment_ref = `${component_account_name}.${environment_ref}`;
+  }
+  if (instance_name) {
+    environment_ref = `${instance_name}--${environment_ref}`;
+  }
+  return environment_ref;
+};
+
 export function buildInterfacesRef(component_config: ComponentSpec | ComponentConfig): string {
   const component_ref = component_config.metadata.ref;
   return resourceRefToNodeRef(component_ref, component_config.metadata?.instance_id);

--- a/test/dependency-manager/utils/slug-splitters.test.ts
+++ b/test/dependency-manager/utils/slug-splitters.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { environmentRef } from '../../../src/dependency-manager/src/config/component-config';
 import { ComponentSlugUtils, ComponentVersionSlugUtils, EnvironmentSlugUtils, ServiceSlugUtils, ServiceVersionSlugUtils } from '../../../src/dependency-manager/src/spec/utils/slugs';
 
 describe('slug validators', () => {
@@ -99,4 +100,19 @@ describe('slug validators', () => {
   it(`EnvironmentSlugUtils.parse throws exception on ${invalid_environment_slug}`, async () => {
     expect(() => EnvironmentSlugUtils.parse(invalid_environment_slug)).to.throw(`must be of the form <account-name>/<environment-name>`);
   });
+
+  describe('environmentRef', () => {
+    it(`account doesn't get included if it is the same as the current`, async () => {
+      expect(environmentRef(component_account_name, service_version_slug)).to.equal(`${component_name}.${service_name}`)
+    });
+    it(`account doesn't get included if it is the same as the current (tenancy)`, async () => {
+      expect(environmentRef(component_account_name, service_version_slug + '@tenant-1')).to.equal(`tenant-1--${component_name}.${service_name}`)
+    });
+    it(`account does get included if it isn't the same as the current`, async () => {
+      expect(environmentRef('examples', service_version_slug)).to.equal(`${component_account_name}.${component_name}.${service_name}`)
+    });
+    it(`account does get included if it isn't the same as the current (tenancy)`, async () => {
+      expect(environmentRef('examples', service_version_slug + '@tenant-1')).to.equal(`tenant-1--${component_account_name}.${component_name}.${service_name}`)
+    });
+  })
 });


### PR DESCRIPTION
### Overview
We want to create readable and unique resource names in an environment as opposed to using slugs.

### Changes
Added a method to generate an environment ref for a resource.

### Tests
https://github.com/architect-team/architect-cli/compare/environment-ref?expand=1#diff-6026c36270e58f1eefb39292afdf46b12618fd699aaf628c9fae70b8ed1ff6a0R104