### PR TITLE
Docker compose exec

### DIFF
--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -215,7 +215,7 @@ export default class Logs extends Command {
     // If no account is default to local first.
     if (!flags.account && flags.environment) {
       // If the env exists locally then just assume local
-      const is_local_env = DockerComposeUtils.isLocalEnvironment(this.app.config.getConfigDir(), flags.environment);
+      const is_local_env = await DockerComposeUtils.isLocalEnvironment(this.app.config.getConfigDir(), flags.environment);
       if (is_local_env) {
         return await this.runLocal();
       }

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -379,7 +379,6 @@ export class DockerComposeUtils {
   }
 
   public static async getLocalServiceForEnvironment(environment: string, compose_file: string, service_name?: string): Promise<string> {
-    console.log(compose_file);
     const cmd = await execa('docker-compose', ['-f', compose_file, '-p', environment, 'ps']);
     const lines = cmd.stdout.split('\n');
     //Remove the headers

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -1,5 +1,6 @@
 import execa, { Options } from 'execa';
 import fs from 'fs-extra';
+import inquirer from 'inquirer';
 import yaml from 'js-yaml';
 import os from 'os';
 import pLimit from 'p-limit';
@@ -15,6 +16,11 @@ import { Dictionary } from '../../dependency-manager/src/utils/dictionary';
 import LocalPaths from '../../paths';
 import PortUtil from '../utils/port';
 import DockerComposeTemplate, { DockerService, DockerServiceBuild } from './template';
+
+class LocalService {
+  display_name!: string;
+  service_name!: string;
+}
 
 export class DockerComposeUtils {
 
@@ -341,6 +347,75 @@ export class DockerComposeUtils {
       }
       throw err;
     }
+  }
+
+  public static async getLocalEnvironments(config_dir: string): Promise<string[]> {
+    const search_directory = path.join(config_dir, LocalPaths.LOCAL_DEPLOY_PATH);
+    const files = await fs.readdir(path.join(search_directory));
+    return files.map((file) => file.split('.')[0]);
+  }
+
+  public static async isLocalEnvironment(config_dir: string, environment_name: string): Promise<boolean> {
+    const local_enviromments = await DockerComposeUtils.getLocalEnvironments(config_dir);
+    return !!(local_enviromments.find(env => env == environment_name));
+  }
+
+  public static async getLocalEnvironment(config_dir: string, environment_name?: string): Promise<string> {
+    const search_directory = path.join(config_dir, LocalPaths.LOCAL_DEPLOY_PATH);
+    const files = await fs.readdir(path.join(search_directory));
+    const local_enviromments = files.map((file) => file.split('.')[0]);
+    const answers: any = await inquirer.prompt([
+      {
+        when: !environment_name,
+        type: 'autocomplete',
+        name: 'environment',
+        message: 'Select a environment',
+        source: async () => {
+          return local_enviromments;
+        },
+      },
+    ]);
+    return environment_name || answers.environment;
+  }
+
+  public static async getLocalServiceForEnvironment(environment: string, compose_file: string, service_name?: string): Promise<string> {
+    console.log(compose_file);
+    const cmd = await execa('docker-compose', ['-f', compose_file, '-p', environment, 'ps']);
+    const lines = cmd.stdout.split('\n');
+    //Remove the headers
+    lines.shift();
+    lines.shift();
+    const services = lines.map(line => {
+      let name = line.split(' ')[0];
+      // Remove env name and counter: cloud_gateway_1
+      name = name.substr(name.indexOf('_') + 1);
+      name = name.substr(0, name.lastIndexOf('_'));
+      const service = new LocalService();
+      // Remove the slug for the display name
+      service.display_name = name.substr(0, name.lastIndexOf('-'));
+      service.service_name = name;
+      return service;
+    }).filter((service) => {
+      // Our services do not have a slug attached and have an empty display name at this point
+      return service.display_name;
+    });
+    const answers: any = await inquirer.prompt([
+      {
+        when: !service_name,
+        type: 'autocomplete',
+        name: 'service',
+        message: 'Select a service',
+        source: async () => {
+          return services.map(service => service.display_name);
+        },
+      },
+    ]);
+    const display_service_name = service_name || answers.service;
+    const full_service_name = services.find((service) => service.display_name == display_service_name)?.service_name;
+    if (!full_service_name) {
+      throw new Error(`Could not find service=${display_service_name}`);
+    }
+    return full_service_name;
   }
 
   public static async run(service_name: string, project_name: string, compose_file?: string): Promise<void> {


### PR DESCRIPTION
## Overview
The current version of our exec command only works on remote platforms. This adds the ability for a user to run the exec command locally as well.

NOTE: This diff relies on the Logs PR, but I do not see a way to base them on top of each other in Github.

## Changes
1. Modified the account/env selection flow to mirror the logs command.
2. Modified the current run method for exec to be runRemote
3. Created the runLocal method which mimics the functionality of remote.

## Testing
1. Create a remote platform env using ```architect deploy```
2. Create a local deploy using ```architect dev```
3. Run ```architect exec ls``` and select ```dev (local account)```
4. Select through to a service and see the list of files on the system.
5. Run ```architect exec ls``` and select any other account
6. Select through to a service and see the list of files on the system.
7. Perform the same steps above but instead of ```ls``` run ```sh``` to run an interactive shell.