### PR TITLE
Remove compose file on end of dev command.

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -234,6 +234,7 @@ export default class Dev extends DevCommand {
       this.log('Gracefully shutting down...');
       execa.sync('docker-compose', ['-f', compose_file, '-p', project_name, 'stop', '--timeout', '0'], { stdio: 'inherit' });
       this.log('Stopping operation...');
+      fs.removeSync(compose_file);
       process.exit(0);
     });
 


### PR DESCRIPTION
## Overview
Both the logs and exec command rely on our config folder to act as a source of truth about active environments. In order for that to remain true we need that folder to only have active environments. This code cleans up docker compose files after a dev command has completed to keep the source of truth valid.

## Changes
Remove the docker compose file once the docker containers have been cleaned up.

## Testing
1. Run ```architect dev``` and create an env called cloud
2. Note the file ```~/.config/architect/architect/docker-compose/cloud.yml``` exists
3. Terminate the ```architect dev``` command
4. Not the file ```~/.config/architect/architect/docker-compose/cloud.yml``` does not exists