### PR TITLE
Fixed log command not working.

### DIFF
--- a/src/architect/account/account.utils.ts
+++ b/src/architect/account/account.utils.ts
@@ -37,7 +37,7 @@ export default class AccountUtils {
       console.log(chalk.blue(`Using account from environment variables: `) + account_name);
     }
 
-    if (!account_name) {
+    if (!account_name && !ask_local_account) {
       const { data: user_data } = await app.api.get('/users/me');
       if (user_data.memberships?.length === 1) { // if user only has one account, use it by default
         return user_data.memberships[0].account;

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -389,8 +389,8 @@ export class DockerComposeUtils {
       const line_parts = line.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
       let name = line_parts[0];
       // Remove env name and counter: cloud_gateway_1
-      name = name.substring(name.indexOf('_') + 1);
-      name = name.substring(0, name.lastIndexOf('_'));
+      name = name.substring(name.indexOf('-') + 1);
+      name = name.substring(0, name.lastIndexOf('-'));
       const service = new LocalService();
       // Remove the slug for the display name and add the status of the service
       const slugless_name = name.substring(0, name.lastIndexOf('-'));


### PR DESCRIPTION
## Overview
I found 2 bugs when testing the log command locally.
1. If the user only has one account they will never be able to select a local account.
2. The name format has been changed for locally running containers. This fixes the parser.

## Changes
1. Add a check that if we allow local accounts we bypass the 1 account quick auto select check.
2. Modified the delimiters for the parsing of the service name.

## Testing
run ```npm run test```
1. Run ```architect logs```
2. Select a local account
3. Select the local environemnt.
4. Notice services are there.
5. Select a service
6. Notice logs work
7. Run ```architect logs```
8. Select a remote account
9. Select a remote environment.
10. Select a remote service
11. Notice logs work

NOTE:
Due to our name changes we could really use a library that both generates and parses names. This module could be used on all our services. Dependency-manager could be a good place for this to live.
