### PR TITLE
Fix issue where passing the service name in does not work

### DIFF
--- a/src/architect/account/account.utils.ts
+++ b/src/architect/account/account.utils.ts
@@ -64,8 +64,7 @@ export default class AccountUtils {
           filter: (x) => x, // api filters
           source: async (answers_so_far: any, input: string) => {
             const { data } = await app.api.get('/accounts', { params: { q: input, limit: 10 } });
-            accounts = accounts.concat(data.rows);
-            return accounts;
+            return accounts.concat(data.rows);
           },
         },
       ]);

--- a/src/architect/account/account.utils.ts
+++ b/src/architect/account/account.utils.ts
@@ -52,7 +52,7 @@ export default class AccountUtils {
       }
     } else {
       inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'));
-      let accounts: Account[] = [];
+      const accounts: Account[] = [];
       if (ask_local_account) {
         accounts.push(this.getLocalAccount());
       }

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -213,7 +213,6 @@ export default class Exec extends Command {
 
   async runLocal(): Promise<void> {
     const { args, flags } = await this.parse(Exec);
-    console.log(args);
 
     const environment_name = await DockerComposeUtils.getLocalEnvironment(this.app.config.getConfigDir(), flags.environment);
     const compose_file = DockerComposeUtils.buildComposeFilepath(this.app.config.getConfigDir(), environment_name);

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -201,7 +201,7 @@ export default class Logs extends Command {
             timeout: 1000 * 60 * 60 * 24, // one day
           });
           log_stream = stream;
-        } catch(err) {
+        } catch (err) {
           this.error(chalk.red(`Couldn't get logs from pod ${replica.ext_ref}. Check that the pod is in a steady state.`));
         }
 

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -18,6 +18,7 @@ import PortUtil from '../utils/port';
 import DockerComposeTemplate, { DockerService, DockerServiceBuild } from './template';
 
 class LocalService {
+  slugless_name!: string;
   display_name!: string;
   service_name!: string;
 }
@@ -381,22 +382,20 @@ export class DockerComposeUtils {
   public static async getLocalServiceForEnvironment(environment: string, compose_file: string, service_name?: string): Promise<string> {
     const cmd = await execa('docker-compose', ['-f', compose_file, '-p', environment, 'ps']);
     const lines = cmd.stdout.split('\n');
-    //Remove the headers
-    lines.shift();
-    lines.shift();
     const services = lines.map(line => {
       // Split the line by space but not if the space is in double qoutes
       const line_parts = line.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
       let name = line_parts[0];
       // Remove env name and counter: cloud_gateway_1
-      name = name.substring(name.indexOf('_') + 1);
-      name = name.substring(0, name.lastIndexOf('_'));
+      name = name.substring(environment.length + 1);
+      name = name.substring(0, Math.max(name.lastIndexOf('-'), name.lastIndexOf('_')));
       const service = new LocalService();
       // Remove the slug for the display name and add the status of the service
       const slugless_name = name.substring(0, name.lastIndexOf('-'));
       if (!slugless_name) {
         return service;
       }
+      service.slugless_name = slugless_name;
       service.display_name = slugless_name + ` (${line_parts[3].toUpperCase()})`;
       service.service_name = name;
       return service;
@@ -415,10 +414,10 @@ export class DockerComposeUtils {
         },
       },
     ]);
-    const display_service_name = service_name || answers.service;
-    const full_service_name = services.find((service) => service.display_name == display_service_name)?.service_name;
+    const selected_service_name = service_name || answers.service;
+    const full_service_name = services.find((service) => service.display_name === selected_service_name || service.slugless_name === selected_service_name)?.service_name;
     if (!full_service_name) {
-      throw new Error(`Could not find service=${display_service_name}`);
+      throw new Error(`Could not find service=${selected_service_name}`);
     }
     return full_service_name;
   }


### PR DESCRIPTION
This fixes 2 issues.
1) When an service is passed in it will never be found.
2) Made the commands more versatile with docker compose versions.

## Test
```
architect-local exec -it -e cloud cloud-api -- sh
architect-local exec -it -e cloud -- sh
architect-local exec -it -- sh
```