### PR TITLE
Update Readme to Oclif 2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,13 +56,14 @@ jobs:
           node-version: '16'
       - run: npm install
       - run: npm run build
-      - name: Set NPM version
+      - name: Set NPM version and update README
         id: npm-version-bump
         run: |
           echo "::set-output name=version::$(npm version ${GITHUB_REF/refs\/tags\//} --git-tag-version=false --allow-same-version)"
           git config --global user.name "Github Actions"
           git config --global user.email "bot@architect.io"
-          git add package.json package-lock.json
+          npm run readme
+          git add package.json package-lock.json README.me
           git commit -m "Published CLI ${GITHUB_REF/refs\/tags\//}"
           git push "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
       - run: npm run pack

--- a/bin/readme
+++ b/bin/readme
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+require('reflect-metadata')
+const ReadmeCommand = require('oclif/lib/commands/readme')
+ReadmeCommand.default.run()

--- a/bin/readme.cmd
+++ b/bin/readme.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+node "%~dp0\readme" %*

--- a/package.json
+++ b/package.json
@@ -136,7 +136,8 @@
     "copy-static": "copyfiles -u 1 \"src/static/*.html\" lib",
     "coverage": "nyc --extension .ts npm test",
     "test": "rm -rf src/dependency-manager/node_modules && mocha --forbid-only \"test/**/*.test.ts\" --config ./test/.mocharc.yml",
-    "pack": "oclif pack:tarballs"
+    "pack": "oclif pack:tarballs",
+    "readme": "./bin/readme"
   },
   "types": "lib/index.d.ts"
 }

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -24,7 +24,7 @@ export default class Logs extends Command {
       default: false,
     }),
     since: Flags.string({
-      description: 'Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used. Only works on remote deploys.',
+      description: 'Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.',
       default: '',
     }),
     raw: Flags.boolean({


### PR DESCRIPTION
## Overview
When changes were made to migrate to Oclif 2 our readme was not being updated properly. This PR fixes those issues and auto generates the readme everytime we publish a new version.

## Changes
1) Added a new bin file called readme. This setups everything we need to call the oclif readme command.
2) Modified the publish workflow to update the readme when we update the version.

The new format has quite a few differences, but overall I think it is actually easier to read. User experience should not be impacted in any meaningful way.

## Testing
```
npm run readme
```
Example file of the new output. https://gist.github.com/mueschm/0d51abfc5a788376c1a1962afa41a527