### PR TITLE
Moved website update hook to cli publish.

### DIFF
--- a/.github/workflows/cli-rc.yml
+++ b/.github/workflows/cli-rc.yml
@@ -89,5 +89,3 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_PUBLISH_TOKEN }}" > .npmrc
           npm publish --tag ${PRERELEASE_PREFIX}
-      - name: docs website re-build
-        run: curl -X POST ${{ secrets.NETLIFY_BUILD_HOOK_URL }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,8 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_PUBLISH_TOKEN }}" > .npmrc
           npm publish
+      - name: docs website re-build
+        run: curl -X POST ${{ secrets.NETLIFY_BUILD_HOOK_URL }}
   attach_binaries_to_release:
     name: Attach CLI binaries to the release
     runs-on: ubuntu-latest


### PR DESCRIPTION
The hook to update the website was being done when an rc was generated. This changes it so that it is done when we publish a new version of the CLI.