### PR TITLE
Draft: Allow user to run exec without being logged in

### DIFF
--- a/src/architect/account/account.utils.ts
+++ b/src/architect/account/account.utils.ts
@@ -47,7 +47,7 @@ export default class AccountUtils {
     // Checks if the user is logged in; If not logged in, default to LocalAccount
     const token_json = await app.auth.getPersistedTokenJSON();
     if (!token_json || token_json.email === 'unknown') {
-      console.log(chalk.yellow('Warning - Login to access remote accounts'));
+      console.log(chalk.yellow('In order to access remote accounts you can login by running `architect login`'));
       let account: Account;
       const answers: { account: Account } = await inquirer.prompt([
         {

--- a/src/architect/account/account.utils.ts
+++ b/src/architect/account/account.utils.ts
@@ -44,6 +44,23 @@ export default class AccountUtils {
       }
     }
 
+    // Checks if the user is logged in; If not logged in, default to LocalAccount
+    const token_json = await app.auth.getPersistedTokenJSON();
+    if (!token_json || token_json.email === 'unknown') {
+      console.log(chalk.yellow('Warning - Login to access remote accounts'));
+      let account: Account;
+      const answers: { account: Account } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'account',
+          message: options?.account_message || 'Select an account',
+          choices: [this.getLocalAccount()],
+        },
+      ]);
+
+      return this.getLocalAccount();
+    }
+
     let account: Account;
     if (account_name) {
       account = (await app.api.get(`/accounts/${account_name}`)).data;

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -10,6 +10,10 @@ import { DockerComposeUtils } from '../common/docker-compose';
 import { ArchitectError, Dictionary, parseUnknownSlug } from '../dependency-manager/src';
 
 export default class Exec extends Command {
+  async auth_required(): Promise<boolean> {
+    return false;
+  }
+
   static description = 'Exec into service instances';
   static usage = 'exec [RESOURCE] [FLAGS] -- [COMMAND]';
 

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -12,6 +12,10 @@ import { DockerComposeUtils } from '../common/docker-compose';
 import { ArchitectError, parseUnknownSlug, ResourceSlugUtils } from '../dependency-manager/src';
 
 export default class Logs extends Command {
+  async auth_required(): Promise<boolean> {
+    return false;
+  }
+
   static description = 'Get logs from services both locally and remote';
 
   static flags = {


### PR DESCRIPTION
Allows users to access their locally run instances without logging in

Added the following changes:
* exec and logs function:
- set auth_required() to false to allow use when not logged in

*account.utils
- Updated getAccount() to check if the user is logged in
	- if not logged in, warn user and default to local account