### PR TITLE
Add restart for local services based on exit status or health

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -207,7 +207,9 @@ export default class Dev extends BaseCommand {
       compose_args.push('-d');
     }
 
-    await DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit', env: { COMPOSE_IGNORE_ORPHANS: 'true' } });
+    const dockerComposeRunnable = DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit', env: { COMPOSE_IGNORE_ORPHANS: 'true' } });
+    await DockerComposeUtils.watchContainersHealth(compose_file, project_name);
+    await dockerComposeRunnable;
     fs.removeSync(compose_file);
   }
 

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -211,8 +211,7 @@ export default class Dev extends BaseCommand {
     try {
       await DockerComposeUtils.watchContainersHealth(compose_file, project_name);
     } catch (err) {
-      docker_compose_runnable.kill();
-      throw err;
+      console.error(err);
     }
     await docker_compose_runnable;
     fs.removeSync(compose_file);

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -207,9 +207,14 @@ export default class Dev extends BaseCommand {
       compose_args.push('-d');
     }
 
-    const dockerComposeRunnable = DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit', env: { COMPOSE_IGNORE_ORPHANS: 'true' } });
-    await DockerComposeUtils.watchContainersHealth(compose_file, project_name);
-    await dockerComposeRunnable;
+    const docker_compose_runnable = DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit', env: { COMPOSE_IGNORE_ORPHANS: 'true' } });
+    try {
+      await DockerComposeUtils.watchContainersHealth(compose_file, project_name);
+    } catch (err) {
+      docker_compose_runnable.kill();
+      throw err;
+    }
+    await docker_compose_runnable;
     fs.removeSync(compose_file);
   }
 

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -208,11 +208,7 @@ export default class Dev extends BaseCommand {
     }
 
     const docker_compose_runnable = DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit', env: { COMPOSE_IGNORE_ORPHANS: 'true' } });
-    try {
-      DockerComposeUtils.watchContainersHealth(compose_file, project_name);
-    } catch (err) {
-      console.error(err);
-    }
+    DockerComposeUtils.watchContainersHealth(compose_file, project_name);
     await docker_compose_runnable;
     fs.removeSync(compose_file);
   }

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -209,7 +209,7 @@ export default class Dev extends BaseCommand {
 
     const docker_compose_runnable = DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit', env: { COMPOSE_IGNORE_ORPHANS: 'true' } });
     try {
-      await DockerComposeUtils.watchContainersHealth(compose_file, project_name);
+      DockerComposeUtils.watchContainersHealth(compose_file, project_name);
     } catch (err) {
       console.error(err);
     }

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -447,7 +447,7 @@ export class DockerComposeUtils {
     await fs.writeFile(compose_file, compose);
   }
 
-  public static async watchContainersHealth(compose_file: string, environment_name: string) {
+  public static async watchContainersHealth(compose_file: string, environment_name: string): Promise<void> {
     const max_restarts = 3;
     const reset_timer = 60000;
     let continueToRun = true;
@@ -494,7 +494,7 @@ export class DockerComposeUtils {
     return {
       stop: () => {
         continueToRun = false;
-      }
+      },
     };
   }
 }

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -519,6 +519,12 @@ export class DockerComposeUtils {
           console.log(chalk.red(`ERROR: ${service_ref} has encountered an error and is being restarted.`));
           console.log(chalk.red(`Retry attempt ${service_data.restarts} of ${max_restarts}`));
           await restart(id);
+          // Docker compose will stop watching when there is a single container and it goes down.
+          // If all containers go down at the same time it will wait for the restart and just move on. So only need this
+          // for the case of 1 container with a health check.
+          if (container_states.length == 1) {
+            DockerComposeUtils.dockerCompose(['-f', compose_file, '-p', environment_name, 'logs', full_service_name, '--follow', '--since', new Date(service_data.last_restart_ms).toISOString()], { stdout: 'inherit' });
+          }
         }
       }
     }

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -519,7 +519,6 @@ export class DockerComposeUtils {
           console.log(chalk.red(`ERROR: ${service_ref} has encountered an error and is being restarted.`));
           console.log(chalk.red(`Retry attempt ${service_data.restarts} of ${max_restarts}`));
           await restart(id);
-          DockerComposeUtils.dockerCompose(['-f', compose_file, '-p', environment_name, 'logs', full_service_name, '--follow', '--since', new Date(service_data.last_restart_ms).toISOString()], { stdout: 'inherit' });
         }
       }
     }

--- a/src/common/utils/docker.ts
+++ b/src/common/utils/docker.ts
@@ -35,6 +35,10 @@ export const getDigest = async (image_ref: string): Promise<string> => {
   return digest.stdout.split('@')[1].replace('\'', '');
 };
 
+export const restart = async (container_id: string): Promise<void> => {
+  return docker(['restart', container_id]);
+}
+
 /**
  * this method splits the tag off of an image string. this logic is not straightforward as the image string may contain a port.
  *

--- a/src/common/utils/docker.ts
+++ b/src/common/utils/docker.ts
@@ -37,7 +37,7 @@ export const getDigest = async (image_ref: string): Promise<string> => {
 
 export const restart = async (container_id: string): Promise<void> => {
   return docker(['restart', container_id]);
-}
+};
 
 /**
  * this method splits the tag off of an image string. this logic is not straightforward as the image string may contain a port.


### PR DESCRIPTION
## Problem
On a remote deployment, kubernetes will restart  a service if there are issues with its health checks or if the container fails to start. Locally this does not happen. If a container fails to start then it just crashes. Health checks are generally ignored. The goal is to bring local deployments into parity with remote deployments.

## Changes
1) Add a new function in the CLI that monitors each running service and checks their health and running state.
2) If a service fails we restart it and reattach the logging for it.
3) If the service becomes unhealthy we 

## Testing
I created a sample app called Health that is as follows.
```
const express = require('express')
const app = express()
const port = process.env.PORT;

let stopService = false;

console.log(port.toString());

let pingCount = 0;

app.get('/ping', (req, res) => {
  pingCount++;
  console.log("PING" + pingCount);
  res.send("PONG");
  if (pingCount == 3) {
    stopService = true;
  }
})

app.get('/', (req, res) => {
  console.log("ROOT");
  res.send('Hello World!')
})

const server = app.listen(port, () => {
  console.log(`Example app listening on port ${port}`)
})


const main = async () => {
  while (!stopService) {
    await new Promise(r => setTimeout(r, 1000));
  }
  console.log("CLOSING APP 2");
  // The server is closed but the app is still running
  // Service is not healthy
  server.close();

  // Close the app after 10 seconds so the app is exited
  await new Promise(r => setTimeout(r, 10000000));
}

main();

```
architect.yml
```
name: health

services:
  health:
    build:
      context: .
    interfaces:
      main: &api-port 8081
    liveness_probe:
      path: /ping
      port: *api-port
      interval: 10s
      failure_threshold: 3
    environment:
      PORT: *api-port
```
Dockerfile
```
FROM node:16

WORKDIR /usr/src/app

COPY package*.json ./

RUN npm install

COPY . .

CMD [ "node", "index.js" ]
```

## Edge Cases
When a container is restarted or brought back online docker compose removes it from the log monitoring. It will only restart the logs if the container had a restart policy it could handle itself. This requires us to add the logs back by calling docker compose logs.

## Restart on Unhealthy
The liveness_probe is used to determine if a service is unhealthy. We essentially have two options for how to handle this.
1) Restart directly when a service becomes unhealthy
2) Wait for multiple checks of unhealthy before restarting
Based on the amount of time kubernetes takes to restart a service it seemed like number 2 was the best parity for remote deployments. So that is what I added.

## Pictures
![image](https://user-images.githubusercontent.com/532523/161774746-82973796-bb30-4d65-ae8b-ccecde232d15.png)
