### PR TITLE
Multiple secret files

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -109,6 +109,8 @@ export default class Deploy extends DeployCommand {
     }),
     'secret-file': Flags.string({
       description: 'Path of secrets file',
+      multiple: true,
+      default: [],
     }),
     secret: Flags.string({
       char: 's',
@@ -171,19 +173,14 @@ export default class Deploy extends DeployCommand {
   }
 
   protected async runRemote(): Promise<void> {
-    const { args, flags, raw } = await this.parse(Deploy);
+    const { args, flags } = await this.parse(Deploy);
 
     const components = args.configs_or_components;
 
-    // Ensure we capture all secret-files provided
-    const all_secret_files = DeployUtils.getAllSecretFiles(raw);
-
     const interfaces_map = DeployUtils.getInterfacesMap(flags.interface);
-    const component_secrets = DeployUtils.getComponentSecrets(flags.secret, all_secret_files);
-    const component_parameters = DeployUtils.getComponentSecrets(flags.parameter, all_secret_files); // TODO: 404: remove
+    const component_secrets = DeployUtils.getComponentSecrets(flags.secret, flags['secret-file']);
+    const component_parameters = DeployUtils.getComponentSecrets(flags.parameter, flags['secret-file']); // TODO: 404: remove
     const all_secrets = { ...component_parameters, ...component_secrets }; // TODO: 404: remove
-
-    console.log(all_secrets);
 
     const account = await AccountUtils.getAccount(this.app, flags.account);
     const environment = await EnvironmentUtils.getEnvironment(this.app.api, account, flags.environment);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -171,14 +171,19 @@ export default class Deploy extends DeployCommand {
   }
 
   protected async runRemote(): Promise<void> {
-    const { args, flags } = await this.parse(Deploy);
+    const { args, flags, raw } = await this.parse(Deploy);
 
     const components = args.configs_or_components;
 
+    // Ensure we capture all secret-files provided
+    const all_secret_files = DeployUtils.getAllSecretFiles(raw);
+
     const interfaces_map = DeployUtils.getInterfacesMap(flags.interface);
-    const component_secrets = DeployUtils.getComponentSecrets(flags.secret, flags['secret-file']);
-    const component_parameters = DeployUtils.getComponentSecrets(flags.parameter, flags['secret-file']); // TODO: 404: remove
+    const component_secrets = DeployUtils.getComponentSecrets(flags.secret, all_secret_files);
+    const component_parameters = DeployUtils.getComponentSecrets(flags.parameter, all_secret_files); // TODO: 404: remove
     const all_secrets = { ...component_parameters, ...component_secrets }; // TODO: 404: remove
+
+    console.log(all_secrets);
 
     const account = await AccountUtils.getAccount(this.app, flags.account);
     const environment = await EnvironmentUtils.getEnvironment(this.app.api, account, flags.environment);

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -216,16 +216,19 @@ export default class Dev extends BaseCommand {
   }
 
   private async runLocal() {
-    const { args, flags } = await this.parse(Dev);
+    const { args, flags, raw } = await this.parse(Dev);
     await Docker.verify();
 
     if (!args.configs_or_components || !args.configs_or_components.length) {
       args.configs_or_components = ['./architect.yml'];
     }
 
+    // Ensure we capture all secret-files provided
+    const all_secret_files = DeployUtils.getAllSecretFiles(raw);
+
     const interfaces_map = DeployUtils.getInterfacesMap(flags.interface);
-    const component_secrets = DeployUtils.getComponentSecrets(flags.secret, flags['secret-file']);
-    const component_parameters = DeployUtils.getComponentSecrets(flags.parameter, flags['secret-file']);
+    const component_secrets = DeployUtils.getComponentSecrets(flags.secret, all_secret_files);
+    const component_parameters = DeployUtils.getComponentSecrets(flags.parameter, all_secret_files);
 
     const linked_components = this.app.linkedComponents;
     const component_versions: string[] = [];

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -47,6 +47,8 @@ export default class Dev extends BaseCommand {
     }),
     'secret-file': Flags.string({
       description: 'Path of secrets file',
+      multiple: true,
+      default: [],
     }),
     secret: Flags.string({
       char: 's',
@@ -216,19 +218,16 @@ export default class Dev extends BaseCommand {
   }
 
   private async runLocal() {
-    const { args, flags, raw } = await this.parse(Dev);
+    const { args, flags } = await this.parse(Dev);
     await Docker.verify();
 
     if (!args.configs_or_components || !args.configs_or_components.length) {
       args.configs_or_components = ['./architect.yml'];
     }
 
-    // Ensure we capture all secret-files provided
-    const all_secret_files = DeployUtils.getAllSecretFiles(raw);
-
     const interfaces_map = DeployUtils.getInterfacesMap(flags.interface);
-    const component_secrets = DeployUtils.getComponentSecrets(flags.secret, all_secret_files);
-    const component_parameters = DeployUtils.getComponentSecrets(flags.parameter, all_secret_files);
+    const component_secrets = DeployUtils.getComponentSecrets(flags.secret, flags['secret-file']);
+    const component_parameters = DeployUtils.getComponentSecrets(flags.parameter, flags['secret-file']);
 
     const linked_components = this.app.linkedComponents;
     const component_versions: string[] = [];

--- a/src/common/utils/deploy.utils.ts
+++ b/src/common/utils/deploy.utils.ts
@@ -59,28 +59,14 @@ export default class DeployUtils {
     return flags;
   }
 
-  static getAllSecretFiles(raw_argv: any): string[] {
-    const all_secret_files = [];
-    for (const raw_flag of raw_argv) {
-      if (raw_flag.type === 'flag' && (raw_flag.flag === 'secret-file' || raw_flag.flag === 'values')) {
-        all_secret_files.push(raw_flag.input);
-      }
-    }
-    return all_secret_files;
-  }
-
-  static getComponentSecrets(individual_secrets: string[], secrets_file?: string | string[]): Dictionary<Dictionary<string | number | null>> {
+  static getComponentSecrets(individual_secrets: string[], secrets_file: string | string[]): Dictionary<Dictionary<string | number | null>> {
     // Check to see if there are multiple secret files; else, just read the single secret file
     let component_secrets: any = {};
-    if (Array.isArray(secrets_file)) {
-      for (const secret_file of secrets_file) {
-        const output_catch = DeployUtils.readSecretsFile(secret_file);
-        // Deep merge to ensure all values from files are captured
-        // By default, the last file in the array will always supersede any other values
-        component_secrets = _.merge(component_secrets,output_catch);
-      }
-    } else {
-      component_secrets = DeployUtils.readSecretsFile(secrets_file);
+    for (const secret_file of secrets_file) {
+      const output_catch = DeployUtils.readSecretsFile(secret_file);
+      // Deep merge to ensure all values from files are captured
+      // By default, the last file in the array will always supersede any other values
+       component_secrets = _.merge(component_secrets,output_catch);
     }
 
     const extra_secrets = DeployUtils.getExtraSecrets(individual_secrets);

--- a/src/common/utils/deploy.utils.ts
+++ b/src/common/utils/deploy.utils.ts
@@ -59,7 +59,7 @@ export default class DeployUtils {
     return flags;
   }
 
-  static getComponentSecrets(individual_secrets: string[], secrets_file: string | string[]): Dictionary<Dictionary<string | number | null>> {
+  static getComponentSecrets(individual_secrets: string[], secrets_file: string[]): Dictionary<Dictionary<string | number | null>> {
     // Check to see if there are multiple secret files; else, just read the single secret file
     let component_secrets: any = {};
     for (const secret_file of secrets_file) {

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -360,4 +360,43 @@ describe('deployment secrets', function () {
     .it('passing a secrets file with the deprecated values flag', ctx => {
       expect((Deploy.prototype.approvePipeline as SinonSpy).getCalls().length).to.equal(1);
     });
+
+
+  const raw_argv = [
+    { type: 'arg', input: '80' },
+    { type: 'arg', input: 'free=bird' },
+    { type: 'flag', flag: 'secret-file', input: 'secrets.yml' },
+    { type: 'flag', flag: 'secret-file', input: 'test-secrets.yml' },
+    { type: 'arg', input: '--port' },
+    { type: 'flag', flag: 'secret', input: 'ah=ha' }
+  ];
+  // testing multiple secret files
+  mockArchitectAuth // TODO: 254: Remove
+    .stub(Docker, 'verify', sinon.stub().returns(Promise.resolve()))
+    .stub(Deploy.prototype, 'warn', sinon.fake.returns(null))
+    .stub(Deploy.prototype, 'approvePipeline', sinon.stub().returns(Promise.resolve()))
+    .stub(DeployUtils, 'readSecretsFile', () => {
+        return wildcard_secrets;
+      })
+    .nock(MOCK_API_HOST, api => api
+      .get(`/accounts/${account.name}`)
+      .reply(200, account))
+    .nock(MOCK_API_HOST, api => api
+      .get(`/accounts/${account.id}/environments/${environment.name}`)
+      .reply(200, environment))
+    .nock(MOCK_API_HOST, api => api
+      .post(`/environments/${environment.id}/deploy`, (body) => {
+        expect(body.values['*'].another_required_key).to.eq('required_value');
+        expect(body.values['echo'].a_required_key).to.eq('some_value');
+        expect(body.values['echo'].api_port).to.eq(3000);
+        expect(body.values['echo'].one_more_required_secret).to.eq('one_more_value');
+        return body;
+      })
+      .reply(200, mock_pipeline))
+    .stdout({ print })
+    .stderr({ print })
+    .command(['deploy', '-e', environment.name, '-a', account.name, 'examples/echo:latest', '--secret-file', './examples/echo/secrets.yml', '--secret-file', './examples/echo/secrets2.yml'])
+    .it('properly intakes both files', ctx => {
+      expect(DeployUtils.getAllSecretFiles(raw_argv).length).to.equal(2);
+    })
 });


### PR DESCRIPTION
Extend Deploy.utils to allow multiple secret-files to be ingested

The last file provided will always upsert any existing secrets, and any secrets passed via CLI will upsert all secret-files in the '*' key.

**Testing:**
With two secret files, you can run:
$ architect deploy --secret-file secrets1.yml --secret-file secrets2.yml
OR
$ architect deploy --secret-file secrets1.yml secrets2.yml
OR
$ architect deploy --secret-file secrets1.yml --secret-file secrets2.yml -s secret_key=secret_value