### PR TITLE
Disable changelog for non main builds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,7 @@
-## [1.15.1-rc.5](https://github.com/architect-team/architect-cli/compare/v1.15.1-rc.4...v1.15.1-rc.5) (2022-04-12)
+## [1.15.2](https://github.com/architect-team/architect-cli/compare/v1.15.1...v1.15.2) (2022-04-12)
 
 
 ### Bug Fixes
 
+* **register:** ignore conditional services for register and validate docker-compose ([af2b02b](https://github.com/architect-team/architect-cli/commit/af2b02bf1488409ddf260a659619b6e1b3d330ec))
 * **register:** ignore conditional services for register and validate docker-compose ([87e44f9](https://github.com/architect-team/architect-cli/commit/87e44f9b3153de5514c0f783ce9115737c0d6c82))
-
-## [1.15.1-rc.4](https://github.com/architect-team/architect-cli/compare/v1.15.1-rc.3...v1.15.1-rc.4) (2022-04-10)
-
-
-### Bug Fixes
-
-* **register:** issue with host overrides ([e21be62](https://github.com/architect-team/architect-cli/commit/e21be626d9cde7560ec81aa4dcbd69a54103b326))
-
-## [1.15.1-rc.3](https://github.com/architect-team/architect-cli/compare/v1.15.1-rc.2...v1.15.1-rc.3) (2022-04-06)
-
-
-### Bug Fixes
-
-* Update package version for semantic release. ([f39b2c3](https://github.com/architect-team/architect-cli/commit/f39b2c385313757dececab951db5ffafc24e5424))
-
-## [1.15.1-rc.2](https://github.com/architect-team/architect-cli/compare/v1.15.1-rc.1...v1.15.1-rc.2) (2022-04-06)
-
-
-### Bug Fixes
-
-* Fix issue with semantic release npm token. ([ee7e324](https://github.com/architect-team/architect-cli/commit/ee7e324160d2eb3f6aead80d47a3de634fd9a5b5))
-
-## [1.15.1-rc.1](https://github.com/architect-team/architect-cli/compare/v1.15.0...v1.15.1-rc.1) (2022-04-06)
-
-
-### Bug Fixes
-
-* Switching over to semantic release ([e161469](https://github.com/architect-team/architect-cli/commit/e161469c9d2e32c851f6bd050c6a96866c123b9d))

--- a/release.config.js
+++ b/release.config.js
@@ -4,12 +4,6 @@ const plugins = [
   "@semantic-release/commit-analyzer",
   "@semantic-release/release-notes-generator",
   [
-    "@semantic-release/changelog",
-    {
-      "changelogFile": "CHANGELOG.md"
-    }
-  ],
-  [
     "@semantic-release/git",
     {
       "assets": [
@@ -38,6 +32,11 @@ const main_plugins = plugins.concat([[
         "label": "Architect-CLI ${nextRelease.version}"
       }
     ]
+  }
+], [
+  "@semantic-release/changelog",
+  {
+    "changelogFile": "CHANGELOG.md"
   }
 ]]);
 


### PR DESCRIPTION
1. Reverted the changelog to make sense based on what is in master.
2. Disable changelog generation for non main branches.