### PR TITLE
Remove orphaned containers on startup.

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -202,12 +202,12 @@ export default class Dev extends BaseCommand {
       }, poll_interval);
     }
 
-    const compose_args = ['-f', compose_file, '-p', project_name, 'up', '--renew-anon-volumes', '--timeout', '0'];
+    const compose_args = ['-f', compose_file, '-p', project_name, 'up', '--remove-orphans', '--renew-anon-volumes', '--timeout', '0'];
     if (flags.detached) {
       compose_args.push('-d');
     }
 
-    await DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit', env: { COMPOSE_IGNORE_ORPHANS: 'true' } });
+    await DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit' });
     fs.removeSync(compose_file);
   }
 


### PR DESCRIPTION
## Overview
Make sure that when `docker compose up` is run that orphaned containers are destroyed.

## Changes
1) Remove the env that ignored orphans
2) Add the parameter that removes orphans

## Test
Used my health test from https://github.com/architect-team/architect-cli/pull/550

Added a service called `health2` and ran that. Stopped it then removed the service from the yml file. Started it again and only one instance was running.