### PR TITLE
Better support exiting dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "matcher": "^4.0.0",
         "opener": "^1.5.2",
         "p-limit": "^3.1.0",
+        "readline": "^1.3.0",
         "reflect-metadata": "0.1.13",
         "semver": "^7.3.5",
         "shell-quote": "^1.7.2",
@@ -13552,6 +13553,11 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/readline": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+      "integrity": "sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw="
+    },
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -26849,6 +26855,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "readline": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+      "integrity": "sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw="
     },
     "rechoir": {
       "version": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "matcher": "^4.0.0",
     "opener": "^1.5.2",
     "p-limit": "^3.1.0",
+    "readline": "^1.3.0",
     "reflect-metadata": "0.1.13",
     "semver": "^7.3.5",
     "shell-quote": "^1.7.2",

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -5,6 +5,7 @@ import fs from 'fs-extra';
 import isCi from 'is-ci';
 import yaml from 'js-yaml';
 import opener from 'opener';
+import { Writable } from 'stream';
 import { buildSpecFromPath, ComponentSlugUtils, ComponentSpec, ComponentVersionSlugUtils } from '../';
 import AccountUtils from '../architect/account/account.utils';
 import { EnvironmentUtils } from '../architect/environment/environment.utils';
@@ -119,6 +120,23 @@ export default class Dev extends BaseCommand {
     return parsed;
   }
 
+  setupSigInt(callback: () => void) {
+    if (process.platform === "win32") {
+      var rl = require("readline").createInterface({
+        input: process.stdin,
+        output: process.stdout
+      });
+
+      rl.on("SIGINT", function () {
+        process.emit("SIGINT", "SIGINT");
+      });
+    }
+
+    process.on("SIGINT", function () {
+      callback();
+    });
+  }
+
   async runCompose(compose: DockerComposeTemplate): Promise<void> {
     const { flags } = await this.parse(Dev);
 
@@ -207,10 +225,67 @@ export default class Dev extends BaseCommand {
       compose_args.push('-d');
     }
 
-    const docker_compose_runnable = DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit' });
-    DockerComposeUtils.watchContainersHealth(compose_file, project_name);
-    await docker_compose_runnable;
+    let is_exiting = false;
+    this.setupSigInt(() => {
+      if (is_exiting) {
+        return;
+      }
+      is_exiting = true;
+      docker_compose_runnable.kill('SIGTERM');
+    });
+
+    const logger = new Writable();
+
+    logger._write = (chunk, _encoding, next) => {
+      chunk.toString().split('\n').filter((e: string) => e).forEach((line: string) => {
+        if (line.indexOf('Gracefully stopping...') !== -1) {
+          console.log(line);
+        } else {
+          console.log("\nGracefully stopping..... Please Wait.....");
+        }
+      });
+      next();
+    };
+
+    const docker_compose_runnable = DockerComposeUtils.dockerCompose(compose_args, { stdout: 'pipe', stdin: "ignore" });
+
+    // When docker compose is stopping it will tell the user to hit `ctrl-c` again
+    // to cancel. We disabled this functionality so also making the message more clear
+    const service_colors = new Map<string, chalk.Chalk>();
+    const rand = () => Math.floor(Math.random() * 255);
+    docker_compose_runnable.stdout?.on('data', (data) => {
+      for (const line of data.toString().split('\n')) {
+        if (line.indexOf('Gracefully stopping...') !== -1) {
+          console.log("\nGracefully stopping..... Please Wait.....");
+          return;
+        }
+        const lineParts = line.split('|');
+        if (lineParts.length > 1) {
+          const service: string = lineParts[0];
+          lineParts.shift();
+          const newLine = lineParts.join('|');
+
+          if (!service_colors.get(service)) {
+            service_colors.set(service, chalk.rgb(rand(), rand(), rand()))
+          }
+
+          const color = service_colors.get(service) as chalk.Chalk;
+
+          console.log(color(service + "\t| ") + newLine);
+        }
+      }
+    });
+    DockerComposeUtils.watchContainersHealth(compose_file, project_name, () => { return is_exiting; });
+
+    try {
+      await docker_compose_runnable;
+    } catch (ex) {
+      if (!is_exiting) {
+        throw ex;
+      }
+    }
     fs.removeSync(compose_file);
+    process.exit();
   }
 
   private async runLocal() {


### PR DESCRIPTION
## Overview
When a user hits ctrl-c multiple times it prevents `docker compose` from being able to clean up after itself. This will leave all the containers still running and just exit the `dev` command. This intercepts the exit signal and makes sure we can gracefully shutdown.

Originaly the plan was also to update `execa` to the latest version. We could have use dynamic imports to pull it in even though its not directly compatible with CommonJS. However I ran into a problem where we used the `Options` type from the import quite a bit. Since dynamic imports require an `await` there is no clean way to continually use this type without making a lot of code async when it does not need to be. The only other options were.
1) Create an abstraction around execa. We do not get really anything from this.
2) Copy all the types into our project so we can include `execa` async but have the types sync. This seemed like a really hacky work around.

Since the current version meets our needs I saw no reason to pursue either of these not great options.

## Changes
1) Intercept the `ctrl-c` command and stop the application from exiting.
2) When `ctrl-c` is pressed send the signal to shutdown `docker compose`
3) Fixed an issue where the healthcheck was now causing issues because containers had exited status even though they were left over from a previous run.
4) `docker compose up` will display a message telling users that they can hit `ctrl-c` again to force exit. We no longer allow this so I intercepted the text stream and override the message. This did lose us color support so had to hack something back in.

## Testing
You can run the react-app to see it working.
```
cd examples/react-app
architect-local dev .
````
![image](https://user-images.githubusercontent.com/532523/164988482-ba510c9d-2b4f-4dcf-b339-e30cc33dfa01.png)
