### PR TITLE
Changed order of plugins to fix git happening too soon.

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,31 +1,28 @@
 const { GIT_BRANCH: branch } = process.env;
 
-const plugins = [
-  "@semantic-release/commit-analyzer",
-  "@semantic-release/release-notes-generator",
-  [
-    "@semantic-release/git",
-    {
-      "assets": [
-        "CHANGELOG.md",
-        "README.md",
-        "package.json",
-        "package-lock.json",
-        "docs/5-reference/2-architect-yml.md",
-        "src/dependency-manager/schema/architect.schema.json",
-      ]
-    }
-  ],
-  [
-    "@semantic-release/exec",
-    {
-      "publishCmd": "npm run pack"
-    }
-  ],
-  "@semantic-release/npm"
+const commitAnalyzer = "@semantic-release/commit-analyzer";
+const releaseNotesGenerator = "@semantic-release/release-notes-generator";
+const git = [
+  "@semantic-release/git",
+  {
+    "assets": [
+      "CHANGELOG.md",
+      "README.md",
+      "package.json",
+      "package-lock.json",
+      "docs/5-reference/2-architect-yml.md",
+      "src/dependency-manager/schema/architect.schema.json",
+    ]
+  }
 ];
-
-const main_plugins = plugins.concat([[
+const exec = [
+  "@semantic-release/exec",
+  {
+    "publishCmd": "npm run pack"
+  }
+];
+const npm = "@semantic-release/npm";
+const github = [
   "@semantic-release/github",
   {
     "assets": [
@@ -35,12 +32,32 @@ const main_plugins = plugins.concat([[
       }
     ]
   }
-], [
+];
+const changelog = [
   "@semantic-release/changelog",
   {
     "changelogFile": "CHANGELOG.md"
   }
-]]);
+];
+
+
+const default_plugins = [
+  commitAnalyzer,
+  releaseNotesGenerator,
+  exec,
+  npm,
+  git
+]
+
+const main_plugins = [
+  commitAnalyzer,
+  releaseNotesGenerator,
+  changelog,
+  exec,
+  npm,
+  git,
+  github
+]
 
 module.exports = {
   "branches": [
@@ -54,5 +71,8 @@ module.exports = {
       "prerelease": true
     }
   ],
-  plugins: branch === 'main' ? main_plugins : plugins,
+  plugins: branch === 'main' ? main_plugins : default_plugins,
 };
+
+
+console.log(module.exports);


### PR DESCRIPTION
## Overview
After looking at the logs it looks like the git command is happening before some of the other commands. Since most commands occur at the same step and they seem to match the order they were put in the config file, I am changing that order. This should fix it.

## Changes
1. Update order of the plugins for semantic release.
2. Log the order to make it easier to debug in the future.

## Testing
`node release.config.js`
```
{
  branches: [
    'main',
    { name: 'rc', prerelease: true },
    { name: 'arc-*', prerelease: true }
  ],
  plugins: [
    '@semantic-release/commit-analyzer',
    '@semantic-release/release-notes-generator',
    [ '@semantic-release/exec', [Object] ],
    '@semantic-release/npm',
    [ '@semantic-release/git', [Object] ]
  ]
}
```

`GIT_BRANCH=main node release.config.js`
```
{
  branches: [
    'main',
    { name: 'rc', prerelease: true },
    { name: 'arc-*', prerelease: true }
  ],
  plugins: [
    '@semantic-release/commit-analyzer',
    '@semantic-release/release-notes-generator',
    [ '@semantic-release/changelog', [Object] ],
    [ '@semantic-release/exec', [Object] ],
    '@semantic-release/npm',
    [ '@semantic-release/git', [Object] ],
    [ '@semantic-release/github', [Object] ]
  ]
}
```