### PR TITLE
Ensure that image names are preserved when a reserved name is used

### DIFF
--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -199,8 +199,8 @@ export default class ComponentRegister extends Command {
     const config = classToPlain(new_spec);
     delete config.metadata;
     const component_dto = {
-      tag: tag,
-      config: config,
+      tag,
+      config,
     };
 
     let previous_config_data;

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -122,12 +122,7 @@ export class DockerComposeUtils {
         service.labels = [];
       }
 
-      let component_name;
-      let tenant_name;
-      if (node.config.metadata.instance_id) {
-        [component_name, tenant_name] = node.config.metadata.instance_id.split('@');
-      }
-      service.labels.push(`architect.ref=${component_name}.${node instanceof ServiceNode ? 'services' : 'tasks'}.${node.config.name}${tenant_name ? `@${tenant_name}` : ''}`);
+      service.labels.push(node.architect_ref);
 
       // Set liveness and healthcheck for services (not supported by Tasks)
       if (node instanceof ServiceNode) {

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -127,7 +127,12 @@ export class DockerComposeUtils {
       if (!service.labels) {
         service.labels = [];
       }
-      service.labels.push(`architect.ref=${node.config.metadata.ref}`);
+
+      if (node.config.reserved_name) {
+        service.labels.push(`architect.ref=${node.config.metadata.instance_id}.${node instanceof ServiceNode ? 'services' : 'tasks'}.${node.config.metadata.ref}`);
+      } else {
+        service.labels.push(`architect.ref=${node.config.metadata.ref}`);
+      }
 
       // Set liveness and healthcheck for services (not supported by Tasks)
       if (node instanceof ServiceNode) {

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -123,11 +123,11 @@ export class DockerComposeUtils {
       }
 
       let component_name;
-      let instance_name;
+      let tenant_name;
       if (node.config.metadata.instance_id) {
-        [component_name, instance_name] = node.config.metadata.instance_id.split('@');
+        [component_name, tenant_name] = node.config.metadata.instance_id.split('@');
       }
-      service.labels.push(`architect.ref=${component_name}.${node instanceof ServiceNode ? 'services' : 'tasks'}.${node.config.name}${instance_name ? `@${instance_name}` : ''}`);
+      service.labels.push(`architect.ref=${component_name}.${node instanceof ServiceNode ? 'services' : 'tasks'}.${node.config.name}${tenant_name ? `@${tenant_name}` : ''}`);
 
       // Set liveness and healthcheck for services (not supported by Tasks)
       if (node instanceof ServiceNode) {

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -14,12 +14,6 @@ import { restart } from '../utils/docker';
 import PortUtil from '../utils/port';
 import DockerComposeTemplate, { DockerService, DockerServiceBuild } from './template';
 
-class LocalService {
-  slugless_name!: string;
-  display_name!: string;
-  service_name!: string;
-}
-
 export class DockerComposeUtils {
 
   // used to namespace docker-compose projects so multiple deployments can happen to local
@@ -128,11 +122,12 @@ export class DockerComposeUtils {
         service.labels = [];
       }
 
-      if (node.config.reserved_name) {
-        service.labels.push(`architect.ref=${node.config.metadata.instance_id}.${node instanceof ServiceNode ? 'services' : 'tasks'}.${node.config.metadata.ref}`);
-      } else {
-        service.labels.push(`architect.ref=${node.config.metadata.ref}`);
+      let component_name;
+      let instance_name;
+      if (node.config.metadata.instance_id) {
+        [component_name, instance_name] = node.config.metadata.instance_id.split('@');
       }
+      service.labels.push(`architect.ref=${component_name}.${node instanceof ServiceNode ? 'services' : 'tasks'}.${node.config.name}${instance_name ? `@${instance_name}` : ''}`);
 
       // Set liveness and healthcheck for services (not supported by Tasks)
       if (node instanceof ServiceNode) {

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -122,7 +122,7 @@ export class DockerComposeUtils {
         service.labels = [];
       }
 
-      service.labels.push(node.architect_ref);
+      service.labels.push(`architect.ref=${node.architect_ref}`);
 
       // Set liveness and healthcheck for services (not supported by Tasks)
       if (node instanceof ServiceNode) {

--- a/src/dependency-manager/graph/node/service.ts
+++ b/src/dependency-manager/graph/node/service.ts
@@ -1,5 +1,6 @@
 import { DependencyNode, DependencyNodeOptions } from '.';
 import { ServiceConfig, ServiceInterfaceConfig } from '../../config/service-config';
+import { Refs } from '../../utils/refs';
 
 export interface ServiceNodeOptions {
   ref: string;
@@ -45,11 +46,6 @@ export class ServiceNode extends DependencyNode implements ServiceNodeOptions {
   }
 
   get architect_ref(): string {
-    let component_name;
-    let tenant_name;
-    if (this.config.metadata.instance_id) {
-      [component_name, tenant_name] = this.config.metadata.instance_id.split('@');
-    }
-    return `architect.ref=${component_name}.services.${this.config.name}${tenant_name ? `@${tenant_name}` : ''}`;
+    return Refs.getArchitectRef(this);
   }
 }

--- a/src/dependency-manager/graph/node/service.ts
+++ b/src/dependency-manager/graph/node/service.ts
@@ -1,4 +1,4 @@
-import { DependencyNode, DependencyNodeOptions, getArchitectRef } from '.';
+import { DependencyNode, DependencyNodeOptions } from '.';
 import { ServiceConfig, ServiceInterfaceConfig } from '../../config/service-config';
 import { Refs } from '../../utils/refs';
 

--- a/src/dependency-manager/graph/node/service.ts
+++ b/src/dependency-manager/graph/node/service.ts
@@ -43,4 +43,13 @@ export class ServiceNode extends DependencyNode implements ServiceNodeOptions {
   get is_local(): boolean {
     return this.local_path !== '';
   }
+
+  get architect_ref(): string {
+    let component_name;
+    let tenant_name;
+    if (this.config.metadata.instance_id) {
+      [component_name, tenant_name] = this.config.metadata.instance_id.split('@');
+    }
+    return `architect.ref=${component_name}.services.${this.config.name}${tenant_name ? `@${tenant_name}` : ''}`;
+  }
 }

--- a/src/dependency-manager/graph/node/service.ts
+++ b/src/dependency-manager/graph/node/service.ts
@@ -1,4 +1,4 @@
-import { DependencyNode, DependencyNodeOptions } from '.';
+import { DependencyNode, DependencyNodeOptions, getArchitectRef } from '.';
 import { ServiceConfig, ServiceInterfaceConfig } from '../../config/service-config';
 import { Refs } from '../../utils/refs';
 
@@ -46,6 +46,6 @@ export class ServiceNode extends DependencyNode implements ServiceNodeOptions {
   }
 
   get architect_ref(): string {
-    return Refs.getArchitectRef(this);
+    return Refs.getArchitectRef(this.config, 'services');
   }
 }

--- a/src/dependency-manager/graph/node/task.ts
+++ b/src/dependency-manager/graph/node/task.ts
@@ -42,6 +42,6 @@ export class TaskNode extends DependencyNode implements TaskNodeOptions {
   }
 
   get architect_ref(): string {
-    return Refs.getArchitectRef(this);
+    return Refs.getArchitectRef(this.config, 'tasks');
   }
 }

--- a/src/dependency-manager/graph/node/task.ts
+++ b/src/dependency-manager/graph/node/task.ts
@@ -1,5 +1,6 @@
 import { DependencyNode, DependencyNodeOptions } from '.';
 import { TaskConfig } from '../../config/task-config';
+import { Refs } from '../../utils/refs';
 
 export interface TaskNodeOptions {
   ref: string;
@@ -41,11 +42,6 @@ export class TaskNode extends DependencyNode implements TaskNodeOptions {
   }
 
   get architect_ref(): string {
-    let component_name;
-    let tenant_name;
-    if (this.config.metadata.instance_id) {
-      [component_name, tenant_name] = this.config.metadata.instance_id.split('@');
-    }
-    return `architect.ref=${component_name}.tasks.${this.config.name}${tenant_name ? `@${tenant_name}` : ''}`;
+    return Refs.getArchitectRef(this);
   }
 }

--- a/src/dependency-manager/graph/node/task.ts
+++ b/src/dependency-manager/graph/node/task.ts
@@ -39,4 +39,13 @@ export class TaskNode extends DependencyNode implements TaskNodeOptions {
   get is_local(): boolean {
     return this.local_path !== '';
   }
+
+  get architect_ref(): string {
+    let component_name;
+    let tenant_name;
+    if (this.config.metadata.instance_id) {
+      [component_name, tenant_name] = this.config.metadata.instance_id.split('@');
+    }
+    return `architect.ref=${component_name}.tasks.${this.config.name}${tenant_name ? `@${tenant_name}` : ''}`;
+  }
 }

--- a/src/dependency-manager/utils/refs.ts
+++ b/src/dependency-manager/utils/refs.ts
@@ -55,7 +55,7 @@ export class Refs {
       .replace(/[\\/+=]/g, ''); // we also remove occurances of slash, plus, and equals to make url-safe
   }
 
-  public static getArchitectRef(node: ServiceNode | TaskNode) {
+  public static getArchitectRef(node: ServiceNode | TaskNode): string {
     let component_name;
     let tenant_name;
     if (node.config.metadata.instance_id) {

--- a/src/dependency-manager/utils/refs.ts
+++ b/src/dependency-manager/utils/refs.ts
@@ -1,4 +1,6 @@
 import crypto from 'crypto';
+import { ServiceNode } from '../graph/node/service';
+import { TaskNode } from '../graph/node/task';
 
 export class Refs {
   private static HASH_LENGTH = 8;
@@ -51,5 +53,16 @@ export class Refs {
       .digest("base64") // base64 adds entropy in a more compact string
       .toLowerCase() // we need to makes everything lower which unfortunately removes some entropy
       .replace(/[\\/+=]/g, ''); // we also remove occurances of slash, plus, and equals to make url-safe
+  }
+
+  public static getArchitectRef(node: ServiceNode | TaskNode) {
+    let component_name;
+    let tenant_name;
+    if (node.config.metadata.instance_id) {
+      [component_name, tenant_name] = node.config.metadata.instance_id.split('@');
+    }
+    const node_type = node instanceof ServiceNode ? 'services' : 'tasks';
+    const tenant = tenant_name ? `@${tenant_name}` : '';
+    return `architect.ref=${component_name}.${node_type}.${node.config.name}${tenant}`;
   }
 }

--- a/src/dependency-manager/utils/refs.ts
+++ b/src/dependency-manager/utils/refs.ts
@@ -1,6 +1,4 @@
 import crypto from 'crypto';
-import { ServiceNode } from '../graph/node/service';
-import { TaskNode } from '../graph/node/task';
 
 export class Refs {
   private static HASH_LENGTH = 8;
@@ -55,14 +53,13 @@ export class Refs {
       .replace(/[\\/+=]/g, ''); // we also remove occurances of slash, plus, and equals to make url-safe
   }
 
-  public static getArchitectRef(node: ServiceNode | TaskNode): string {
+  public static getArchitectRef(node_config: any, node_type: 'services' | 'tasks'): string {
     let component_name;
     let tenant_name;
-    if (node.config.metadata.instance_id) {
-      [component_name, tenant_name] = node.config.metadata.instance_id.split('@');
+    if (node_config.metadata.instance_id) {
+      [component_name, tenant_name] = node_config.metadata.instance_id.split('@');
     }
-    const node_type = node instanceof ServiceNode ? 'services' : 'tasks';
     const tenant = tenant_name ? `@${tenant_name}` : '';
-    return `architect.ref=${component_name}.${node_type}.${node.config.name}${tenant}`;
+    return `architect.ref=${component_name}.${node_type}.${node_config.name}${tenant}`;
   }
 }

--- a/src/dependency-manager/utils/refs.ts
+++ b/src/dependency-manager/utils/refs.ts
@@ -60,6 +60,6 @@ export class Refs {
       [component_name, tenant_name] = node_config.metadata.instance_id.split('@');
     }
     const tenant = tenant_name ? `@${tenant_name}` : '';
-    return `architect.ref=${component_name}.${node_type}.${node_config.name}${tenant}`;
+    return `${component_name}.${node_type}.${node_config.name}${tenant}`;
   }
 }

--- a/test/dependency-manager/reserved-names.test.ts
+++ b/test/dependency-manager/reserved-names.test.ts
@@ -67,7 +67,7 @@ describe('components with reserved_name field set', function () {
             "build": {
               "context": path.resolve("/stack")
             },
-            labels: [`architect.ref=${reserved_name}`]
+            labels: [`architect.ref=architect/cloud.services.api`]
           },
         },
         "version": "3",
@@ -260,7 +260,7 @@ describe('components with reserved_name field set', function () {
             "build": {
               "context": path.resolve("/stack")
             },
-            labels: [`architect.ref=${api_ref}`]
+            labels: [`architect.ref=architect/cloud.services.api`]
           },
           [app_ref]: {
             "depends_on": [

--- a/test/dependency-manager/utils/refs.test.ts
+++ b/test/dependency-manager/utils/refs.test.ts
@@ -12,6 +12,21 @@ describe('Refs.safeRef', () => {
 
   const tag = '1.0.0';
   const transformed_tag = '1-0-0';
+  const tenant_name = 'tenant-name';
+
+  const node_config = {
+    name: service_name,
+    metadata: {
+      instance_id: `${component_account_name}/${component_name}`,
+    },
+  };
+
+  const node_config_with_tenant = {
+    name: service_name,
+    metadata: {
+      instance_id: `${component_account_name}/${component_name}@${tenant_name}`,
+    },
+  };
 
   it(`Refs.safeRef works for component_slug`, async () => {
     const component_slug = `${component_account_name}/${component_name}`;
@@ -212,5 +227,33 @@ describe('Refs.safeRef', () => {
     expect(trim_ref).to.not.equal(safe_ref);
     expect(trim_ref.length).to.be.equal(trim_length);
     expect(trim_ref).to.equal(`boutique-shop-fron${suffix}-mwwd9bxo`);
+  });
+
+  it(`Refs.getArchitectRef works for service with no tenant`, async () => {
+    const expected_ref = `${component_account_name}/${component_name}.services.${service_name}`;
+
+    const architect_ref = Refs.getArchitectRef(node_config, 'services');
+    expect(architect_ref).to.equal(expected_ref);
+  });
+
+  it(`Refs.getArchitectRef works for service with a tenant`, async () => {
+    const expected_ref = `${component_account_name}/${component_name}.services.${service_name}@${tenant_name}`;
+
+    const architect_ref = Refs.getArchitectRef(node_config_with_tenant, 'services');
+    expect(architect_ref).to.equal(expected_ref);
+  });
+
+  it(`Refs.getArchitectRef works for task with no tenant`, async () => {
+    const expected_ref = `${component_account_name}/${component_name}.tasks.${service_name}`;
+
+    const architect_ref = Refs.getArchitectRef(node_config, 'tasks');
+    expect(architect_ref).to.equal(expected_ref);
+  });
+
+  it(`Refs.getArchitectRef works for task with a tenant`, async () => {
+    const expected_ref = `${component_account_name}/${component_name}.tasks.${service_name}@${tenant_name}`;
+
+    const architect_ref = Refs.getArchitectRef(node_config_with_tenant, 'tasks');
+    expect(architect_ref).to.equal(expected_ref);
   });
 });


### PR DESCRIPTION
The purpose of this PR is to restore the image name generation in the register command. Adding `reserved_name` changes the `ref` of a node to just that reserved name and that's it.Without a reserved name though, the ref would contain the component name, whether the node was a service or task node, and the name of the service or task that it represents. This information is required when creating an image to push to the registry