### PR TITLE
Alert user on K8 version support

### DIFF
--- a/src/commands/platforms/create.ts
+++ b/src/commands/platforms/create.ts
@@ -56,16 +56,6 @@ export default class PlatformCreate extends Command {
   private async createPlatform() {
     const { args, flags } = await this.parse(PlatformCreate);
 
-    this.log(chalk.yellow(`
-    ==============================================================================================================
-
-      Note - Architect currently supports Kubernetes up to v1.23
-
-      For more details, please refer to - https://github.com/hashicorp/terraform-provider-kubernetes/issues/1724
-
-    ==============================================================================================================
-    `));
-
     const answers: any = await inquirer.prompt([
       {
         type: 'input',

--- a/src/commands/platforms/create.ts
+++ b/src/commands/platforms/create.ts
@@ -1,13 +1,12 @@
 import { CliUx, Flags, Interfaces } from '@oclif/core';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { Dictionary, Slugs } from '../../';
 import AccountUtils from '../../architect/account/account.utils';
 import PipelineUtils from '../../architect/pipeline/pipeline.utils';
 import { CreatePlatformInput } from '../../architect/platform/platform.utils';
 import Command from '../../base-command';
 import { KubernetesPlatformUtils } from '../../common/utils/kubernetes-platform.utils';
-import { Dictionary } from '../../';
-import { Slugs } from '../../';
 
 export default class PlatformCreate extends Command {
   static aliases = ['platforms:register', 'platform:create', 'platforms:create'];
@@ -56,6 +55,16 @@ export default class PlatformCreate extends Command {
 
   private async createPlatform() {
     const { args, flags } = await this.parse(PlatformCreate);
+
+    this.log(chalk.yellow(`
+    ==============================================================================================================
+
+      Note - Architect currently supports Kubernetes up to v1.23
+
+      For more details, please refer to - https://github.com/hashicorp/terraform-provider-kubernetes/issues/1724
+
+    ==============================================================================================================
+    `));
 
     const answers: any = await inquirer.prompt([
       {

--- a/src/common/utils/kubernetes-platform.utils.ts
+++ b/src/common/utils/kubernetes-platform.utils.ts
@@ -86,8 +86,6 @@ export class KubernetesPlatformUtils {
       if (major_ver >= 1 && minor_ver >= 24) {
         throw new ArchitectError('Architect currently does not support Kubernetes v1.24 or higher.');
       }
-    } else {
-      throw new ArchitectError('Error reading kubectl version.');
     }
 
     // Check for existing Service Account


### PR DESCRIPTION
When running `platform:create`, a message will show notifying
the user of the latest version of K8 we suport (up to v1.23).

If the user tries to register a K8 cluster v.1.24.0 or higher,
an error will be thrown