### PR TITLE
fixing interpolation if a service config string has a -- in it

### DIFF
--- a/src/commands/secrets/download.ts
+++ b/src/commands/secrets/download.ts
@@ -20,6 +20,7 @@ export default class SecretsDownload extends BaseCommand {
   };
 
   static args = [{
+    non_sensitive: true,
     name: 'secrets_file',
     description: 'Secrets filename to download secrets',
     required: true,

--- a/src/commands/secrets/upload.ts
+++ b/src/commands/secrets/upload.ts
@@ -25,7 +25,7 @@ export default class SecretsUpload extends BaseCommand {
         description: 'Allow override of existing secrets',
         default: false,
       }),
-    }
+    },
   };
 
   static args = [{

--- a/src/commands/secrets/upload.ts
+++ b/src/commands/secrets/upload.ts
@@ -19,13 +19,17 @@ export default class SecretsUpload extends BaseCommand {
     ...BaseCommand.flags,
     ...AccountUtils.flags,
     ...EnvironmentUtils.flags,
-    override: Flags.boolean({
-      description: 'Allow override of existing secrets',
-      default: false,
-    }),
+    override: {
+      non_sensitive: true,
+      ...Flags.boolean({
+        description: 'Allow override of existing secrets',
+        default: false,
+      }),
+    }
   };
 
   static args = [{
+    non_sensitive: true,
     name: 'secrets_file',
     description: 'Secrets file to be uploaded',
     required: true,

--- a/src/dependency-manager/spec/utils/slugs.ts
+++ b/src/dependency-manager/spec/utils/slugs.ts
@@ -15,7 +15,7 @@ export class Slugs {
 
   public static ArchitectSlugDescription = `must contain only lower alphanumeric and single hyphens or underscores in the middle; max length ${Slugs.SLUG_CHAR_LIMIT}`;
   static CharacterCountLookahead = `(?=.{1,${Slugs.SLUG_CHAR_LIMIT}}(\\${Slugs.NAMESPACE_DELIMITER}|${Slugs.TAG_DELIMITER}|$))`;
-  public static ArchitectSlugRegexBase = `(?!-)(?!.*--)[a-z0-9-]{1,${Slugs.SLUG_CHAR_LIMIT}}(?<!-)`;
+  public static ArchitectSlugRegexBase = `(?!-)(?!.{0,${Slugs.SLUG_CHAR_LIMIT}}--)[a-z0-9-]{1,${Slugs.SLUG_CHAR_LIMIT}}(?<!-)`;
   public static ArchitectSlugValidator = new RegExp(`^${Slugs.ArchitectSlugRegexBase}$`);
 
   public static LabelMax = 63;

--- a/test/dependency-manager/interpolation.test.ts
+++ b/test/dependency-manager/interpolation.test.ts
@@ -1639,4 +1639,51 @@ describe('interpolation spec v1', () => {
       API_ADDR: 'http://127.0.0.1:12345'
     })
   });
+
+  it('All edges are still found if a double dash exists later in the service config', async () => {
+    const config = `
+    name: examples/test
+
+    secrets:
+      api_port: 8080
+
+    interfaces:
+      api: \${{ services.api.interfaces.main.url }}
+
+    services:
+      app:
+        environment:
+          API_PORT: \${{ services.api.interfaces.main.port }}
+          API_ADDR: \${{ services.api.interfaces.main.url }}
+        liveness_probe:
+          command: curl --fail localhost:3000/users || exit 1
+          interval: 30s
+          failure_threshold: 3
+      api:
+        interfaces:
+          main: \${{ secrets.api_port }}
+        environment:
+          MY_PORT: \${{ services.api.interfaces.main.port }}
+          MY_ADDR: \${{ services.api.interfaces.main.url }}
+    `
+
+    mock_fs({
+      '/stack/architect.yml': config,
+    });
+
+    const manager = new LocalDependencyManager(axios.create(), {
+      'examples/test': '/stack/architect.yml',
+    });
+    const graph = await manager.getGraph(
+      await manager.loadComponentSpecs('examples/test')
+    );
+
+    const test_component_ref = resourceRefToNodeRef('examples/test');
+    const app_ref = resourceRefToNodeRef('examples/test.services.app');
+    const api_ref = resourceRefToNodeRef('examples/test.services.api');
+    expect(graph.edges.map((e) => e.toString())).has.members([
+      `${test_component_ref} [api] -> ${api_ref} [main]`,
+      `${app_ref} [service->main] -> ${api_ref} [main]`,
+    ]);
+  });
 });

--- a/test/dependency-manager/utils/slug-splitters.test.ts
+++ b/test/dependency-manager/utils/slug-splitters.test.ts
@@ -11,7 +11,6 @@ describe('slug validators with account', () => {
   const component_slug = `${component_account_name}/${component_name}`;
   const component_version_slug = `${component_account_name}/${component_name}:${tag}`;
   const resource_slug = `${component_account_name}/${component_name}.services.${resource_name}`;
-  const resource_version_slug = `${component_account_name}/${component_name}.services.${resource_name}:${tag}`;
 
   const invalid_slug = 'double--dashes';
   const invalid_tag = '.1.0.0';
@@ -19,7 +18,6 @@ describe('slug validators with account', () => {
   const invalid_component_slug = `${invalid_slug}/${component_name}`;
   const invalid_component_version_slug = `${component_account_name}/${component_name}:${invalid_tag}`;
   const invalid_resource_slug = `${component_account_name}/${component_name}.services.${invalid_slug}`;
-  const invalid_resource_version_slug = `${component_account_name}/${component_name}.services.${resource_name}:${invalid_tag}`;
 
   it(`ComponentSlugUtils.parse accurately splits ${component_slug}`, async () => {
     const result = ComponentSlugUtils.parse(component_slug);
@@ -63,7 +61,6 @@ describe('slug validators without account', () => {
   const component_slug = `${component_name}`;
   const component_version_slug = `${component_name}:${tag}`;
   const resource_slug = `${component_name}.services.${resource_name}`;
-  const resource_version_slug = `${component_name}.services.${resource_name}:${tag}`;
 
   const invalid_slug = 'double--dashes';
   const invalid_tag = '.1.0.0';
@@ -71,7 +68,6 @@ describe('slug validators without account', () => {
   const invalid_component_slug = `${invalid_slug}/${component_name}`;
   const invalid_component_version_slug = `${component_name}:${invalid_tag}`;
   const invalid_resource_slug = `${component_name}.services.${invalid_slug}`;
-  const invalid_resource_version_slug = `${component_name}.services.${resource_name}:${invalid_tag}`;
 
   it(`ComponentSlugUtils.parse accurately splits ${component_slug}`, async () => {
     const result = ComponentSlugUtils.parse(component_slug);


### PR DESCRIPTION
Our interpolation was using a forward lookahead for an unlimited amount of characters before, which could catch something like an `curl --fail localhost:3000/users || exit 1` in the service config. The `--` would fail the regex match, and therefore not find the edges of a service for the graph. The regex has been updated to take this into account, and a test was added