### PR TITLE
Fix incompatible builders between os on same system.

### DIFF
--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -173,7 +173,7 @@ export default class ComponentRegister extends BaseCommand {
     const builder = await DockerBuildXUtils.getBuilder(this.app.config);
 
     try {
-      await DockerBuildXUtils.dockerBuildX(['bake', '-f', compose_file, '--push', ...build_args, '--builder', builder], builder, {
+      await DockerBuildXUtils.dockerBuildX(['bake', '-f', compose_file, '--push', ...build_args], builder, {
         stdio: 'inherit',
       });
     } catch (err: any) {

--- a/src/common/utils/docker-buildx.utils.ts
+++ b/src/common/utils/docker-buildx.utils.ts
@@ -48,12 +48,12 @@ export default class DockerBuildXUtils {
 
   public static async getBuilder(config: config): Promise<string> {
     const is_local = this.isLocal(config);
-    const builder = is_local ? 'architect-local' : 'architect';
+    const builder = (is_local ? 'architect-local' : 'architect') + `-${process.platform}`;
 
     // Create a docker context
     try {
       await docker(['context', 'create', `${builder}-context`]);
-    // eslint-disable-next-line no-empty
+      // eslint-disable-next-line no-empty
     } catch (err) { }
 
     try {
@@ -71,7 +71,7 @@ export default class DockerBuildXUtils {
           stdio: 'inherit',
         });
       }
-    // eslint-disable-next-line no-empty
+      // eslint-disable-next-line no-empty
     } catch { }
 
     return builder;
@@ -81,7 +81,7 @@ export default class DockerBuildXUtils {
     if (use_console) {
       process.stdin.setRawMode(true);
     }
-    const cmd = execa('docker', [`--context=${docker_builder_name}-context`, 'buildx', ...args], execa_opts);
+    const cmd = execa('docker', [`--context=${docker_builder_name}-context`, 'buildx', '--builder', docker_builder_name, ...args], execa_opts);
     if (use_console) {
       cmd.on('exit', () => {
         process.exit();


### PR DESCRIPTION
## Overview
A bug was found where running `architect register` on Windows and then on WSL2 would cause a failure. This was found to be because the buildx contexts that are generated are not compatible between OSs. The fix is to append the platform to the context name in order to make it unique per system.

## Changes
1. Append the os name to each context.
2. Moved some of the logic from the register function into the buildx function to make it more clear what is being used where.

## Testing
Smoke test: `npm run test`
Ran `architect register ./examples/hello-world/architect.yml` on both WSL2 and Windows on the same machine.