### PR TITLE
Add status code on exit for exec local

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -1,4 +1,5 @@
 import { Flags } from '@oclif/core';
+import execa from 'execa';
 import inquirer from 'inquirer';
 import stream from 'stream';
 import stringArgv from 'string-argv';
@@ -234,7 +235,14 @@ export default class Exec extends BaseCommand {
       compose_args.push(arg);
     }
 
-    await DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit' }, true);
+    await DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit' }, true, (cmd: execa.ExecaChildProcess<string>) => {
+      try {
+        this.exit(cmd.exitCode || 0);
+      } catch (_) {
+        // Oclif exit always throws an error for some reason
+        // This is not necessary since the error is not helpful
+      }
+    });
   }
 
   async run(): Promise<void> {

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -1,5 +1,4 @@
 import { Flags } from '@oclif/core';
-import execa from 'execa';
 import inquirer from 'inquirer';
 import stream from 'stream';
 import stringArgv from 'string-argv';

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -235,14 +235,7 @@ export default class Exec extends BaseCommand {
       compose_args.push(arg);
     }
 
-    await DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit' }, true, (cmd: execa.ExecaChildProcess<string>) => {
-      try {
-        this.exit(cmd.exitCode || 0);
-      } catch (_) {
-        // Oclif exit always throws an error for some reason
-        // This is not necessary since the error is not helpful
-      }
-    });
+    await DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit' }, true);
   }
 
   async run(): Promise<void> {

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -349,7 +349,7 @@ export class DockerComposeUtils {
     }
   }
 
-  public static dockerCompose(args: string[], execa_opts?: Options, use_console = false, on_end?: (cmd: execa.ExecaChildProcess<string>) => void): execa.ExecaChildProcess<string> {
+  public static dockerCompose(args: string[], execa_opts?: Options, use_console = false): execa.ExecaChildProcess<string> {
     this.dockerCommandCheck();
     if (use_console) {
       process.stdin.setRawMode(true);
@@ -357,11 +357,7 @@ export class DockerComposeUtils {
     const cmd = execa('docker', ['compose', ...args], execa_opts);
     if (use_console) {
       cmd.on('exit', () => {
-        if (on_end) {
-          on_end(cmd);
-        } else {
-          process.exit();
-        }
+        process.exit(cmd.exitCode || 0);
       });
     }
     return cmd;

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -349,7 +349,7 @@ export class DockerComposeUtils {
     }
   }
 
-  public static dockerCompose(args: string[], execa_opts?: Options, use_console = false): execa.ExecaChildProcess<string> {
+  public static dockerCompose(args: string[], execa_opts?: Options, use_console = false, on_end?: (cmd: execa.ExecaChildProcess<string>) => void): execa.ExecaChildProcess<string> {
     this.dockerCommandCheck();
     if (use_console) {
       process.stdin.setRawMode(true);
@@ -357,7 +357,11 @@ export class DockerComposeUtils {
     const cmd = execa('docker', ['compose', ...args], execa_opts);
     if (use_console) {
       cmd.on('exit', () => {
-        process.exit();
+        if (on_end) {
+          on_end(cmd);
+        } else {
+          process.exit();
+        }
       });
     }
     return cmd;


### PR DESCRIPTION
When running the exec command we now send back the correct status code for the downstream command.

Failed downstream command
```
muesch@Michael-PC:~/Architect/code/architect-cli$ architect-local exec -- cat nothasdf
? Select an account dev (Local Machine)
? Select a service cloud.services.registry
cat: can't open 'nothasdf': No such file or directory
Command failed with exit code 1: docker compose -f /home/muesch/.config/architect-local/architect/docker-compose/cloud.yml -p cloud exec cloud--registry cat nothasdf
Error: Command failed with exit code 1: docker compose -f /home/muesch/.config/architect-local/architect/docker-compose/cloud.yml -p cloud exec cloud--registry cat nothasdf
    at makeError (/home/muesch/Architect/code/architect-cli/node_modules/execa/lib/error.js:60:11)
    at handlePromise (/home/muesch/Architect/code/architect-cli/node_modules/execa/index.js:118:26)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Exec.runLocal (/home/muesch/Architect/code/architect-cli/src/commands/exec.ts:238:5)
    at async Exec.run (/home/muesch/Architect/code/architect-cli/src/commands/exec.ts:266:14)
    at async Exec._run (/home/muesch/Architect/code/architect-cli/node_modules/@oclif/core/lib/command.js:67:22)
    at async Config.runCommand (/home/muesch/Architect/code/architect-cli/node_modules/@oclif/core/lib/config/config.js:268:25)
    at async Object.run (/home/muesch/Architect/code/architect-cli/node_modules/@oclif/core/lib/main.js:73:5)

muesch@Michael-PC:~/Architect/code/architect-cli$ echo $?
1
```

Successful downstream command
```
muesch@Michael-PC:~/Architect/code/architect-cli$ architect-local exec -- ls
? Select an account dev (Local Machine)
? Select a service cloud.services.api
concourse                    test
dist                         tsconfig-paths-bootstrap.js
nest-cli.json                tsconfig.build.json
node_modules                 tsconfig.json
package-lock.json            tsconfig.production.json
package.json                 webpack-hmr.config.js
src

muesch@Michael-PC:~/Architect/code/architect-cli$ echo $?
0
```