### PR TITLE
Pass the proper auth header when using exec via token_type

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -90,7 +90,7 @@ export default class Exec extends BaseCommand {
       const protocols = ['v4.channel.k8s.io', 'v3.channel.k8s.io', 'v2.channel.k8s.io', 'channel.k8s.io'];
 
       const headers: Dictionary<string> = {
-        Authorization: `Bearer ${auth_result?.access_token}`,
+        Authorization: `${auth_result?.token_type} ${auth_result?.access_token}`,
       };
 
       const url = new URL(uri);


### PR DESCRIPTION
Looks like this is the only place in the CLI that we weren't using `token.token_type` yet - necessary for `architect exec` to work with personal access tokens (token_type is "Basic" for them).