### PR TITLE
Sentry Refactor and Bug Fix

### DIFF
--- a/.madgerc
+++ b/.madgerc
@@ -1,0 +1,7 @@
+{
+  "detectiveOptions": {
+    "ts": {
+      "skipTypeImports": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "test": "mocha --forbid-only \"test/**/*.test.ts\" --config ./test/.mocharc.yml",
     "pack": "oclif pack:tarballs",
     "readme": "./bin/readme",
+    "check": "npm run lint && npm run test && npm run check-circular",
     "generate:schema-docs": "ts-node --project ./tsconfig.json ./src/dependency-manager/generate.ts",
     "generate:yarn-lock": "(rm yarn.lock || true) && yarn import",
     "semantic-release": "./node_modules/semantic-release/bin/semantic-release.js"

--- a/src/app-config/service.ts
+++ b/src/app-config/service.ts
@@ -19,10 +19,8 @@ export default class AppService {
   version: string;
   errorContext?: Error;
 
-  static async create(config_dir: string, version: string): Promise<AppService> {
-    const service = new AppService(config_dir, version);
-    await service.auth.init();
-    return service;
+  static create(config_dir: string, version: string): AppService {
+    return new AppService(config_dir, version);
   }
 
   constructor(config_dir: string, version: string) {

--- a/src/architect/user/user.entity.ts
+++ b/src/architect/user/user.entity.ts
@@ -1,4 +1,5 @@
 export default interface User {
   id: string;
   name: string;
+  email: string;
 }

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -37,7 +37,7 @@ export default abstract class BaseCommand extends Command {
     try {
       this.sentry = await SentryService.create(this.app, this.constructor as any, this);
     } catch (e) {
-      console.log('SENTRY: an error occurred creating a new instance of SentryService');
+      this.debug('SENTRY: an error occurred creating a new instance of SentryService');
     }
   }
 

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -35,7 +35,7 @@ export default abstract class BaseCommand extends Command {
 
   private async createSentry() {
     try {
-      this.sentry = await SentryService.create(this.app, this.constructor as any, this);
+      this.sentry = await SentryService.create(this.app, this.constructor as any, this.debug.bind(this));
     } catch (e) {
       this.debug('SENTRY: an error occurred creating a new instance of SentryService');
     }
@@ -123,12 +123,5 @@ export default abstract class BaseCommand extends Command {
     await this.sentry?.catch(err);
     // Oclif supers go as the return
     return super.catch(err);
-  }
-
-  // The current debug method is protected and we need a full logger
-  // this is a temporary work around until we implement
-  // https://gitlab.com/architect-io/architect-cli/-/issues/474
-  consoleDebug(message: string): void {
-    this.debug(message);
   }
 }

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -112,7 +112,6 @@ export default abstract class BaseCommand extends Command {
   }
 
   async finally(err: Error | undefined): Promise<any> {
-    console.log("FINALLY");
     const calling_class = this.constructor as any;
     await this.sentry?.endSentryTransaction(!(await this.disable_sentry_recording()), await this.parse(calling_class), calling_class, err)
     // Oclif supers go as the return
@@ -120,10 +119,13 @@ export default abstract class BaseCommand extends Command {
   }
 
   async catch(err: any): Promise<void> {
-    console.log("CATCH");
     if (err.oclif && err.oclif.exit === 0) return;
     await this.sentry?.catch(err);
-    // Oclif supers go as the return
-    return super.catch(err);
+    // Sentry flush does not seem to work as intended and calling super
+    // here causes errors not to be sent up. This needs to be investigated more
+    // but it should not block the rest of the update. Have brought in the necessary
+    // code from the super below
+    // return super.catch(err);
+    process.exitCode = process.exitCode ?? err.exitCode ?? 1
   }
 }

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -112,13 +112,15 @@ export default abstract class BaseCommand extends Command {
   }
 
   async finally(err: Error | undefined): Promise<any> {
+    console.log("FINALLY");
     const calling_class = this.constructor as any;
-    await this.sentry?.endSentryTransaction(!(await this.disable_sentry_recording()), this.parse(calling_class), calling_class, err)
+    await this.sentry?.endSentryTransaction(!(await this.disable_sentry_recording()), await this.parse(calling_class), calling_class, err)
     // Oclif supers go as the return
     return super.finally(err);
   }
 
   async catch(err: any): Promise<void> {
+    console.log("CATCH");
     if (err.oclif && err.oclif.exit === 0) return;
     await this.sentry?.catch(err);
     // Oclif supers go as the return

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -1,6 +1,9 @@
 import { Command, Config, Interfaces } from '@oclif/core';
 import '@sentry/tracing';
+import chalk from 'chalk';
+import { ValidationErrors } from '.';
 import AppService from './app-config/service';
+import { prettyValidationErrors } from './common/dependency-manager/validation';
 import LoginRequiredError from './common/errors/login-required';
 import SentryService from './sentry';
 
@@ -9,19 +12,12 @@ const DEPRECATED_LABEL = '[deprecated]';
 export default abstract class BaseCommand extends Command {
   static readonly DEPRECATED: string = DEPRECATED_LABEL;
 
-  app!: AppService;
-  accounts?: any;
-  sentry!: SentryService;
+  app: AppService;
+  sentry: SentryService;
 
   async auth_required(): Promise<boolean> {
     return true;
   }
-
-  async disable_sentry_recording(): Promise<boolean> {
-    return false;
-  }
-
-  static flags = {};
 
   checkFlagDeprecations(flags: any, flag_definitions: any): void {
     Object.keys(flags).forEach((flagName: string) => {
@@ -33,58 +29,51 @@ export default abstract class BaseCommand extends Command {
     });
   }
 
-  private async ignoreTryCatch(fn: () => Promise<void>, debug_message: string) {
-    try {
-      await fn();
-    } catch {
-      this.debug(debug_message);
-    }
-  }
-
-  private async createSentry() {
-    this.ignoreTryCatch(async () => {
-      this.sentry = await SentryService.create(this.constructor as any, this.debug.bind(this));
-    }, 'SENTRY: an error occurred creating a new instance of SentryService');
-  }
-
   constructor(argv: string[], config: Config) {
     super(argv, config);
-    this.createSentry();
+    this.app = AppService.create(this.config.configDir, this.config.userAgent.split(/\/|\s/g)[2]);
+    this.sentry = new SentryService(this);
+  }
+
+  // override debug being a protected method on the oclif Command class
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  debug(...args: any[]): void {
+    return super.debug(...args);
   }
 
   async init(): Promise<void> {
-    const { flags } = await this.parse(this.constructor as any);
-    const flag_definitions = (this.constructor as any).flags;
+    const command_class = this.getClass();
+    const { flags } = await this.parse(command_class);
+    const flag_definitions = command_class.flags;
     this.checkFlagDeprecations(flags, flag_definitions);
 
-    if (!this.app) {
-      this.app = await AppService.create(this.config.configDir, this.config.userAgent.split(/\/|\s/g)[2]);
-      if (await this.auth_required()) {
-        const token_json = await this.app.auth.getPersistedTokenJSON();
-        if (!token_json) {
+    await this.app.auth.init();
+
+    if (await this.auth_required()) {
+      const token_json = await this.app.auth.getPersistedTokenJSON();
+      if (!token_json) {
+        throw new LoginRequiredError();
+      }
+      if (token_json.email === 'unknown') {
+        throw new LoginRequiredError();
+      }
+      if (token_json.expires_in) {
+        const auth_client = this.app.auth.getAuthClient();
+        const access_token = auth_client.createToken(token_json);
+        if (access_token.expired()) {
           throw new LoginRequiredError();
-        }
-        if (token_json.email === 'unknown') {
-          throw new LoginRequiredError();
-        }
-        if (token_json.expires_in) {
-          const auth_client = this.app.auth.getAuthClient();
-          const access_token = auth_client.createToken(token_json);
-          if (access_token.expired()) {
-            throw new LoginRequiredError();
-          }
         }
       }
     }
-
     await this.sentry.startSentryTransaction(this.app);
   }
 
   // Move all args to the front of the argv to get around: https://github.com/oclif/oclif/issues/190
-  protected async parse<F, A extends {
+  async parse<F, A extends {
     [name: string]: any;
   }>(options?: Interfaces.Input<F>, argv = this.argv): Promise<Interfaces.ParserOutput<F, A>> {
-    const flag_definitions = (this.constructor as any).flags;
+    const flag_definitions = this.getClass().flags;
 
     // Support -- input ex. architect exec -- ls -la
     const double_dash_index = argv.indexOf('--');
@@ -118,20 +107,50 @@ export default abstract class BaseCommand extends Command {
   }
 
   async finally(err: Error | undefined): Promise<any> {
-    const calling_class = this.constructor as any;
-    await this.ignoreTryCatch(async () => {
-      await this.sentry?.endSentryTransaction(!(await this.disable_sentry_recording()), await this.parse(calling_class), calling_class, err);
-    }, 'SENTRY: Error occurred on ending transaction');
+    await this.sentry.endSentryTransaction(err);
+
     // Oclif supers go as the return
     return super.finally(err);
   }
 
-  async catch(err: any): Promise<void> {
-    if (err.oclif && err.oclif.exit === 0) return;
-    await this.ignoreTryCatch(async () => {
-      await this.sentry?.catch(err);
-    }, 'SENTRY: Error occurred on catch');
+  async catch(error: any): Promise<void> {
+    if (error.oclif && error.oclif.exit === 0) return;
+
+    try {
+      if (error.stack) {
+        error.stack = [...new Set(error.stack.split('\n'))].join("\n");
+      }
+
+      if (error instanceof ValidationErrors) {
+        return prettyValidationErrors(error);
+      }
+
+      if (error.response?.data instanceof Object) {
+        error.message += `\nmethod: ${error.config.method}`;
+        for (const [k, v] of Object.entries(error.response.data)) {
+          try {
+            const msg = JSON.parse(v as any).message;
+            if (!msg) { throw new Error('Invalid msg'); }
+            error.message += `\n${k}: ${msg}`;
+          } catch {
+            error.message += `\n${k}: ${v}`;
+          }
+        }
+      }
+
+      if (error.stderr) {
+        error.message += `\nstderr:\n${error.stderr}\n`;
+      }
+
+      console.error(chalk.red(error.message));
+    } catch {
+      this.debug('Unable to add more context to error message');
+    }
     // Oclif supers go as the return
-    return super.catch(err);
+    return super.catch(error);
+  }
+
+  getClass(): typeof BaseCommand {
+    return this.constructor as any;
   }
 }

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -72,9 +72,6 @@ export default abstract class BaseCommand extends Command {
   }
 
   async finally(_: Error | undefined): Promise<any> {
-    if (_ instanceof ValidationErrors) {
-      process.exitCode = 1;
-    }
     return await this.endSentryTransaction();
   }
 
@@ -117,6 +114,7 @@ export default abstract class BaseCommand extends Command {
 
   async catch(err: any): Promise<void> {
     if (err.oclif && err.oclif.exit === 0) return;
+    process.exitCode = 1;
 
     try {
 

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -113,7 +113,7 @@ export default abstract class BaseCommand extends Command {
 
   async finally(err: Error | undefined): Promise<any> {
     const calling_class = this.constructor as any;
-    await this.sentry?.endSentryTransaction(!(await this.disable_sentry_recording()), await this.parse(calling_class), calling_class, err)
+    await this.sentry?.endSentryTransaction(!(await this.disable_sentry_recording()), await this.parse(calling_class), calling_class, err);
     // Oclif supers go as the return
     return super.finally(err);
   }

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -72,6 +72,9 @@ export default abstract class BaseCommand extends Command {
   }
 
   async finally(_: Error | undefined): Promise<any> {
+    if (_ instanceof ValidationErrors) {
+      process.exitCode = 1;
+    }
     return await this.endSentryTransaction();
   }
 

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -66,7 +66,7 @@ export default abstract class BaseCommand extends Command {
         }
       }
     }
-    await this.sentry.startSentryTransaction(this.app);
+    await this.sentry.startSentryTransaction();
   }
 
   // Move all args to the front of the argv to get around: https://github.com/oclif/oclif/issues/190

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -124,4 +124,11 @@ export default abstract class BaseCommand extends Command {
     // Oclif supers go as the return
     return super.catch(err);
   }
+
+  // The current debug method is protected and we need a full logger
+  // this is a temporary work around until we implement
+  // https://gitlab.com/architect-io/architect-cli/-/issues/474
+  consoleDebug(message: string) {
+    this.debug(message);
+  }
 }

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -128,7 +128,7 @@ export default abstract class BaseCommand extends Command {
   // The current debug method is protected and we need a full logger
   // this is a temporary work around until we implement
   // https://gitlab.com/architect-io/architect-cli/-/issues/474
-  consoleDebug(message: string) {
+  consoleDebug(message: string): void {
     this.debug(message);
   }
 }

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -121,11 +121,7 @@ export default abstract class BaseCommand extends Command {
   async catch(err: any): Promise<void> {
     if (err.oclif && err.oclif.exit === 0) return;
     await this.sentry?.catch(err);
-    // Sentry flush does not seem to work as intended and calling super
-    // here causes errors not to be sent up. This needs to be investigated more
-    // but it should not block the rest of the update. Have brought in the necessary
-    // code from the super below
-    // return super.catch(err);
-    process.exitCode = process.exitCode ?? err.exitCode ?? 1
+    // Oclif supers go as the return
+    return super.catch(err);
   }
 }

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -1,10 +1,6 @@
 import { Command, Interfaces } from '@oclif/core';
 import '@sentry/tracing';
-import chalk from 'chalk';
-import { ValidationErrors } from './';
-import { ENVIRONMENT } from './app-config/config';
 import AppService from './app-config/service';
-import { prettyValidationErrors } from './common/dependency-manager/validation';
 import LoginRequiredError from './common/errors/login-required';
 import SentryService from './sentry';
 
@@ -37,6 +33,19 @@ export default abstract class BaseCommand extends Command {
     });
   }
 
+  private async createSentry() {
+    try {
+      this.sentry = await SentryService.create(this.app, this.constructor as any, this);
+    } catch (e) {
+      console.log('SENTRY: an error occurred creating a new instance of SentryService');
+    }
+  }
+
+  private async loginRequired() {
+    await this.createSentry();
+    throw new LoginRequiredError();
+  }
+
   async init(): Promise<void> {
     const { flags } = await this.parse(this.constructor as any);
     const flag_definitions = (this.constructor as any).flags;
@@ -47,32 +56,22 @@ export default abstract class BaseCommand extends Command {
       if (await this.auth_required()) {
         const token_json = await this.app.auth.getPersistedTokenJSON();
         if (!token_json) {
-          throw new LoginRequiredError();
+          return await this.loginRequired();
         }
         if (token_json.email === 'unknown') {
-          throw new LoginRequiredError();
+          return await this.loginRequired();
         }
         if (token_json.expires_in) {
           const auth_client = this.app.auth.getAuthClient();
           const access_token = auth_client.createToken(token_json);
           if (access_token.expired()) {
-            throw new LoginRequiredError();
+            return await this.loginRequired();
           }
         }
       }
-    }
-    try {
-      this.sentry = await SentryService.create(this.app, this.constructor as any);
-    } catch (e) {
-      console.debug("SENTRY: an error occurred creating a new instance of SentryService");
-    }
-    if (!this.sentry) {
-      console.debug("SENTRY: SentryService failed to initialize");
-    }
-  }
 
-  async finally(_: Error | undefined): Promise<any> {
-    return await this.endSentryTransaction();
+      await this.createSentry();
+    }
   }
 
   // Move all args to the front of the argv to get around: https://github.com/oclif/oclif/issues/190
@@ -112,85 +111,17 @@ export default abstract class BaseCommand extends Command {
     return super.parse(options, [...args, ...flags]);
   }
 
+  async finally(err: Error | undefined): Promise<any> {
+    const calling_class = this.constructor as any;
+    await this.sentry?.endSentryTransaction(!(await this.disable_sentry_recording()), this.parse(calling_class), calling_class, err)
+    // Oclif supers go as the return
+    return super.finally(err);
+  }
+
   async catch(err: any): Promise<void> {
     if (err.oclif && err.oclif.exit === 0) return;
-    process.exitCode = 1;
-
-    try {
-
-      if (err.stack) {
-        err.stack = [...new Set(err.stack.split('\n'))].join("\n");
-      }
-
-      if (err instanceof ValidationErrors) {
-        return prettyValidationErrors(err);
-      }
-
-      if (err.response?.data instanceof Object) {
-        err.message += `\nmethod: ${err.config.method}`;
-        for (const [k, v] of Object.entries(err.response.data)) {
-          try {
-            const msg = JSON.parse(v as any).message;
-            if (!msg) { throw new Error('Invalid msg'); }
-            err.message += `\n${k}: ${msg}`;
-          } catch {
-            err.message += `\n${k}: ${v}`;
-          }
-        }
-      }
-
-      if (err.stderr) {
-        err.message += `\nstderr:\n${err.stderr}\n`;
-      }
-
-      console.error(chalk.red(err.message));
-
-    } catch {
-      this.warn('Unable to add more context to error message');
-    }
-    const app_env = this.app?.config?.environment;
-    if (!this.sentry || !app_env || app_env === ENVIRONMENT.TEST) {
-      return super.catch(err);
-    }
-    return await this.endSentryTransaction(err);
+    await this.sentry?.catch(err);
+    // Oclif supers go as the return
+    return super.catch(err);
   }
-
-  async _filterNonSensitiveSentryMetadata(non_sensitive: Set<string>, metadata: any): Promise<any> {
-    return Object.entries(metadata)
-      .filter((value,) => !!value[1] && non_sensitive.has(value[0]))
-      .map(key => ({ [key[0]]: key[1] }));
-  }
-
-  async endSentryTransaction(err?: any): Promise<any> {
-    const app_env = this.app?.config?.environment;
-    if (!this.sentry || !app_env || app_env === ENVIRONMENT.TEST) {
-      return err;
-    }
-
-    const calling_class = this.constructor as any;
-
-    const non_sensitive = new Set([
-      ...Object.entries(calling_class.flags || {}).filter(([_, value]) => (value as any).non_sensitive).map(([key, _]) => key),
-      ...Object.entries(calling_class.args || {}).filter(([_, value]) => (value as any).non_sensitive).map(([_, value]) => (value as any).name),
-    ]);
-
-    try {
-      const { args, flags } = await this.parse(calling_class);
-      const filtered_sentry_args = await this._filterNonSensitiveSentryMetadata(non_sensitive, args);
-      const filtered_sentry_flags = await this._filterNonSensitiveSentryMetadata(non_sensitive, flags);
-
-      await this.sentry.setScopeExtra('command_args', filtered_sentry_args);
-      await this.sentry.setScopeExtra('command_flags', filtered_sentry_flags);
-    } catch {
-      this.warn('Failed to get command metadata');
-    }
-
-    await this.sentry.endSentryTransaction(!(await this.disable_sentry_recording()), err);
-
-    if (!err) {
-      return await super.finally(err);
-    }
-    return await super.catch(err);
-  }
-
 }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -30,7 +30,7 @@ export abstract class DeployCommand extends BaseCommand {
     },
   };
 
-  protected async parse<F, A extends {
+  async parse<F, A extends {
     [name: string]: any;
   }>(options?: Interfaces.Input<F>, argv = this.argv): Promise<Interfaces.ParserOutput<F, A>> {
     const parsed = await super.parse(options, argv) as Interfaces.ParserOutput<F, A>;
@@ -200,7 +200,7 @@ export default class Deploy extends DeployCommand {
   }];
 
   // overrides the oclif default parse to allow for configs_or_components to be a list of components
-  protected async parse<F, A extends {
+  async parse<F, A extends {
     [name: string]: any;
   }>(options?: Interfaces.Input<F>, argv = this.argv): Promise<Interfaces.ParserOutput<F, A>> {
     if (!options) {

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -150,7 +150,7 @@ export default class Dev extends BaseCommand {
   }];
 
   // overrides the oclif default parse to allow for configs_or_components to be a list of components
-  protected async parse<F, A extends {
+  async parse<F, A extends {
     [name: string]: any;
   }>(options?: Interfaces.Input<F>, argv = this.argv): Promise<Interfaces.ParserOutput<F, A>> {
     if (!options) {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -107,10 +107,6 @@ export default class Doctor extends BaseCommand {
     return false;
   }
 
-  async disable_sentry_recording(): Promise<boolean> {
-    return true;
-  }
-
   history: SentryHistory[] = [];
 
   static description = 'Get debugging information for troubleshooting';

--- a/src/commands/environments/destroy.ts
+++ b/src/commands/environments/destroy.ts
@@ -43,7 +43,7 @@ export default class EnvironmentDestroy extends BaseCommand {
     parse: async (value: string): Promise<string> => value.toLowerCase(),
   }];
 
-  protected async parse<F, A extends {
+  async parse<F, A extends {
     [name: string]: any;
   }>(options?: Interfaces.Input<F>, argv = this.argv): Promise<Interfaces.ParserOutput<F, A>> {
     const parsed = await super.parse(options, argv) as Interfaces.ParserOutput<F, A>;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -54,7 +54,7 @@ export abstract class InitCommand extends BaseCommand {
     },
   };
 
-  protected async parse<F, A extends {
+  async parse<F, A extends {
     [name: string]: any;
   }>(options?: Interfaces.Input<F>, argv = this.argv): Promise<Interfaces.ParserOutput<F, A>> {
     const parsed = await super.parse(options, argv) as Interfaces.ParserOutput<F, A>;

--- a/src/commands/platforms/create.ts
+++ b/src/commands/platforms/create.ts
@@ -63,7 +63,7 @@ export default class PlatformCreate extends BaseCommand {
     },
   };
 
-  protected async parse<F, A extends {
+  async parse<F, A extends {
     [name: string]: any;
   }>(options?: Interfaces.Input<F>, argv = this.argv): Promise<Interfaces.ParserOutput<F, A>> {
     const parsed = await super.parse(options, argv) as Interfaces.ParserOutput<F, A>;

--- a/src/commands/platforms/destroy.ts
+++ b/src/commands/platforms/destroy.ts
@@ -43,7 +43,7 @@ export default class PlatformDestroy extends BaseCommand {
     parse: async (value: string): Promise<string> => value.toLowerCase(),
   }];
 
-  protected async parse<F, A extends {
+  async parse<F, A extends {
     [name: string]: any;
   }>(options?: Interfaces.Input<F>, argv = this.argv): Promise<Interfaces.ParserOutput<F, A>> {
     const parsed = await super.parse(options, argv) as Interfaces.ParserOutput<F, A>;

--- a/src/commands/platforms/index.ts
+++ b/src/commands/platforms/index.ts
@@ -21,6 +21,7 @@ export default class Platforms extends BaseCommand {
   }];
 
   async run(): Promise<void> {
+    throw new Error("TEST");
     const { args, flags } = await this.parse(Platforms);
 
     let account: Account | undefined = undefined;

--- a/src/commands/platforms/index.ts
+++ b/src/commands/platforms/index.ts
@@ -21,7 +21,6 @@ export default class Platforms extends BaseCommand {
   }];
 
   async run(): Promise<void> {
-    throw new Error("TEST");
     const { args, flags } = await this.parse(Platforms);
 
     let account: Account | undefined = undefined;

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -63,7 +63,7 @@ export default class TaskExec extends BaseCommand {
     },
   ];
 
-  protected async parse<F, A extends {
+  async parse<F, A extends {
     [name: string]: any;
   }>(options?: Interfaces.Input<F>, argv = this.argv): Promise<Interfaces.ParserOutput<F, A>> {
     const parsed = await super.parse(options, argv) as Interfaces.ParserOutput<F, A>;

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -28,7 +28,7 @@ export default class ComponentValidate extends BaseCommand {
   }];
 
   // overrides the oclif default parse to allow for configs_or_components to be a list of components
-  protected async parse<F, A extends {
+  async parse<F, A extends {
     [name: string]: any;
   }>(options?: Interfaces.Input<F>, argv = this.argv): Promise<Interfaces.ParserOutput<F, A>> {
     if (!options) {

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -110,7 +110,7 @@ export default class SentryService {
         scope.setTags(sentry_tags);
       });
     } catch {
-      console.debug("SENTRY: Unable to start sentry transaction");
+      this.command.consoleDebug("SENTRY: Unable to start sentry transaction");
     }
   }
 
@@ -146,7 +146,7 @@ export default class SentryService {
       const update_scope = Sentry.getCurrentHub().getScope();
       update_scope?.setExtras(sentry_session_metadata);
     } catch {
-      console.debug("SENTRY: Unable to attach metadata to the current transaction");
+      this.command.consoleDebug("SENTRY: Unable to attach metadata to the current transaction");
     }
   }
 
@@ -202,7 +202,7 @@ export default class SentryService {
       await this.setScopeExtra('command_args', filtered_sentry_args);
       await this.setScopeExtra('command_flags', filtered_sentry_flags);
     } catch (err) {
-      console.debug("Unable to add extra sentry metadata");
+      this.command.consoleDebug("Unable to add extra sentry metadata");
     }
 
     try {
@@ -223,7 +223,7 @@ export default class SentryService {
       }
       await Sentry.getCurrentHub().getClient()?.close();
     } catch {
-      console.log("SENTRY: Unable to save and submit the current transaction");
+      this.command.consoleDebug("SENTRY: Unable to save and submit the current transaction");
     }
   }
 
@@ -235,7 +235,7 @@ export default class SentryService {
       const update_scope = Sentry.getCurrentHub().getScope();
       update_scope?.setExtra(key, value);
     } catch {
-      console.debug("SENTRY: Unable to add extra metadata element to the current transaction");
+      this.command.consoleDebug("SENTRY: Unable to add extra metadata element to the current transaction");
     }
   }
 
@@ -253,7 +253,7 @@ export default class SentryService {
 
       return updated_docker_info;
     } catch {
-      console.debug("SENTRY: Unable to retrieve running docker container metadata");
+      this.command.consoleDebug("SENTRY: Unable to retrieve running docker container metadata");
       return [];
     }
   }
@@ -264,7 +264,7 @@ export default class SentryService {
       const addr = fs.readdirSync(path, { withFileTypes: true });
       return addr.filter(f => f.isFile()).map(f => ({ name: f.name })) || [];
     } catch {
-      console.debug("SENTRY: Unable to read list of file names from the architect config directory");
+      this.command.consoleDebug("SENTRY: Unable to read list of file names from the architect config directory");
       return [];
     }
   }
@@ -275,7 +275,7 @@ export default class SentryService {
       try {
         command_history = await JSON.parse(fs.readFileSync(this.sentry_history_file_path).toString()) || [];
       } catch {
-        console.debug("SENTRY: Unable to read command history file from the architect config directory");
+        this.command.consoleDebug("SENTRY: Unable to read command history file from the architect config directory");
       }
     }
     return command_history;
@@ -312,7 +312,7 @@ export default class SentryService {
       const maximum_records = ~Math.min(5, history.length) + 1;
       fs.outputJsonSync(this.sentry_history_file_path, history.slice(maximum_records), { spaces: 2 });
     } catch {
-      console.debug("SENTRY: Unable to write command history file to the architect config directory");
+      this.command.consoleDebug("SENTRY: Unable to write command history file to the architect config directory");
     }
   }
 

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -4,7 +4,6 @@ import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 import { ENVIRONMENT } from './app-config/config';
-import AppService from './app-config/service';
 import User from './architect/user/user.entity';
 import type BaseCommand from './base-command';
 import { docker } from './common/utils/docker';
@@ -80,10 +79,10 @@ export default class SentryService {
     }
   }
 
-  async startSentryTransaction(app: AppService): Promise<void> {
+  async startSentryTransaction(): Promise<void> {
     this.ignoreTryCatch(async () => {
-      this.file_out = app.config.environment !== ENVIRONMENT.TEST && app.config.environment !== ENVIRONMENT.PREVIEW;
-      this.sentry_history_file_path = path.join(app.config?.getConfigDir(), LocalPaths.SENTRY_FILENAME);
+      this.file_out = this.command.app.config.environment !== ENVIRONMENT.TEST && this.command.app.config.environment !== ENVIRONMENT.PREVIEW;
+      this.sentry_history_file_path = path.join(this.command.app.config?.getConfigDir(), LocalPaths.SENTRY_FILENAME);
 
       const sentry_user = await this.getUser();
 

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -23,6 +23,7 @@ export default class SentryService {
 
 
   static async create(app: AppService, child: any, command: BaseCommand): Promise<SentryService> {
+    command.consoleDebug("SENTRY: Initializing");
     const sentry = new SentryService(app, child, command);
     await sentry.startSentryTransaction();
     return sentry;

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import { ENVIRONMENT } from './app-config/config';
 import AppService from './app-config/service';
 import User from './architect/user/user.entity';
-import BaseCommand from './base-command';
+import type BaseCommand from './base-command';
 import { docker } from './common/utils/docker';
 import PromptUtils from './common/utils/prompt-utils';
 import LocalPaths from './paths';

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -35,7 +35,7 @@ export default class SentryService {
     this.command = command;
     this.file_out = app.config.environment !== ENVIRONMENT.TEST && app.config.environment !== ENVIRONMENT.PREVIEW;
     this.sentry_history_file_path = path.join(app.config?.getConfigDir(), LocalPaths.SENTRY_FILENAME);
-    this.sentry_out = true;// app.config.environment === ENVIRONMENT.PRODUCTION || app.config.environment === ENVIRONMENT.DEV || app.config.environment === ENVIRONMENT.PREVIEW;
+    this.sentry_out = app.config.environment === ENVIRONMENT.PRODUCTION || app.config.environment === ENVIRONMENT.DEV || app.config.environment === ENVIRONMENT.PREVIEW;
   }
 
   async startSentryTransaction(): Promise<void> {

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -215,13 +215,13 @@ export default class SentryService {
       if (this.sentry_out) {
         if (error) {
           Sentry.withScope(async scope => {
-            Sentry.captureException(error, scope)
-            await Sentry.flush();
+            Sentry.captureException(error, scope);
           });
         }
         Sentry.getCurrentHub().getScope()?.getSpan()?.finish();
         Sentry.getCurrentHub().getScope()?.getTransaction()?.finish();
       }
+      await Sentry.getCurrentHub().getClient()?.close();
     } catch {
       console.log("SENTRY: Unable to save and submit the current transaction");
     }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -6,8 +6,10 @@ import os from 'os';
 import path from 'path';
 import { ENVIRONMENT } from './app-config/config';
 import AppService from './app-config/service';
+import { prettyValidationErrors } from './common/dependency-manager/validation';
 import { docker } from './common/utils/docker';
 import PromptUtils from './common/utils/prompt-utils';
+import { ValidationErrors } from './dependency-manager/utils/errors';
 import LocalPaths from './paths';
 
 const CLI_SENTRY_DSN = 'https://272fd53f577f4729b014701d74fe6c53@o298191.ingest.sentry.io/6465948';
@@ -154,6 +156,10 @@ export default class SentryService {
     try {
       if (error.stack) {
         error.stack = [...new Set(error.stack.split('\n'))].join("\n");
+      }
+
+      if (error instanceof ValidationErrors) {
+        return prettyValidationErrors(error);
       }
 
       if (error.response?.data instanceof Object) {

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -65,7 +65,7 @@ export default class SentryService {
 
       Sentry.init({
         dsn: CLI_SENTRY_DSN,
-        debug: true,
+        debug: false,
         environment: this.app.config.environment,
         release: process.env?.npm_package_version,
         tracesSampleRate: 1.0,
@@ -201,8 +201,8 @@ export default class SentryService {
 
       await this.setScopeExtra('command_args', filtered_sentry_args);
       await this.setScopeExtra('command_flags', filtered_sentry_flags);
-    } catch {
-
+    } catch (err) {
+      console.debug("Unable to add extra sentry metadata");
     }
 
     try {

--- a/test/commands/config/get.test.ts
+++ b/test/commands/config/get.test.ts
@@ -9,7 +9,7 @@ import ConfigGet from '../../../src/commands/config/get';
 import ARCHITECTPATHS from '../../../src/paths';
 
 const expectValueForField = async (tmp_config_dir: string, key: string, value: string) => {
-  const app_config_stub = sinon.stub().resolves(new AppService(tmp_config_dir, '0.0.1'));
+  const app_config_stub = sinon.stub().returns(new AppService(tmp_config_dir, '0.0.1'));
   const logSpy = sinon.fake.returns(null);
   sinon.replace(ConfigGet.prototype, 'log', logSpy);
   sinon.replace(AppService, 'create', app_config_stub);

--- a/test/commands/config/view.test.ts
+++ b/test/commands/config/view.test.ts
@@ -31,7 +31,7 @@ describe('config:view', () => {
     const tmp_config_file = path.join(tmp_config_dir, ARCHITECTPATHS.CLI_CONFIG_FILENAME);
     fs.writeJSONSync(tmp_config_file, config);
 
-    const app_config_spy = sinon.fake.resolves(new AppService(tmp_config_dir, '0.0.1'));
+    const app_config_spy = sinon.fake.returns(new AppService(tmp_config_dir, '0.0.1'));
     const log_spy = sinon.fake.returns(null);
 
     // set to true while working on tests for easier debugging; otherwise oclif/test eats the stdout/stderr

--- a/test/commands/environments/index.test.ts
+++ b/test/commands/environments/index.test.ts
@@ -15,7 +15,7 @@ describe('environments', () => {
     const config = new AppConfig('', {});
     const tmp_config_file = path.join(tmp_dir, ARCHITECTPATHS.CLI_CONFIG_FILENAME);
     fs.writeJSONSync(tmp_config_file, config);
-    const app_config_stub = sinon.stub().resolves(new AppService(tmp_dir, '0.0.1'));
+    const app_config_stub = sinon.stub().returns(new AppService(tmp_dir, '0.0.1'));
     sinon.replace(AppService, 'create', app_config_stub);
   });
 

--- a/test/commands/link.test.ts
+++ b/test/commands/link.test.ts
@@ -21,7 +21,7 @@ describe('link', () => {
     fs.writeJSONSync(tmp_linked_components_file, {});
     const tmp_config_file = path.join(tmp_dir, ARCHITECTPATHS.CLI_CONFIG_FILENAME);
     fs.writeJSONSync(tmp_config_file, config);
-    const app_config_stub = sinon.stub().resolves(new AppService(tmp_dir, '0.0.1'));
+    const app_config_stub = sinon.stub().returns(new AppService(tmp_dir, '0.0.1'));
     sinon.replace(AppService, 'create', app_config_stub);
   });
 

--- a/test/commands/platforms/create.test.ts
+++ b/test/commands/platforms/create.test.ts
@@ -35,7 +35,7 @@ describe('platform:create', function () {
     });
     const tmp_config_file = path.join(tmp_dir, ARCHITECTPATHS.CLI_CONFIG_FILENAME);
     fs.writeJSONSync(tmp_config_file, config);
-    const app_config_stub = sinon.stub().resolves(new AppService(tmp_dir, '0.0.1'));
+    const app_config_stub = sinon.stub().returns(new AppService(tmp_dir, '0.0.1'));
     sinon.replace(AppService, 'create', app_config_stub);
   });
 

--- a/test/commands/register.test.ts
+++ b/test/commands/register.test.ts
@@ -57,7 +57,6 @@ describe('register', function () {
     .command(['register', 'examples/fusionauth/architect.yml', '-t', '1.0.0', '-a', 'examples'])
     .it('test file: replacement', ctx => {
       expect(ctx.stdout).to.contain('Successfully registered component');
-      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -84,7 +83,6 @@ describe('register', function () {
     .command(['register', 'examples/fusionauth/architect.yml', '-t', '1.0.0', '--architecture', 'amd64', '--architecture', 'arm64v8', '--architecture', 'windows-amd64', '-a', 'examples'])
     .it('register component with architecture flag', ctx => {
       expect(ctx.stdout).to.contain('Successfully registered component');
-      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -97,11 +95,10 @@ describe('register', function () {
     .stderr({ print })
     .command(['register', 'examples/database-seeding/architect.yml', '-t', '1.0.0', '--architecture', 'incorrect', '-a', 'examples'])
     .catch(err => {
+      expect(process.exitCode).eq(1);
       expect(`${err}`).to.contain('Some internal docker build exception');
     })
-    .it('register component with architecture flag failed', ctx => {
-      expect(process.exitCode).eq(1);
-    });
+    .it('register component with architecture flag failed');
 
   mockArchitectAuth
     .nock(MOCK_REGISTRY_HOST, api => api
@@ -139,7 +136,6 @@ describe('register', function () {
     .command(['register', 'test/mocks/superset/architect.yml', '-t', '1.0.0', '-a', 'examples'])
     .it('register superset', async ctx => {
       expect(ctx.stdout).to.contain('Successfully registered component');
-      expect(process.exitCode).eq(0);
       /*
       const writeCompose = DockerComposeUtils.writeCompose as sinon.SinonStub;
       const compose_contents = yaml.load(writeCompose.firstCall.args[1]) as DockerComposeTemplate;
@@ -180,7 +176,6 @@ describe('register', function () {
     .command(['register', 'examples/gcp-pubsub/pubsub/architect.yml', '-t', '1.0.0', '-a', 'examples'])
     .it('it reports to the user that the component was registered successfully', ctx => {
       expect(ctx.stdout).to.contain('Successfully registered component');
-      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -207,7 +202,6 @@ describe('register', function () {
     .it('it does not call any docker commands if the image is provided', ctx => {
       expect(ctx.stderr).to.contain('Registering component examples/gcp-pubsub:1.0.0 with Architect Cloud');
       expect(ctx.stdout).to.contain('Successfully registered component');
-      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -229,7 +223,6 @@ describe('register', function () {
     .it('it defaults the tag to latest if not supplied', ctx => {
       expect(ctx.stderr).to.contain('Registering component examples/gcp-pubsub:latest with Architect Cloud');
       expect(ctx.stdout).to.contain('Successfully registered component');
-      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -243,11 +236,10 @@ describe('register', function () {
     .stderr({ print })
     .command(['register', 'examples/hello-world/architect.yml', '-a', 'examples'])
     .catch(err => {
+      expect(process.exitCode).eq(1);
       expect(err.message).to.contain('Friendly error message from server');
     })
-    .it('rejects with informative error message if account is unavailable', ctx => {
-      expect(process.exitCode).eq(1);
-    });
+    .it('rejects with informative error message if account is unavailable');
 
   mockArchitectAuth
     .stub(fs, 'move', sinon.stub())
@@ -279,7 +271,6 @@ describe('register', function () {
     .it('gives user feedback while running docker commands', ctx => {
       expect(ctx.stderr).to.contain('Registering component database-seeding:1.0.0 with Architect Cloud');
       expect(ctx.stdout).to.contain('Successfully registered component');
-      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -292,11 +283,11 @@ describe('register', function () {
     .stderr({ print })
     .command(['register', 'examples/database-seeding/architect.yml', '-t', '1.0.0', '-a', 'examples'])
     .catch(err => {
+      expect(process.exitCode).eq(1);
       expect(`${err}`).to.contain('Some internal docker build exception');
     })
     .it('rejects with informative error message if docker buildx inspect fails', ctx => {
       expect(ctx.stdout).to.contain("Docker buildx bake failed. Please make sure docker is running.");
-      expect(process.exitCode).eq(1);
     });
 
   mockArchitectAuth
@@ -325,7 +316,6 @@ describe('register', function () {
     .command(['register', 'examples/stateless-component/architect.yml', '-t', '1.0.0', '-a', 'examples'])
     .it('gives user feedback for each component in the environment while running docker commands', ctx => {
       expect(ctx.stderr).to.contain('Registering component stateless-component:1.0.0 with Architect Cloud');
-      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -364,7 +354,6 @@ describe('register', function () {
         'mock.registry.localhost/examples/react-app.services.api:latest',
         'mock.registry.localhost/examples/react-app.services.app:latest',
       ]);
-      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -395,6 +384,5 @@ describe('register', function () {
       expect(compose.callCount).to.eq(1);
       expect(compose.firstCall.args[0][5]).to.deep.equal("*.args.NODE_ENV=dev");
       expect(compose.firstCall.args[0][7]).to.deep.equal('*.args.SSH_PUB_KEY="abc==\ntest.architect.io"');
-      expect(process.exitCode).eq(1);
     });
 });

--- a/test/commands/register.test.ts
+++ b/test/commands/register.test.ts
@@ -25,13 +25,13 @@ describe('register', function () {
     location: null,
     website: null,
     is_public: false,
-    default_user_id: null
-  }
+    default_user_id: null,
+  };
 
   const mock_architect_account_response = {
     ...mock_account_response,
-    name: 'architect'
-  }
+    name: 'architect',
+  };
 
   mockArchitectAuth
     .nock(MOCK_API_HOST, api => api
@@ -40,11 +40,11 @@ describe('register', function () {
     )
     .nock(MOCK_API_HOST, api => api
       .post(/\/accounts\/.*\/components/, (body) => {
-        expect(body.tag).to.eq('1.0.0')
-        expect(body.config.name).to.eq('fusionauth')
-        expect(body.config.services.fusionauth.image).to.eq('fusionauth/fusionauth-app:latest')
-        expect(body.config.services.fusionauth.environment.ADMIN_USER_PASSWORD).to.eq('${{ secrets.admin_user_password }}')
-        expect(body.config.services.fusionauth.environment.FUSIONAUTH_KICKSTART).to.eq('/usr/local/fusionauth/kickstart.json')
+        expect(body.tag).to.eq('1.0.0');
+        expect(body.config.name).to.eq('fusionauth');
+        expect(body.config.services.fusionauth.image).to.eq('fusionauth/fusionauth-app:latest');
+        expect(body.config.services.fusionauth.environment.ADMIN_USER_PASSWORD).to.eq('${{ secrets.admin_user_password }}');
+        expect(body.config.services.fusionauth.environment.FUSIONAUTH_KICKSTART).to.eq('/usr/local/fusionauth/kickstart.json');
 
         const config = fs.readFileSync('examples/fusionauth/config/kickstart.json');
         expect(body.config.services.fusionauth.environment.KICKSTART_CONTENTS).to.eq(config.toString().trim());
@@ -57,6 +57,7 @@ describe('register', function () {
     .command(['register', 'examples/fusionauth/architect.yml', '-t', '1.0.0', '-a', 'examples'])
     .it('test file: replacement', ctx => {
       expect(ctx.stdout).to.contain('Successfully registered component');
+      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -66,11 +67,11 @@ describe('register', function () {
     )
     .nock(MOCK_API_HOST, api => api
       .post(/\/accounts\/.*\/components/, (body) => {
-        expect(body.tag).to.eq('1.0.0')
-        expect(body.config.name).to.eq('fusionauth')
-        expect(body.config.services.fusionauth.image).to.eq('fusionauth/fusionauth-app:latest')
-        expect(body.config.services.fusionauth.environment.ADMIN_USER_PASSWORD).to.eq('${{ secrets.admin_user_password }}')
-        expect(body.config.services.fusionauth.environment.FUSIONAUTH_KICKSTART).to.eq('/usr/local/fusionauth/kickstart.json')
+        expect(body.tag).to.eq('1.0.0');
+        expect(body.config.name).to.eq('fusionauth');
+        expect(body.config.services.fusionauth.image).to.eq('fusionauth/fusionauth-app:latest');
+        expect(body.config.services.fusionauth.environment.ADMIN_USER_PASSWORD).to.eq('${{ secrets.admin_user_password }}');
+        expect(body.config.services.fusionauth.environment.FUSIONAUTH_KICKSTART).to.eq('/usr/local/fusionauth/kickstart.json');
 
         const config = fs.readFileSync('examples/fusionauth/config/kickstart.json');
         expect(body.config.services.fusionauth.environment.KICKSTART_CONTENTS).to.eq(config.toString().trim());
@@ -83,6 +84,7 @@ describe('register', function () {
     .command(['register', 'examples/fusionauth/architect.yml', '-t', '1.0.0', '--architecture', 'amd64', '--architecture', 'arm64v8', '--architecture', 'windows-amd64', '-a', 'examples'])
     .it('register component with architecture flag', ctx => {
       expect(ctx.stdout).to.contain('Successfully registered component');
+      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -95,9 +97,10 @@ describe('register', function () {
     .stderr({ print })
     .command(['register', 'examples/database-seeding/architect.yml', '-t', '1.0.0', '--architecture', 'incorrect', '-a', 'examples'])
     .catch(err => {
-      expect(`${err}`).to.contain('Some internal docker build exception')
+      expect(`${err}`).to.contain('Some internal docker build exception');
     })
     .it('register component with architecture flag failed', ctx => {
+      expect(process.exitCode).eq(1);
     });
 
   mockArchitectAuth
@@ -124,7 +127,7 @@ describe('register', function () {
           if (IF_EXPRESSION_REGEX.test(task_name)) { continue; }
           expect(task.image).not.undefined;
         }
-        cb(null, body)
+        cb(null, body);
       })
     )
     .nock(MOCK_API_HOST, api => api
@@ -136,7 +139,7 @@ describe('register', function () {
     .command(['register', 'test/mocks/superset/architect.yml', '-t', '1.0.0', '-a', 'examples'])
     .it('register superset', async ctx => {
       expect(ctx.stdout).to.contain('Successfully registered component');
-
+      expect(process.exitCode).eq(0);
       /*
       const writeCompose = DockerComposeUtils.writeCompose as sinon.SinonStub;
       const compose_contents = yaml.load(writeCompose.firstCall.args[1]) as DockerComposeTemplate;
@@ -165,7 +168,7 @@ describe('register', function () {
         const contents = yaml.load(fs.readFileSync('examples/gcp-pubsub/pubsub/architect.yml').toString());
         expect(body.config).to.deep.equal(contents);
         expect(validateSpec(body.config)).to.have.lengthOf(0);
-        cb(null, body)
+        cb(null, body);
       })
     )
     .nock(MOCK_API_HOST, api => api
@@ -177,6 +180,7 @@ describe('register', function () {
     .command(['register', 'examples/gcp-pubsub/pubsub/architect.yml', '-t', '1.0.0', '-a', 'examples'])
     .it('it reports to the user that the component was registered successfully', ctx => {
       expect(ctx.stdout).to.contain('Successfully registered component');
+      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -186,9 +190,9 @@ describe('register', function () {
     )
     .nock(MOCK_API_HOST, api => api
       .post(/\/accounts\/.*\/components/, (body) => {
-        expect(body.tag).to.eq('1.0.0')
-        expect(body.config.name).to.eq('examples/gcp-pubsub')
-        expect(body.config.services.pubsub.image).to.eq('gcr.io/google.com/cloudsdktool/cloud-sdk:emulators')
+        expect(body.tag).to.eq('1.0.0');
+        expect(body.config.name).to.eq('examples/gcp-pubsub');
+        expect(body.config.services.pubsub.image).to.eq('gcr.io/google.com/cloudsdktool/cloud-sdk:emulators');
         return body;
       })
       .reply(200, {})
@@ -203,6 +207,7 @@ describe('register', function () {
     .it('it does not call any docker commands if the image is provided', ctx => {
       expect(ctx.stderr).to.contain('Registering component examples/gcp-pubsub:1.0.0 with Architect Cloud');
       expect(ctx.stdout).to.contain('Successfully registered component');
+      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -224,22 +229,25 @@ describe('register', function () {
     .it('it defaults the tag to latest if not supplied', ctx => {
       expect(ctx.stderr).to.contain('Registering component examples/gcp-pubsub:latest with Architect Cloud');
       expect(ctx.stdout).to.contain('Successfully registered component');
+      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
     .nock(MOCK_API_HOST, api => api
       .get('/accounts/examples')
       .reply(403, {
-        message: 'Friendly error message from server'
+        message: 'Friendly error message from server',
       })
     )
     .stdout({ print })
     .stderr({ print })
     .command(['register', 'examples/hello-world/architect.yml', '-a', 'examples'])
     .catch(err => {
-      expect(err.message).to.contain('Friendly error message from server')
+      expect(err.message).to.contain('Friendly error message from server');
     })
-    .it('rejects with informative error message if account is unavailable');
+    .it('rejects with informative error message if account is unavailable', ctx => {
+      expect(process.exitCode).eq(1);
+    });
 
   mockArchitectAuth
     .stub(fs, 'move', sinon.stub())
@@ -254,9 +262,9 @@ describe('register', function () {
     )
     .nock(MOCK_API_HOST, api => api
       .post(/\/accounts\/.*\/components/, (body) => {
-        expect(body.tag).to.eq('1.0.0')
-        expect(body.config.name).to.eq('database-seeding')
-        expect(body.config.services.app.image).to.eq('mock.registry.localhost/examples/database-seeding.services.app@some-digest')
+        expect(body.tag).to.eq('1.0.0');
+        expect(body.config.name).to.eq('database-seeding');
+        expect(body.config.services.app.image).to.eq('mock.registry.localhost/examples/database-seeding.services.app@some-digest');
         return body;
       })
       .reply(200, {})
@@ -271,6 +279,7 @@ describe('register', function () {
     .it('gives user feedback while running docker commands', ctx => {
       expect(ctx.stderr).to.contain('Registering component database-seeding:1.0.0 with Architect Cloud');
       expect(ctx.stdout).to.contain('Successfully registered component');
+      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -283,10 +292,11 @@ describe('register', function () {
     .stderr({ print })
     .command(['register', 'examples/database-seeding/architect.yml', '-t', '1.0.0', '-a', 'examples'])
     .catch(err => {
-      expect(`${err}`).to.contain('Some internal docker build exception')
+      expect(`${err}`).to.contain('Some internal docker build exception');
     })
     .it('rejects with informative error message if docker buildx inspect fails', ctx => {
       expect(ctx.stdout).to.contain("Docker buildx bake failed. Please make sure docker is running.");
+      expect(process.exitCode).eq(1);
     });
 
   mockArchitectAuth
@@ -315,6 +325,7 @@ describe('register', function () {
     .command(['register', 'examples/stateless-component/architect.yml', '-t', '1.0.0', '-a', 'examples'])
     .it('gives user feedback for each component in the environment while running docker commands', ctx => {
       expect(ctx.stderr).to.contain('Registering component stateless-component:1.0.0 with Architect Cloud');
+      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -353,6 +364,7 @@ describe('register', function () {
         'mock.registry.localhost/examples/react-app.services.api:latest',
         'mock.registry.localhost/examples/react-app.services.app:latest',
       ]);
+      expect(process.exitCode).eq(0);
     });
 
   mockArchitectAuth
@@ -383,5 +395,6 @@ describe('register', function () {
       expect(compose.callCount).to.eq(1);
       expect(compose.firstCall.args[0][5]).to.deep.equal("*.args.NODE_ENV=dev");
       expect(compose.firstCall.args[0][7]).to.deep.equal('*.args.SSH_PUB_KEY="abc==\ntest.architect.io"');
+      expect(process.exitCode).eq(1);
     });
 });

--- a/test/commands/unlink.test.ts
+++ b/test/commands/unlink.test.ts
@@ -25,7 +25,7 @@ describe('unlink', () => {
     });
     const tmp_config_file = path.join(tmp_dir, ARCHITECTPATHS.CLI_CONFIG_FILENAME);
     fs.writeJSONSync(tmp_config_file, config);
-    const app_config_stub = sinon.stub().resolves(new AppService(tmp_dir, '0.0.1'));
+    const app_config_stub = sinon.stub().returns(new AppService(tmp_dir, '0.0.1'));
     sinon.replace(AppService, 'create', app_config_stub);
   });
 

--- a/test/dependency-manager/validation.test.ts
+++ b/test/dependency-manager/validation.test.ts
@@ -829,6 +829,7 @@ services:
       expect(errors).lengthOf(1);
       expect(err.message).includes(`services.app.labels.environment2`);
       expect(err.message).includes('must match pattern');
+      expect(process.exitCode).eq(1);
     });
 
     it('invalid labels length', async () => {
@@ -1094,6 +1095,7 @@ services:
     const errors = JSON.parse(err.message);
     expect(errors).lengthOf(1);
     expect(errors[0].path).eq(`architect/cloud.TE@ST`);
+    expect(process.exitCode).eq(1);
   });
 
   it('component values are defined in an object', () => {

--- a/test/dependency-manager/validation.test.ts
+++ b/test/dependency-manager/validation.test.ts
@@ -19,9 +19,9 @@ describe('validate spec', () => {
             main: 8080
       interfaces:
         frontend: \${{ services['stateless-app'].interfaces.main.url }}
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
-      buildSpecFromPath('/architect.yml')
+      buildSpecFromPath('/architect.yml');
     });
 
     it('invalid nested debug', async () => {
@@ -37,11 +37,11 @@ services:
       debug:
         environment:
           LOG_LEVEL: debug
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
       let err;
       try {
-        buildSpecFromPath('/architect.yml')
+        buildSpecFromPath('/architect.yml');
       } catch (e: any) {
         err = e;
       }
@@ -54,6 +54,7 @@ services:
       expect(errors[0].start?.column).eq(7);
       expect(errors[0].end?.row).eq(10);
       expect(errors[0].end?.column).eq(12);
+      expect(process.exitCode).eq(1);
     });
 
     it('invalid host_path outside debug block', async () => {
@@ -66,10 +67,10 @@ services:
     volumes:
       test:
         host_path: ./test
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
 
-      expect(() => { buildSpecFromPath('/architect.yml') }).to.throw(ValidationErrors);
+      expect(() => { buildSpecFromPath('/architect.yml'); }).to.throw(ValidationErrors);
     });
 
     it('invalid deploy key', async () => {
@@ -85,11 +86,11 @@ services:
                 inputs:
                   deploy-input-string: some_deploy_input
                   deploy-input-unset:
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
       let err;
       try {
-        buildSpecFromPath('/architect.yml')
+        buildSpecFromPath('/architect.yml');
       } catch (e: any) {
         err = e;
       }
@@ -98,6 +99,7 @@ services:
       expect(errors).lengthOf(1);
       expect(errors[0].path).eq(`services.stateless-app.deploy`);
       expect(errors[0].message).includes(`Invalid key: deploy`);
+      expect(process.exitCode).eq(1);
     });
 
     it('invalid replicas value', async () => {
@@ -106,7 +108,7 @@ services:
       services:
         stateless-app:
           replicas: '1'
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
         'test/component': '/architect.yml',
@@ -120,7 +122,7 @@ services:
         err = e;
       }
 
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message);
       expect(errors).lengthOf(1);
       expect(errors[0].path).eq(`services.stateless-app.replicas`);
@@ -129,6 +131,7 @@ services:
       expect(errors[0].start?.column).eq(22);
       expect(errors[0].end?.row).eq(5);
       expect(errors[0].end?.column).eq(22);
+      expect(process.exitCode).eq(1);
     });
 
     it('invalid service ref', async () => {
@@ -140,7 +143,7 @@ services:
             main: 8080
       interfaces:
         frontend: \${{ services.fake.interfaces.main.url }}
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
         'test/component': '/architect.yml',
@@ -154,11 +157,12 @@ services:
         err = e;
       }
 
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message);
       expect(errors).lengthOf(1);
       expect(errors[0].message).includes(`services.stateless-app.interfaces.main.url`);
       expect(errors[0].path).eq(`interfaces.frontend`);
+      expect(process.exitCode).eq(1);
     });
 
     it('services and tasks can share the same name', async () => {
@@ -172,7 +176,7 @@ services:
         app:
           environment:
             TEST: 1
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
         'component': '/architect.yml',
@@ -181,11 +185,11 @@ services:
       const graph = await manager.getGraph([
         await manager.loadComponentSpec('component'),
       ]);
-      expect(graph.nodes).to.have.lengthOf(2)
+      expect(graph.nodes).to.have.lengthOf(2);
       expect(graph.nodes.map((node) => node.ref)).to.have.members([
         resourceRefToNodeRef('component.services.app'),
-        resourceRefToNodeRef('component.tasks.app')
-      ])
+        resourceRefToNodeRef('component.tasks.app'),
+      ]);
     });
 
     it('valid service depends_on', async () => {
@@ -202,9 +206,9 @@ services:
             main: 5432
       interfaces:
         frontend: \${{ services['stateful-app'].interfaces.main.url }}
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
-      buildSpecFromPath('/architect.yml')
+      buildSpecFromPath('/architect.yml');
     });
 
     it('invalid task schedule', async () => {
@@ -214,7 +218,7 @@ services:
         some-task:
           schedule: "*/5 * * * ? * * * * *"
           image: ellerbrock/alpine-bash-curl-ssl
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
         'test/component': '/architect.yml',
@@ -227,10 +231,11 @@ services:
       } catch (e: any) {
         err = e;
       }
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message);
       expect(errors).lengthOf(1);
       expect(errors[0].path).eq(`tasks.some-task.schedule`);
+      expect(process.exitCode).eq(1);
     });
 
     it('valid task depends_on', async () => {
@@ -251,9 +256,9 @@ services:
             main: 5432
       interfaces:
         frontend: \${{ services['stateful-app'].interfaces.main.url }}
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
-      buildSpecFromPath('/architect.yml')
+      buildSpecFromPath('/architect.yml');
     });
 
     it('invalid task depends_on', async () => {
@@ -271,7 +276,7 @@ services:
             main: 8080
       interfaces:
         frontend: \${{ services['stateless-app'].interfaces.main.url }}
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
         'test/component': '/architect.yml',
@@ -284,10 +289,11 @@ services:
       } catch (e: any) {
         err = e;
       }
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message);
       expect(errors).lengthOf(1);
       expect(errors[0].path).eq(`services.stateless-app.depends_on`);
+      expect(process.exitCode).eq(1);
     });
 
     it('invalid service self reference', async () => {
@@ -301,7 +307,7 @@ services:
             main: 8080
       interfaces:
         frontend: \${{ services['stateless-app'].interfaces.main.url }}
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
         'test/component': '/architect.yml',
@@ -314,10 +320,11 @@ services:
       } catch (e: any) {
         err = e;
       }
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message);
       expect(errors).lengthOf(1);
       expect(errors[0].path).eq(`services.stateless-app.depends_on`);
+      expect(process.exitCode).eq(1);
     });
 
     it('invalid service depends_on reference', async () => {
@@ -331,7 +338,7 @@ services:
             main: 8080
       interfaces:
         frontend: \${{ services['stateless-app'].interfaces.main.url }}
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
         'test/component': '/architect.yml',
@@ -344,10 +351,11 @@ services:
       } catch (e: any) {
         err = e;
       }
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message);
       expect(errors).lengthOf(1);
       expect(errors[0].path).eq(`services.stateless-app.depends_on`);
+      expect(process.exitCode).eq(1);
     });
 
     it('invalid circular service reference', async () => {
@@ -366,7 +374,7 @@ services:
             main: 5432
       interfaces:
         frontend: \${{ services['stateful-app'].interfaces.main.url }}
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
 
       const manager = new LocalDependencyManager(axios.create(), {
@@ -380,13 +388,14 @@ services:
       } catch (e: any) {
         err = e;
       }
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(2);
       expect(errors.map(e => e.path)).members([
         'services.stateful-app.depends_on',
-        'services.backend.depends_on'
-      ])
+        'services.backend.depends_on',
+      ]);
+      expect(process.exitCode).eq(1);
     });
 
     it('invalid deep circular service reference', async () => {
@@ -410,7 +419,7 @@ services:
             main: 5432
       interfaces:
         frontend: \${{ services['stateful-app'].interfaces.main.url }}
-      `
+      `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
         'test/component': '/architect.yml',
@@ -423,22 +432,23 @@ services:
       } catch (e: any) {
         err = e;
       }
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(3);
       expect(errors.map(e => e.path)).members([
         'services.stateful-app.depends_on',
         'services.api.depends_on',
-        'services.backend.depends_on'
-      ])
+        'services.backend.depends_on',
+      ]);
+      expect(process.exitCode).eq(1);
     });
-  })
+  });
 
   describe('component validation', () => {
     it('invalid component name', async () => {
       const component_config = `
       name: test_component
-      `
+      `;
 
       mock_fs({
         '/component.yml': component_config,
@@ -455,18 +465,19 @@ services:
         err = e;
       }
 
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(1);
       expect(errors.map(e => e.path)).members([
         'name',
-      ])
+      ]);
       expect(errors[0].message).includes('architect/component-name');
       expect(errors[0].component).eq('test_component');
       expect(errors[0].start?.row).eq(2);
       expect(errors[0].start?.column).eq(12);
       expect(errors[0].end?.row).eq(2);
       expect(errors[0].end?.column).eq(26);
+      expect(process.exitCode).eq(1);
     });
 
     it('invalid key value', async () => {
@@ -479,7 +490,7 @@ services:
           \${{ secrets.environment == 'local' }}:
             environment:
               TEST: 1
-      `
+      `;
 
       mock_fs({
         '/component.yml': component_config,
@@ -496,17 +507,18 @@ services:
         err = e;
       }
 
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(1);
       expect(errors.map(e => e.path)).members([
         `services.app.\${{ secrets.environment == 'local' }}`,
-      ])
+      ]);
       expect(errors[0].invalid_key).is.true;
       expect(errors[0].start?.row).eq(7);
       expect(errors[0].start?.column).eq(11);
       expect(errors[0].end?.row).eq(7);
       expect(errors[0].end?.column).eq(48);
+      expect(process.exitCode).eq(1);
     });
 
     it('invalid component secret keys', async () => {
@@ -519,7 +531,7 @@ services:
         test%%%%: test
         test***test:
           default: test
-      `
+      `;
 
       mock_fs({
         '/component.yml': component_config,
@@ -536,14 +548,15 @@ services:
         err = e;
       }
 
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(2);
       expect(errors.map(e => e.path)).members([
         'secrets.test%%%%',
-        'secrets.test***test'
-      ])
+        'secrets.test***test',
+      ]);
       expect(errors[0].message).includes(Slugs.ComponentSecretDescription);
+      expect(process.exitCode).eq(1);
     });
 
     it('invalid secret ref', async () => {
@@ -555,7 +568,7 @@ services:
         api:
           environment:
             TEST: \${{ secret.test }}
-      `
+      `;
 
       mock_fs({
         '/component.yml': component_config,
@@ -572,19 +585,20 @@ services:
         err = e;
       }
 
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(1);
 
       expect(errors.map(e => e.path)).members([
         'services.api.environment.TEST',
-      ])
+      ]);
       expect(errors[0].message).includes('secrets.test');
       expect(errors[0].component).eq('test/component');
       expect(errors[0].start?.row).eq(8);
       expect(errors[0].start?.column).eq(23);
       expect(errors[0].end?.row).eq(8);
       expect(errors[0].end?.column).eq(33);
+      expect(process.exitCode).eq(1);
     });
 
     it('invalid component interfaces ref', async () => {
@@ -597,7 +611,7 @@ services:
             EXT_OTHER_ADDR: \${{ dependencies.test/other.ingresses.fake.url }}
       dependencies:
         test/other: latest
-      `
+      `;
       const other_component_config = `
       name: test/other
       interfaces:
@@ -606,7 +620,7 @@ services:
         api:
           interfaces:
             main: 8080
-      `
+      `;
 
       mock_fs({
         '/component.yml': component_config,
@@ -614,25 +628,26 @@ services:
       });
       const manager = new LocalDependencyManager(axios.create(), {
         'test/component': '/component.yml',
-        'test/other': '/other-component.yml'
+        'test/other': '/other-component.yml',
       });
       let err;
       try {
         await manager.getGraph([
           await manager.loadComponentSpec('test/component'),
-          await manager.loadComponentSpec('test/other')
+          await manager.loadComponentSpec('test/other'),
         ]);
       } catch (e: any) {
         err = e;
       }
 
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(2);
       expect(errors.map(e => e.path)).members([
         'services.api.environment.OTHER_ADDR',
-        'services.api.environment.EXT_OTHER_ADDR'
-      ])
+        'services.api.environment.EXT_OTHER_ADDR',
+      ]);
+      expect(process.exitCode).eq(1);
     });
 
     it('invalid services interfaces ref', async () => {
@@ -649,7 +664,7 @@ services:
         other-api:
           interfaces:
             not-fake: 8080
-      `
+      `;
 
       mock_fs({
         '/component.yml': component_config,
@@ -665,14 +680,15 @@ services:
       } catch (e: any) {
         err = e;
       }
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(3);
       expect(errors.map(e => e.path)).members([
         'services.api.environment.OTHER_ADDR',
         'services.api.environment.INT_OTHER_ADDR',
-        'services.api.environment.EXT_OTHER_ADDR'
-      ])
+        'services.api.environment.EXT_OTHER_ADDR',
+      ]);
+      expect(process.exitCode).eq(1);
     });
 
     it('invalid services ref', async () => {
@@ -685,7 +701,7 @@ services:
         api:
           interfaces:
             main: 8080
-      `
+      `;
 
       mock_fs({
         '/component.yml': component_config,
@@ -701,15 +717,16 @@ services:
       } catch (e: any) {
         err = e;
       }
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(2);
       expect(errors.map(e => e.path)).members([
         'interfaces.api.url',
-        'interfaces.api2.url'
-      ])
-      expect(errors[0].message).includes('services.api.interfaces.main.url')
-      expect(errors[1].message).includes('services.api.interfaces.main.url')
+        'interfaces.api2.url',
+      ]);
+      expect(errors[0].message).includes('services.api.interfaces.main.url');
+      expect(errors[1].message).includes('services.api.interfaces.main.url');
+      expect(process.exitCode).eq(1);
     });
 
     it('deploy time validation', async () => {
@@ -726,7 +743,7 @@ services:
           liveness_probe:
             path: http://localhost/
             port: 8080
-      `
+      `;
       mock_fs({
         '/component.yml': component_config,
       });
@@ -741,12 +758,13 @@ services:
       } catch (e: any) {
         err = e;
       }
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(1);
       expect(errors.map(e => e.path)).members([
         "services.api.liveness_probe.path",
-      ])
+      ]);
+      expect(process.exitCode).eq(1);
     });
 
 
@@ -760,7 +778,7 @@ services:
           labels:
             environment: dev
             environment2: \${{ secrets.environment }}
-      `
+      `;
       mock_fs({
         '/component.yml': component_config,
       });
@@ -790,7 +808,7 @@ services:
             environment: dev
             environment2: \${{ secrets.environment }}
             architect.io/Environment: dev
-      `
+      `;
       mock_fs({
         '/component.yml': component_config,
       });
@@ -822,7 +840,7 @@ services:
         app:
           labels:
             architect.io.architect.io.architect.io.architect.io.architect.io.architect.io/architect.io: architect.io
-      `
+      `;
       mock_fs({
         '/component.yml': component_config,
       });
@@ -841,6 +859,7 @@ services:
       const errors = JSON.parse(err.message);
       expect(errors).lengthOf(1);
       expect(errors[0].message).eq('Invalid key: architect.io.architect.io.architect.io.architect.io.architect.io.architect.io/architect.io');
+      expect(process.exitCode).eq(1);
     });
   });
 
@@ -855,14 +874,14 @@ services:
             OTHER_ADDR: \${{ dependencies.test/other.interfaces.fake.url }}
       dependencies:
         test/other: latest
-      `
+      `;
 
       const other_component_config = `
       name: test/other
       services:
         api:
           image: test
-      `
+      `;
       mock_fs({
         '/test-file.txt': `some file text\non another line`,
         '/component.yml': component_config,
@@ -871,31 +890,32 @@ services:
 
       const manager = new LocalDependencyManager(axios.create(), {
         'test/component': '/component.yml',
-        'test/other': '/other-component.yml'
+        'test/other': '/other-component.yml',
       });
       let err;
       try {
         await manager.getGraph([
           await manager.loadComponentSpec('test/component'),
-          await manager.loadComponentSpec('test/other')
+          await manager.loadComponentSpec('test/other'),
         ]);
       } catch (e: any) {
         err = e;
       }
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(1);
       expect(errors.map(e => e.path)).members([
         'services.api.environment.OTHER_ADDR',
-      ])
+      ]);
       expect(errors[0].start).to.deep.equal({
         row: 7,
-        column: 29
-      })
+        column: 29,
+      });
       expect(errors[0].end).to.deep.equal({
         row: 7,
-        column: 71
-      })
+        column: 71,
+      });
+      expect(process.exitCode).eq(1);
     });
   });
 
@@ -921,7 +941,7 @@ services:
             REQUIRED_IMPLICIT: \${{ secrets.required-implicit }}
             REQUIRED_EXPLICIT: \${{ secrets.required-explicit }}
             NOT_REQUIRED: \${{ secrets.not-required }}
-      `
+      `;
       mock_fs({
         '/component.yml': component_config,
       });
@@ -936,17 +956,18 @@ services:
       } catch (e: any) {
         err = e;
       }
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(3);
       expect(errors.map(e => e.path)).members([
         'secrets.required',
         'secrets.required-implicit',
         'secrets.required-explicit',
-      ])
+      ]);
       expect([...new Set(errors.map(e => e.component))]).members([
         'test/component',
-      ])
+      ]);
+      expect(process.exitCode).eq(1);
     });
 
     it('required dependency secret', async () => {
@@ -965,7 +986,7 @@ services:
       interfaces:
         echo:
           url: \${{ services.api.interfaces.main.url }}
-      `
+      `;
 
       const component_config2 = `
       name: examples/hello-world2
@@ -984,7 +1005,7 @@ services:
       interfaces:
         echo:
           url: \${{ services.api.interfaces.main.url }}
-      `
+      `;
 
       mock_fs({
         '/architect.yml': component_config,
@@ -1004,32 +1025,33 @@ services:
       } catch (e: any) {
         err = e;
       }
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(1);
       expect(errors.map(e => e.path)).members([
         'secrets.aws_secret',
-      ])
+      ]);
       expect([...new Set(errors.map(e => e.component))]).members([
         'examples/hello-world2',
-      ])
+      ]);
+      expect(process.exitCode).eq(1);
     });
   });
 
   it('valid component keys in values files pass validation', () => {
     const values_dict = {
       "*": {
-        "POSTGRES_HOST": "172.17.0.1"
+        "POSTGRES_HOST": "172.17.0.1",
       },
       "architect/cloud": {
-        "TEST": "string"
-      }
+        "TEST": "string",
+      },
 
     };
 
     let passed_validation = false;
     try {
-      SecretsConfig.validate(values_dict)
+      SecretsConfig.validate(values_dict);
       passed_validation = true;
     } catch (e: any) { }
     expect(passed_validation).true;
@@ -1038,13 +1060,13 @@ services:
   it('invalid component keys in values files fail validation', () => {
     const values_dict = {
       "architect_cloud:latest": {
-        "TEST": "string"
-      }
+        "TEST": "string",
+      },
     };
 
     let err;
     try {
-      SecretsConfig.validate(values_dict)
+      SecretsConfig.validate(values_dict);
     } catch (e: any) {
       err = e;
     }
@@ -1052,18 +1074,19 @@ services:
     const errors = JSON.parse(err.message);
     expect(errors).lengthOf(1);
     expect(errors[0].path).eq(`architect_cloud:latest`);
+    expect(process.exitCode).eq(1);
   });
 
   it('invalid value keys in values files fail validation', () => {
     const values_dict = {
       "architect/cloud": {
-        "TE@ST": "string"
-      }
+        "TE@ST": "string",
+      },
     };
 
     let err;
     try {
-      SecretsConfig.validate(values_dict)
+      SecretsConfig.validate(values_dict);
     } catch (e: any) {
       err = e;
     }
@@ -1076,12 +1099,12 @@ services:
   it('component values are defined in an object', () => {
     const values_dict = {
       "architect/cloud": [],
-      "architect/cloud@v2": 'string'
+      "architect/cloud@v2": 'string',
     };
 
     let err;
     try {
-      SecretsConfig.validate(values_dict as any)
+      SecretsConfig.validate(values_dict as any);
     } catch (e: any) {
       err = e;
     }
@@ -1090,24 +1113,25 @@ services:
     expect(errors).lengthOf(2);
     expect(errors[0].path).eq(`architect/cloud`);
     expect(errors[1].path).eq(`architect/cloud@v2`);
+    expect(process.exitCode).eq(1);
   });
 
   it('component values are strings only', () => {
     const values_dict = {
       "architect/cloud": {
-        'test': 'test value'
+        'test': 'test value',
       },
       "architect/cloud@v2": {
-        'ANOTHER_test': 'another value'
+        'ANOTHER_test': 'another value',
       },
       "architect/*": {
-        'ANOTHER_test': 'another value'
-      }
+        'ANOTHER_test': 'another value',
+      },
     };
 
     let err;
     try {
-      SecretsConfig.validate(values_dict)
+      SecretsConfig.validate(values_dict);
     } catch (e: any) {
       err = e;
     }
@@ -1125,7 +1149,7 @@ services:
             min_replicas: 1
             max_replicas: 1
             metrics:
-      `
+      `;
     mock_fs({
       '/component.yml': component_config,
     });
@@ -1140,13 +1164,14 @@ services:
     } catch (e: any) {
       err = e;
     }
-    expect(err).instanceOf(ValidationErrors)
+    expect(err).instanceOf(ValidationErrors);
     const errors = JSON.parse(err.message) as ValidationError[];
     expect(errors).lengthOf(1);
     expect(errors.map(e => e.path)).members([
       'services.api.scaling.metrics',
-    ])
-  })
+    ]);
+    expect(process.exitCode).eq(1);
+  });
 
   it('valid interface number', async () => {
     const component_config = `
@@ -1155,7 +1180,7 @@ services:
         app:
           interfaces:
             main: 3000
-      `
+      `;
     mock_fs({
       '/component.yml': component_config,
     });
@@ -1181,7 +1206,7 @@ services:
         app:
           interfaces:
             main: "3000"
-      `
+      `;
     mock_fs({
       '/component.yml': component_config,
     });
@@ -1204,6 +1229,7 @@ services:
     expect(err.message).includes('or must be an interpolation ref ex. ${{ secrets.example }}');
     expect(err.message).includes('or must be number');
     expect(err.message).includes('or must be object');
+    expect(process.exitCode).eq(1);
   });
 
   it('valid interface interpolation reference', async () => {
@@ -1215,7 +1241,7 @@ services:
         app:
           interfaces:
             main: \${{ secrets.app_port }}
-      `
+      `;
     mock_fs({
       '/component.yml': component_config,
     });
@@ -1242,7 +1268,7 @@ services:
         app:
           interfaces:
             main: "3000"
-      `
+      `;
     mock_fs({
       '/component.yml': component_config,
     });
@@ -1265,6 +1291,7 @@ services:
     expect(err.message).includes('or must be an interpolation ref ex. ${{ secrets.example }}');
     expect(err.message).includes('or must be number');
     expect(err.message).includes('or must be object');
+    expect(process.exitCode).eq(1);
   });
 
   it('valid component interface string', async () => {
@@ -1276,7 +1303,7 @@ services:
         app:
           interfaces:
             main: 3000
-      `
+      `;
     mock_fs({
       '/component.yml': component_config,
     });
@@ -1304,7 +1331,7 @@ services:
         app:
           interfaces:
             main: 3000
-      `
+      `;
     mock_fs({
       '/component.yml': component_config,
     });
@@ -1326,6 +1353,7 @@ services:
     expect(err.message).includes(`interfaces.main`);
     expect(err.message).includes('must be object');
     expect(err.message).includes('must be string');
+    expect(process.exitCode).eq(1);
   });
 
   it('invalid component interface number', async () => {
@@ -1336,7 +1364,7 @@ services:
         app:
           interfaces:
             main: 3000
-      `
+      `;
     mock_fs({
       '/component.yml': component_config,
     });
@@ -1357,6 +1385,7 @@ services:
     expect(errors).lengthOf(1);
     expect(err.message).includes(`interfaces`);
     expect(err.message).includes('must be object');
+    expect(process.exitCode).eq(1);
   });
 
   it('valid command', async () => {
@@ -1367,7 +1396,7 @@ services:
       services:
         app:
           command: catalina.sh run -Pprofile=\${{ secrets.SPRING_PROFILE }} --test-string "two words" --test-env $API_KEY
-      `
+      `;
     mock_fs({
       '/component.yml': component_config,
     });
@@ -1379,7 +1408,7 @@ services:
       await manager.loadComponentSpec('test/component'),
     ]);
     const service_node = graph.nodes.find((node) => node instanceof ServiceNode) as ServiceNode;
-    expect(service_node.config.command).to.deep.equal(['catalina.sh', 'run', '-Pprofile=test', '--test-string', 'two words', '--test-env', '$API_KEY'])
+    expect(service_node.config.command).to.deep.equal(['catalina.sh', 'run', '-Pprofile=test', '--test-string', 'two words', '--test-env', '$API_KEY']);
   });
 
   it('liveness_probe rejects command with path', async () => {
@@ -1394,7 +1423,7 @@ services:
               - /bin/bash
               - health.sh
             path: /test
-      `
+      `;
     mock_fs({
       '/component.yml': component_config,
     });
@@ -1409,13 +1438,14 @@ services:
     } catch (e: any) {
       err = e;
     }
-    expect(err).instanceOf(ValidationErrors)
+    expect(err).instanceOf(ValidationErrors);
     const errors = JSON.parse(err.message) as ValidationError[];
     expect(errors).lengthOf(1);
     expect(errors.map(e => e.path)).members([
       'services.api.liveness_probe',
-    ])
-  })
+    ]);
+    expect(process.exitCode).eq(1);
+  });
 
   it('liveness_probe rejects command with port', async () => {
     const component_config = `
@@ -1429,7 +1459,7 @@ services:
               - /bin/bash
               - health.sh
             port: 3000
-      `
+      `;
     mock_fs({
       '/component.yml': component_config,
     });
@@ -1444,13 +1474,14 @@ services:
     } catch (e: any) {
       err = e;
     }
-    expect(err).instanceOf(ValidationErrors)
+    expect(err).instanceOf(ValidationErrors);
     const errors = JSON.parse(err.message) as ValidationError[];
     expect(errors).lengthOf(1);
     expect(errors.map(e => e.path)).members([
       'services.api.liveness_probe',
     ]);
-  })
+    expect(process.exitCode).eq(1);
+  });
 
   it('liveness_probe accepts command', async () => {
     const component_config = `
@@ -1463,7 +1494,7 @@ services:
             command:
               - /bin/bash
               - health.sh
-      `
+      `;
     mock_fs({
       '/component.yml': component_config,
     });
@@ -1480,7 +1511,7 @@ services:
     }
 
     expect(err).to.be.undefined;
-  })
+  });
 
   it('liveness_probe accepts port and path', async () => {
     const component_config = `
@@ -1492,7 +1523,7 @@ services:
           liveness_probe:
             port: 8080
             path: /health
-      `
+      `;
     mock_fs({
       '/component.yml': component_config,
     });
@@ -1509,7 +1540,7 @@ services:
     }
 
     expect(err).to.be.undefined;
-  })
+  });
 
   it('liveness_probe rejects port without path', async () => {
     const component_config = `
@@ -1536,7 +1567,7 @@ services:
       err = e;
     }
 
-    expect(err).instanceOf(ValidationErrors)
+    expect(err).instanceOf(ValidationErrors);
     const errors = JSON.parse(err.message) as ValidationError[];
     expect(errors).lengthOf(1);
     expect(errors.map(e => e.path)).members([
@@ -1545,7 +1576,8 @@ services:
     expect(errors.map(e => e.message)).members([
       `must have required property 'command' or must have required property 'path' or must match exactly one schema in oneOf`,
     ]);
-  })
+    expect(process.exitCode).eq(1);
+  });
 
   it('liveness_probe rejects path without port', async () => {
     const component_config = `
@@ -1556,7 +1588,7 @@ services:
             main: 8080
           liveness_probe:
             path: /health
-      `
+      `;
     mock_fs({
       '/component.yml': component_config,
     });
@@ -1572,7 +1604,7 @@ services:
       err = e;
     }
 
-    expect(err).instanceOf(ValidationErrors)
+    expect(err).instanceOf(ValidationErrors);
     const errors = JSON.parse(err.message) as ValidationError[];
     expect(errors).lengthOf(1);
     expect(errors.map(e => e.path)).members([
@@ -1581,7 +1613,8 @@ services:
     expect(errors.map(e => e.message)).members([
       `must have required property 'command' or must have required property 'port' or must match exactly one schema in oneOf`,
     ]);
-  })
+    expect(process.exitCode).eq(1);
+  });
 
   it('throw error for trying to expose incorrect interface', async () => {
     const yml = `
@@ -1592,7 +1625,7 @@ services:
           main: 8080
     interfaces:
       app: \${{ services.app.interfaces.main.url }}
-    `
+    `;
 
     mock_fs({
       '/stack/architect.yml': yml,
@@ -1611,13 +1644,14 @@ services:
       err = e;
     }
 
-    expect(err).instanceOf(ValidationErrors)
+    expect(err).instanceOf(ValidationErrors);
     const errors = JSON.parse(err.message) as ValidationError[];
     expect(errors).lengthOf(1);
     expect(errors.map(e => e.path)).members([
       'interfaces.appppp',
     ]);
-    expect(errors[0].message).to.include('interfaces.app')
+    expect(errors[0].message).to.include('interfaces.app');
+    expect(process.exitCode).eq(1);
   });
 
   describe('validate if statements', () => {
@@ -1627,7 +1661,7 @@ services:
       \${{ if true }}:
         secrets:
           test: test
-      `
+      `;
 
       let err;
       try {
@@ -1636,13 +1670,14 @@ services:
         err = e;
       }
 
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(1);
       expect(errors.map(e => e.path)).members([
         '${{ if true }}',
       ]);
-    })
+      expect(process.exitCode).eq(1);
+    });
 
     it('cannot use if statement in secrets block', async () => {
       const yml = `
@@ -1650,7 +1685,7 @@ services:
       secrets:
         \${{ if true }}:
           test: test
-      `
+      `;
 
       let err;
       try {
@@ -1659,13 +1694,14 @@ services:
         err = e;
       }
 
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(1);
       expect(errors.map(e => e.path)).members([
         'secrets.${{ if true }}',
       ]);
-    })
+      expect(process.exitCode).eq(1);
+    });
 
     it('cannot use if statement in secret value block', async () => {
       const yml = `
@@ -1674,7 +1710,7 @@ services:
         test:
           \${{ if true }}:
             default: test
-      `
+      `;
 
       let err;
       try {
@@ -1683,13 +1719,14 @@ services:
         err = e;
       }
 
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(1);
       expect(errors.map(e => e.path)).members([
         'secrets.test.${{ if true }}',
       ]);
-    })
+      expect(process.exitCode).eq(1);
+    });
 
     it('cannot use if statement in dependencies block', async () => {
       const yml = `
@@ -1697,7 +1734,7 @@ services:
       dependencies:
         \${{ if true }}:
           test/dependency: latest
-      `
+      `;
 
       let err;
       try {
@@ -1706,13 +1743,14 @@ services:
         err = e;
       }
 
-      expect(err).instanceOf(ValidationErrors)
+      expect(err).instanceOf(ValidationErrors);
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(1);
       expect(errors.map(e => e.path)).members([
         'dependencies.${{ if true }}',
       ]);
-    })
+      expect(process.exitCode).eq(1);
+    });
 
     it('can use if statement in service block', async () => {
       const yml = `
@@ -1724,8 +1762,8 @@ services:
           \${{ if true }}:
             environment:
               TEST2: 2
-      `
+      `;
       buildSpecFromYml(yml);
-    })
-  })
+    });
+  });
 });


### PR DESCRIPTION
## Overview
This diff cleans up some of the Sentry code as well as fixes how it handles exit codes.

## Changes
1. Migrated most code into the sentry class and out of base command
2. Added tests to make sure exit codes get set on error for regsiter
3. Cleaned up some of the logic to decouple Oclif and Sentry
4. Switched the debug logs to now use Oclif debug. We will most likely migrate off those, but this is not a blocker. To view the logs just put `DEBUG=architect:* ` before any command.

Worked on it in conjunction with Devin.

## Testing
### Basic Tests
`npm run test`
### Error Code
`architect-dev register .
/examples/react-app/architect.yml --architecture not-real`
This will fail since the architecture is not real. Then check the error code with
`echo $?` which should return `1`.
You can also see the error logs appear in Sentry.
### Working
`architect-dev register .
/examples/react-app/architect.yml --architecture not-real`
`echo $?` which should return `0`.

***Edit:** Gitlab issue: https://gitlab.com/architect-io/architect-cli/-/issues/472*