### PR TITLE
Automatically detect proper value for flags.tty if not explicitly set

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ env:
 jobs:
   build_run:
     runs-on: ubuntu-latest
+    env:
+      XDG_CACHE_HOME: ~/.cache/architect
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -21,6 +23,7 @@ jobs:
       - run: rm -r node_modules
       - run: npm ci --omit=dev
       - run: ./bin/run --version
+      - run: rm -rf $XDG_CACHE_HOME # Remove oclif cache to prevent plugin-warn-if-update-available from showing warning
       - run: | # Check if stderr is not empty and hard error (captures node warnings)
           error=$(./bin/run --version 2>&1 >/dev/null)
           [ ! -z "$error" ] && echo "$error" && exit 1 || echo "No error"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,6 @@ env:
 jobs:
   build_run:
     runs-on: ubuntu-latest
-    env:
-      XDG_CACHE_HOME: ~/.cache/architect
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -23,7 +21,7 @@ jobs:
       - run: rm -r node_modules
       - run: npm ci --omit=dev
       - run: ./bin/run --version
-      - run: rm -rf $XDG_CACHE_HOME # Remove oclif cache to prevent plugin-warn-if-update-available from showing warning
+      - run: rm -r node_modules/@oclif/plugin-warn-if-update-available/lib/hooks/ # Remove plugin-warn-if-update-available hook from showing warning
       - run: | # Check if stderr is not empty and hard error (captures node warnings)
           error=$(./bin/run --version 2>&1 >/dev/null)
           [ ! -z "$error" ] && echo "$error" && exit 1 || echo "No error"

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -1,5 +1,4 @@
 import { Flags } from '@oclif/core';
-import chalk from 'chalk';
 import inquirer from 'inquirer';
 import stream from 'stream';
 import stringArgv from 'string-argv';
@@ -43,7 +42,7 @@ export default class Exec extends BaseCommand {
     tty: {
       non_sensitive: true,
       ...Flags.boolean({
-        description: 'Stdin is a TTY.',
+        description: 'Stdin is a TTY. If the flag isn\'t supplied, tty or no-tty is automatically detected.',
         char: 't',
         allowNo: true,
         default: undefined,
@@ -79,6 +78,8 @@ export default class Exec extends BaseCommand {
 
       if (flags.stdin) {
         if (flags.tty) {
+          // This method is only available when stdin is a TTY as it's part of the tty.ReadStream class:
+          // https://nodejs.org/api/tty.html#readstreamsetrawmodemode
           process.stdin.setRawMode(true);
         }
         process.stdin.pipe(this.getInputTransform()).pipe(duplex);
@@ -253,7 +254,6 @@ export default class Exec extends BaseCommand {
         flags.tty = true;
       } else {
         flags.tty = false;
-        this.log(chalk.yellow('stdin does not support tty and was automatically disabled, --no-tty should be used'));
       }
     } else if (flags.tty && !process.stdin.isTTY) {
       throw new ArchitectError('stdin does not support tty');

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -250,11 +250,8 @@ export default class Exec extends BaseCommand {
 
     // Automatically set tty if the user doesn't supply it based on whether stdin is TTY.
     if (flags.tty === undefined) {
-      if (process.stdin.isTTY) {
-        flags.tty = true;
-      } else {
-        flags.tty = false;
-      }
+      // NOTE: stdin.isTTY is undefined if stdin is not a TTY, which is why this is a double negation.
+      flags.tty = !!process.stdin.isTTY;
     } else if (flags.tty && !process.stdin.isTTY) {
       throw new ArchitectError('stdin does not support tty');
     }

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -1,4 +1,5 @@
 import { Flags } from '@oclif/core';
+import { OutputArgs, OutputFlags } from '@oclif/core/lib/interfaces';
 import inquirer from 'inquirer';
 import stream from 'stream';
 import stringArgv from 'string-argv';
@@ -9,17 +10,6 @@ import AccountUtils from '../architect/account/account.utils';
 import { EnvironmentUtils, Replica } from '../architect/environment/environment.utils';
 import BaseCommand from '../base-command';
 import { DockerComposeUtils } from '../common/docker-compose';
-
-
-type ExecFlags = {
-  stdin: boolean;
-  tty: boolean;
-  environment: string | undefined;
-  account: string | undefined;
-  json: boolean | undefined;
-};
-
-type ExecArgs = { [name: string]: any };
 
 export default class Exec extends BaseCommand {
   async auth_required(): Promise<boolean> {
@@ -69,7 +59,7 @@ export default class Exec extends BaseCommand {
   public static readonly StderrStream = 2;
   public static readonly StatusStream = 3;
 
-  async exec(uri: string, flags: ExecFlags): Promise<void> {
+  async exec(uri: string, flags: OutputFlags<typeof Exec['flags']>): Promise<void> {
     const ws = await this.getWebSocket(uri);
 
     await new Promise((resolve, reject) => {
@@ -179,7 +169,7 @@ export default class Exec extends BaseCommand {
     return transform;
   }
 
-  async runRemote(account: Account, args: ExecArgs, flags: ExecFlags): Promise<void> {
+  async runRemote(account: Account, args: OutputArgs, flags: OutputFlags<typeof Exec['flags']>): Promise<void> {
     const environment = await EnvironmentUtils.getEnvironment(this.app.api, account, flags.environment);
 
     let component_account_name: string | undefined;
@@ -224,7 +214,7 @@ export default class Exec extends BaseCommand {
     await this.exec(uri, flags);
   }
 
-  async runLocal(args: ExecArgs, flags: ExecFlags): Promise<void> {
+  async runLocal(args: OutputArgs, flags: OutputFlags<typeof Exec['flags']>): Promise<void> {
     const environment_name = await DockerComposeUtils.getLocalEnvironment(this.app.config.getConfigDir(), flags.environment);
     const compose_file = DockerComposeUtils.buildComposeFilepath(this.app.config.getConfigDir(), environment_name);
     const service = await DockerComposeUtils.getLocalServiceForEnvironment(compose_file, args.resource);

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -21,8 +21,8 @@ export default class Exec extends BaseCommand {
   static examples = [
     'architect exec -- ls',
     'architect exec -- /bin/sh',
-    'architect exec --account architect --environment example example-component.services.app -- /bin/sh'
-  ]
+    'architect exec --account architect --environment example example-component.services.app -- /bin/sh',
+  ];
 
   static flags = {
     ...BaseCommand.flags,

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -18,6 +18,11 @@ export default class Exec extends BaseCommand {
 
   static description = 'Exec into service instances';
   static usage = 'exec [RESOURCE] [FLAGS] -- [COMMAND]';
+  static examples = [
+    'architect exec -- ls',
+    'architect exec -- /bin/sh',
+    'architect exec --account architect --environment example example-component.services.app -- /bin/sh'
+  ]
 
   static flags = {
     ...BaseCommand.flags,

--- a/test/commands/exec.test.ts
+++ b/test/commands/exec.test.ts
@@ -28,14 +28,14 @@ describe('exec', () => {
 
   defaults
     .stdout()
-    .command(['exec', '-a', account.name, '-e', environment.name, '--no-tty', '--', 'ls', '-la'])
+    .command(['exec', '-a', account.name, '-e', environment.name, '--', 'ls', '-la'])
     .it('exec command with spaces', ctx => {
       expect(ctx.stdout).to.equal('worked\n')
     })
 
   defaults
     .stdout()
-    .command(['exec', '-a', account.name, '-e', environment.name, '--no-tty', 'examples/react-app', '--', 'ls', '-la'])
+    .command(['exec', '-a', account.name, '-e', environment.name, 'examples/react-app', '--', 'ls', '-la'])
     .it('exec component and command with spaces', ctx => {
       expect(ctx.stdout).to.equal('worked\n')
     })

--- a/test/commands/exec.test.ts
+++ b/test/commands/exec.test.ts
@@ -28,14 +28,14 @@ describe('exec', () => {
 
   defaults
     .stdout()
-    .command(['exec', '-a', account.name, '-e', environment.name, '--', 'ls', '-la'])
+    .command(['exec', '-a', account.name, '-e', environment.name, '--no-tty', '--', 'ls', '-la'])
     .it('exec command with spaces', ctx => {
       expect(ctx.stdout).to.equal('worked\n')
     })
 
   defaults
     .stdout()
-    .command(['exec', '-a', account.name, '-e', environment.name, 'examples/react-app', '--', 'ls', '-la'])
+    .command(['exec', '-a', account.name, '-e', environment.name, '--no-tty', 'examples/react-app', '--', 'ls', '-la'])
     .it('exec component and command with spaces', ctx => {
       expect(ctx.stdout).to.equal('worked\n')
     })


### PR DESCRIPTION
Thanks to the beauty of StackOverflow, I found an easy way to run `architect exec` with no tty: https://superuser.com/a/1430883


I used the following test script to run exec:
```sh
#!/bin/sh
XDG_CONFIG_HOME=~/.config/architect/local/architect /Users/tyler/code/architect/architect-cli/bin/dev exec -a tyler-aldrich -e example-environment -- "sh -c \"ls -la && echo 'hi'\""
```

Running this on this branch now gives the following output:
```
~/code/architect/architect-cli (detect-notty-automatically*) » true | (setsid ./test-script.sh) 2>&1                                                                                  
stdin does not support tty and was automatically disabled, --no-tty should be used
total 68
drwxr-xr-x    1 root     root           116 Aug  4 18:33 .
drwxr-xr-x    1 root     root            17 Jul 20 16:49 ..
-rw-r--r--    1 root     root            15 Jul  5 16:58 .gitignore
-rw-r--r--    1 root     root           107 Jul  5 16:58 Dockerfile
-rw-r--r--    1 root     root          1901 Jul  5 16:58 README.md
-rw-r--r--    1 root     root           537 Aug  4 18:08 architect.yml
-rw-r--r--    1 root     root           341 Aug  4 15:36 index.js
drwxr-xr-x   59 root     root          4096 Jul 20 16:50 node_modules
-rw-r--r--    1 root     root         39745 Jul 20 16:50 package-lock.json
-rw-r--r--    1 root     root           291 Jul  5 16:58 package.json
hi
```

If you add the --no-tty flag, the warning goes away:
```
~/code/architect/architect-cli (detect-notty-automatically*) » true | (setsid ./test-script.sh) 2>&1                                                                                 
total 68
drwxr-xr-x    1 root     root           116 Aug  4 18:33 .
drwxr-xr-x    1 root     root            17 Jul 20 16:49 ..
-rw-r--r--    1 root     root            15 Jul  5 16:58 .gitignore
-rw-r--r--    1 root     root           107 Jul  5 16:58 Dockerfile
-rw-r--r--    1 root     root          1901 Jul  5 16:58 README.md
-rw-r--r--    1 root     root           537 Aug  4 18:08 architect.yml
-rw-r--r--    1 root     root           341 Aug  4 15:36 index.js
drwxr-xr-x   59 root     root          4096 Jul 20 16:50 node_modules
-rw-r--r--    1 root     root         39745 Jul 20 16:50 package-lock.json
-rw-r--r--    1 root     root           291 Jul  5 16:58 package.json
hi
```

Running with `setsid` and `--tty` explicitly passed fails as expected:
```
~/code/architect/architect-cli (detect-notty-automatically*) » true | (setsid ./test-script.sh) 2>&1                                                                                  
stdin does not support tty
Error: stdin does not support tty
    at Exec.run (/Users/tyler/code/architect/architect-cli/src/commands/exec.ts:259:13)
    at async Exec._run (/Users/tyler/code/architect/architect-cli/node_modules/@oclif/core/lib/command.js:67:22)
    at async Config.runCommand (/Users/tyler/code/architect/architect-cli/node_modules/@oclif/core/lib/config/config.js:268:25)
    at async Object.run (/Users/tyler/code/architect/architect-cli/node_modules/@oclif/core/lib/main.js:73:5)
```

Running this command without `setsid` (and therefore with a tty) works as expected:
```
~/code/architect/architect-cli (detect-notty-automatically*) » ./test-script.sh                                                                                                       tyler@tylers-mbp
total 68
drwxr-xr-x    1 root     root           116 Aug  4 18:33 .
drwxr-xr-x    1 root     root            17 Jul 20 16:49 ..
-rw-r--r--    1 root     root            15 Jul  5 16:58 .gitignore
-rw-r--r--    1 root     root           107 Jul  5 16:58 Dockerfile
-rw-r--r--    1 root     root          1901 Jul  5 16:58 README.md
-rw-r--r--    1 root     root           537 Aug  4 18:08 architect.yml
-rw-r--r--    1 root     root           341 Aug  4 15:36 index.js
drwxr-xr-x   59 root     root          4096 Jul 20 16:50 node_modules
-rw-r--r--    1 root     root         39745 Jul 20 16:50 package-lock.json
-rw-r--r--    1 root     root           291 Jul  5 16:58 package.json
hi
```