### PR TITLE
Handle multiple arguments after -- without requiring quotes

### DIFF
--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -77,10 +77,11 @@ export default abstract class BaseCommand extends Command {
 
     // Support -- input ex. architect exec -- ls -la
     const double_dash_index = argv.indexOf('--');
+    let command: string[] = [];
     if (double_dash_index >= 0) {
-      const command = argv.slice(double_dash_index + 1, argv.length).join(' ');
+      command = argv.slice(double_dash_index + 1, argv.length);
       argv = argv.slice(0, double_dash_index);
-      argv.unshift(command);
+      argv.unshift(command.join(' '));
     }
 
     const args = [];
@@ -103,7 +104,11 @@ export default abstract class BaseCommand extends Command {
       }
     }
 
-    return super.parse(options, [...args, ...flags]);
+    const parsed = await super.parse(options, [...args, ...flags]) as Interfaces.ParserOutput<F, A>;
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    parsed.args.command_array = command;
+    return parsed;
   }
 
   async finally(err: Error | undefined): Promise<any> {

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -3,7 +3,6 @@ import { OutputArgs, OutputFlags } from '@oclif/core/lib/interfaces';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import stream from 'stream';
-import stringArgv from 'string-argv';
 import WebSocket, { createWebSocketStream } from 'ws';
 import { ArchitectError, Dictionary, parseUnknownSlug } from '../';
 import Account from '../architect/account/account.entity';
@@ -246,7 +245,7 @@ export default class Exec extends BaseCommand {
       query.append('stdin', 'true');
     }
 
-    for (const arg of stringArgv(args.command)) {
+    for (const arg of args.command_array) {
       query.append('command', arg);
     }
 
@@ -266,7 +265,7 @@ export default class Exec extends BaseCommand {
     }
     compose_args.push(service.name);
 
-    for (const arg of stringArgv(args.command)) {
+    for (const arg of args.command_array) {
       compose_args.push(arg);
     }
 

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -275,6 +275,10 @@ export default class Exec extends BaseCommand {
   async run(): Promise<void> {
     inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'));
 
+    if (this.argv.indexOf('--') === -1) {
+      this.error(chalk.red('Command must be provided after --\n(e.g. "architect exec -- ls")'));
+    }
+
     const { args, flags } = await this.parse(Exec);
 
     // Automatically set tty if the user doesn't supply it based on whether stdin is TTY.

--- a/test/commands/exec.test.ts
+++ b/test/commands/exec.test.ts
@@ -6,13 +6,13 @@ import { MOCK_API_HOST } from '../utils/mocks';
 describe('exec', () => {
   const account = {
     name: 'examples',
-    id: '1'
-  }
+    id: '1',
+  };
   const environment = {
     name: 'test',
-    id: '1'
-  }
-  const replicas: Replica[] = [{ ext_ref: 'ext', node_ref: 'node-ref', resource_ref: 'resource-ref', created_at: new Date().toUTCString() }]
+    id: '1',
+  };
+  const replicas: Replica[] = [{ ext_ref: 'ext', node_ref: 'node-ref', resource_ref: 'resource-ref', created_at: new Date().toUTCString() }];
 
   const defaults = test
     .nock(MOCK_API_HOST, api => api
@@ -24,19 +24,24 @@ describe('exec', () => {
     .nock(MOCK_API_HOST, api => api
       .get(new RegExp(`/environments/${environment.id}/replicas.*`))
       .reply(200, replicas))
-    .stub(Exec.prototype, 'exec', () => { console.log('worked'); })
+    .stub(Exec.prototype, 'exec', () => { console.log('worked'); });
 
   defaults
     .stdout()
     .command(['exec', '-a', account.name, '-e', environment.name, '--', 'ls', '-la'])
     .it('exec command with spaces', ctx => {
-      expect(ctx.stdout).to.equal('worked\n')
-    })
+      expect(ctx.stdout).to.equal('worked\n');
+    });
 
   defaults
     .stdout()
     .command(['exec', '-a', account.name, '-e', environment.name, 'examples/react-app', '--', 'ls', '-la'])
     .it('exec component and command with spaces', ctx => {
-      expect(ctx.stdout).to.equal('worked\n')
-    })
-})
+      expect(ctx.stdout).to.equal('worked\n');
+    });
+
+   test
+    .command(['exec', '-a', account.name, '-e', environment.name, 'examples/react-app', 'ls'])
+    .exit(2)
+    .it('exec without -- fails');
+});


### PR DESCRIPTION
- Enforced `--` is used when exec'ing. Our `--help` usage says that this is required and it makes things less confusing, so it is now enforced
- Keep track of the raw argv array of commands so that we can pass that directly to docker/kubectl. 
  - Without keeping track of this, it's impossible to figure out what parts were quoted in the original command (e.g. `sh -c "echo foo"`  would look the same as `sh -c "echo foo"` which the user probably wanted because we join the cmd into a string, and the shell strips the quotes).


Works on remote via kubectl:
```
~/code/architect/architect-cli (exec-multi-command-args*) » architect exec -- sh -c 'echo 1; ls'
? Select an account tyler-aldrich
? Select a environment example-environment
1
Dockerfile         node_modules       package.json
architect.yml      package-lock.json  src
```

And locally via docker:
```
~/code/architect/architect-cli (exec-multi-command-args*) » architect exec -- sh -c 'echo 1; ls'
? Select an account dev (Local Machine)
? Select a service hellow-world.services.my-app-2
1
Dockerfile         node_modules       package.json
architect.yml      package-lock.json  src
```