### PR TITLE
Use local SSL for 

### DIFF
--- a/src/app-config/config.ts
+++ b/src/app-config/config.ts
@@ -21,6 +21,8 @@ export default class AppConfig {
   oauth_client_id: string;
   account: string;
   environment: string;
+  external_https_address: string;
+  external_http_address: string;
 
   constructor(config_dir: string, partial?: Partial<AppConfig>) {
     this.config_dir = config_dir;
@@ -38,6 +40,8 @@ export default class AppConfig {
     this.oauth_client_id = '079Kw3UOB5d2P6yZlyczP9jMNNq8ixds';
     this.account = '';
     this.environment = process.env.TEST === '1' ? ENVIRONMENT.TEST : ENVIRONMENT.PRODUCTION;
+    this.external_https_address = 'localhost.architect.sh';
+    this.external_http_address = 'arc.localhost';
 
     // Override defaults with input values
     Object.assign(this, partial);
@@ -71,6 +75,8 @@ export default class AppConfig {
       oauth_client_id: this.oauth_client_id,
       account: this.account,
       environment: this.environment,
+      external_https_address: this.external_https_address,
+      external_http_address: this.external_http_address,
     };
   }
 }

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -119,7 +119,9 @@ export default class ComponentRegister extends BaseCommand {
         delete interface_config?.host;
       }
     }
-    const full_compose = await DockerComposeUtils.generate(graph);
+
+    // The external address and ssl have no bearing on registration
+    const full_compose = await DockerComposeUtils.generate(graph, this.app.config, false);
 
     const compose: DockerComposeTemplate = {
       version: '3',

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -28,6 +28,7 @@ export class DockerComposeUtils {
       volumes: {},
     };
 
+    const protocol = use_ssl ? 'https' : 'http';
     const external_addr = use_ssl ? app_config.external_https_address : app_config.external_http_address;
     const limit = pLimit(5);
     const port_promises = [];
@@ -186,7 +187,7 @@ export class DockerComposeUtils {
         const liveness_probe = node.config.liveness_probe;
         if (liveness_probe) {
           if (!liveness_probe.command) {
-            liveness_probe.command = ['CMD-SHELL', `curl -f http://localhost:${liveness_probe.port}${liveness_probe.path} || exit 1`]; // deprecated
+            liveness_probe.command = ['CMD-SHELL', `curl -f ${protocol}://localhost:${liveness_probe.port}${liveness_probe.path} || exit 1`]; // deprecated
           } else {
             liveness_probe.command = ['CMD', ...liveness_probe.command];
           }

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -66,7 +66,7 @@ export class DockerComposeUtils {
           certificates: [{
             certFile: '/etc/traefik/fullchain.pem',
             keyFile: '/etc/traefik/privkey.pem',
-          }]
+          }],
         },
         options: {
           default: {
@@ -87,12 +87,12 @@ export class DockerComposeUtils {
           filters: {
             minDuration: '1s',
             statusCodes: '400-599',
-          }
+          },
         },
         providers: {
           docker: {
             exposedByDefault: false,
-            constraints: `Label(\`traefik.port\`,\`${gateway_port}\`)`
+            constraints: `Label(\`traefik.port\`,\`${gateway_port}\`)`,
           },
           // Required to load the TLS configs
           file: {
@@ -102,11 +102,11 @@ export class DockerComposeUtils {
         },
         entrypoints: {
           web: {
-            address: ':' + gateway_port
+            address: ':' + gateway_port,
           },
         },
         ...(use_ssl ? tls_config : {}),
-      }
+      };
       const traefik_yaml = yaml.dump(traefik_config);
       fs.writeFileSync(path.join(app_config.getConfigDir(), `traefik-${gateway_port}.yaml`), traefik_yaml);
 

--- a/src/dependency-manager/manager.ts
+++ b/src/dependency-manager/manager.ts
@@ -26,6 +26,7 @@ export default abstract class DependencyManager {
 
   account?: string;
   external_addr = 'arc.localhost:80';
+  use_ssl = true;
 
   getComponentNodes(component: ComponentConfig): DependencyNode[] {
     const nodes = [];
@@ -507,7 +508,7 @@ export default abstract class DependencyManager {
     // Set component interfaces
     const [external_host, external_port_string] = this.external_addr.split(':');
     const external_port = parseInt(external_port_string);
-    const external_protocol = external_host === 'arc.localhost' ? 'http' : 'https';
+    const external_protocol = this.use_ssl ? 'https' : 'http';
     for (const [interface_name, interface_config] of Object.entries(component_config.interfaces)) {
       const url_regex = new RegExp(`\\\${{\\s*(.*?)\\.url\\s*}}`, 'g');
       const matches = url_regex.exec(interface_config.url);


### PR DESCRIPTION
This adds support for SSL certificates for local development.

## Changes
1. Script to download certificates from a remote bucket. If unable to download them then we cache them for 30 days.
2. Update to traefik to support SSL.
3. Flag to disable SSL

## Testing
1. Test with ssl `architect dev ./examples/react/`
2. Test without ssl `architect dev ./examples/react/ --no-ssl`
3. Test complex applications like ones made by the the project command that use ingresses from other components.
<img width="1240" alt="image" src="https://user-images.githubusercontent.com/532523/185235279-bc7c8669-6ca0-40f9-91cb-0a78f6a92d14.png">
