### PR TITLE
Dev command leaves containers running when process exits with an error

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -74,7 +74,7 @@ const HOST_REGEX = new RegExp(/Host\(`(.*?)`\)/g);
 
   /** Spawns a process running `docker compose stop`  */
   async stop(): Promise<void> {
-    await DockerComposeUtils.dockerCompose(['-f', this.compose_file, '-p', this.project_name, 'stop'], { detached: true });
+    await DockerComposeUtils.dockerCompose(['-f', this.compose_file, '-p', this.project_name, 'stop'], { detached: !this.is_windows });
   }
 
   /** Sends the SIGINT signal to the running `docker compose up` process. */

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -156,7 +156,9 @@ const HOST_REGEX = new RegExp(/Host\(`(.*?)`\)/g);
     this.configureLogs();
 
     DockerComposeUtils.watchContainersHealth(this.compose_file, this.project_name,
-      () => { return this.is_exiting; });
+      () => { return this.is_exiting; }).finally(async () => {
+        await this.stop();
+      });
 
     try {
       await this.compose_process;

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -74,7 +74,7 @@ const HOST_REGEX = new RegExp(/Host\(`(.*?)`\)/g);
 
   /** Spawns a process running `docker compose stop`  */
   async stop(): Promise<void> {
-    await DockerComposeUtils.dockerCompose(['-f', this.compose_file, '-p', this.project_name, 'stop']);
+    await DockerComposeUtils.dockerCompose(['-f', this.compose_file, '-p', this.project_name, 'stop'], { detached: true });
   }
 
   /** Sends the SIGINT signal to the running `docker compose up` process. */

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -539,6 +539,10 @@ export class DockerComposeUtils {
                 await restart(id);
               } catch (err) {
                 console.log(chalk.red(`ERROR: ${service_ref} failed to restart.`));
+                // We awaited again and need to re-check `should_stop()`.
+                if (should_stop()) {
+                  return;
+                }
                 continue;
               }
             }


### PR DESCRIPTION
When we hit this code:

```typescript
try {
    await compose_process;
} catch (ex) {
    if (!is_exiting) {
        throw ex;
    }
}
```

it was possible for the `compose_process` to end (with an error that we throw) - but the process finishing with an error doesn't guarantee that containers get cleaned up. One container may hard-fail, the process ends, and other containers remain running.

To fix that, we now run:
```typescript
    try {
      await this.compose_process;
    } catch (ex) {
      if (!this.is_exiting) {
        // Always call `docker compose stop` here - the process died so there's nothing to kill,
        // need to call `docker compose stop` to clean up any remaining running containers.
        console.error(chalk.red(ex));
        console.log(chalk.red('\nError detected - Stopping running containers...'));
        await this.stop();
      }
    }
```

to call `docker compose stop` after the `compose up` process ends to ensure that containers are stopped. 

I also moved all the code that manages the `docker compose up` process into it's own class to make the logic in this file more easily understandable.
- The `Dev` command class is still handling most of the work
- The `UpProcessManager` now starts/registers the process interrupts/stops the long-running `docker compose up` process and when it's finished running, the `Dev.run` can continue cleanup.


Tested on 
- [x] Mac
- [x] WSL2
- [x] (Windows) Powershell
- [x] (Windows) Cmd