### PR TITLE
fixing healthcheck liveness probe protocol for port/path

### DIFF
--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -61,7 +61,6 @@ export class DockerComposeUtils {
       volumes: {},
     };
 
-    const protocol = use_ssl ? 'https' : 'http';
     const limit = pLimit(5);
     const port_promises = [];
 
@@ -180,7 +179,7 @@ export class DockerComposeUtils {
         const liveness_probe = node.config.liveness_probe;
         if (liveness_probe) {
           if (!liveness_probe.command) {
-            liveness_probe.command = ['CMD-SHELL', `curl -f ${protocol}://localhost:${liveness_probe.port}${liveness_probe.path} || exit 1`]; // deprecated
+            liveness_probe.command = ['CMD-SHELL', `curl -f http://localhost:${liveness_probe.port}${liveness_probe.path} || exit 1`]; // deprecated
           } else {
             liveness_probe.command = ['CMD', ...liveness_probe.command];
           }


### PR DESCRIPTION
Undoes the change [here](https://github.com/architect-team/architect-cli/pull/676/files#diff-c501db4ece42dfe6ff2e5e68da3e74b84a44bb1e6e14bbb53fc920376a11bc0cR183) as a liveness probe shouldn't be using HTTPS