### PR TITLE
Improve error message for Windows PS users

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -80,12 +80,12 @@ export default class Exec extends BaseCommand {
   }>(options?: Interfaces.Input<F>, argv = this.argv): Promise<Interfaces.ParserOutput<F, A>> {
     const double_dash_index = argv.indexOf('--');
     if (double_dash_index === -1) {
-      let missing_dash_error_msg = 'Command must be provided after --\n(e.g. "architect exec -- ls")'
+      let missing_dash_error_msg = 'Command must be provided after --\n(e.g. "architect exec -- ls")';
       if (process.platform === 'win32') {
         missing_dash_error_msg += `\n
 If using PowerShell, -- must be escaped with quotes or \`
 (e.g. "architect exec \`-- ls", "architect exec '--' ls)
-Alternatively, running "architect --% exec -- ls" will prevent the PowerShell parser from changing the meaning of --.`
+Alternatively, running "architect --% exec -- ls" will prevent the PowerShell parser from changing the meaning of --.`;
       }
       this.error(chalk.red(missing_dash_error_msg));
     }

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -80,7 +80,14 @@ export default class Exec extends BaseCommand {
   }>(options?: Interfaces.Input<F>, argv = this.argv): Promise<Interfaces.ParserOutput<F, A>> {
     const double_dash_index = argv.indexOf('--');
     if (double_dash_index === -1) {
-      this.error(chalk.red('Command must be provided after --\n(e.g. "architect exec -- ls")'));
+      let missing_dash_error_msg = 'Command must be provided after --\n(e.g. "architect exec -- ls")'
+      if (process.platform === 'win32') {
+        missing_dash_error_msg += `\n
+If using PowerShell, -- must be escaped with quotes or \`
+(e.g. "architect exec \`-- ls", "architect exec '--' ls)
+Alternatively, running "architect --% exec -- ls" will prevent the PowerShell parser from changing the meaning of --.`
+      }
+      this.error(chalk.red(missing_dash_error_msg));
     }
 
     const command = argv.slice(double_dash_index + 1);
@@ -90,7 +97,7 @@ export default class Exec extends BaseCommand {
 
     const argv_without_command = argv.slice(0, double_dash_index);
 
-     const parsed = await super.parse(options, argv_without_command) as Interfaces.ParserOutput<F, A>;
+    const parsed = await super.parse(options, argv_without_command) as Interfaces.ParserOutput<F, A>;
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     parsed.args.command = command;


### PR DESCRIPTION
`--` has a different but equally special meaning in PowerShell, and running `--` in a command causes PowerShell to treat it specially and it doesn't appear in the programs `argv`.

In order for `architect exec` to work nicely in PowerShell, there's only 2 (maybe 3) options:

1. Ask users to delete `architect.ps1` from wherever they npm install it. This makes it so `architect` on the CLI will use the cmd executable that doesn't have this issue.
2. Provide this error message so users can self-correct the -- behavior by escaping it
3. (not realistic) pray that NPM reverses the decision to include a special powershell script when publishing packages. As far as I can tell, this can't be disabled by us

The most realistic fix unless https://github.com/npm/cmd-shim changes is to just provide a detailed error msg for PS users