### PR TITLE
Fix getLocalEnvironment failing on older versions of compose without ConfigFiles

### DIFF
--- a/src/common/docker-compose/project.ts
+++ b/src/common/docker-compose/project.ts
@@ -1,5 +1,11 @@
 export type DockerComposeProject = {
   Name: string;
   Status: string;
+  ConfigFiles: string | undefined;
+};
+
+export type DockerComposeProjectWithConfig = {
+  Name: string;
+  Status: string;
   ConfigFiles: string;
 };


### PR DESCRIPTION
Older versions of `docker compose` don't have a `ConfigFiles` key when running `docker compose ls`. I installed docker compose v2.2.3 from January and this key isn't yet available.

It's ideal to use this value directly if it exists, but if it doesn't, we fall back to manually searching the `LOCAL_DEPLOY_PATH` directory and matching the files there up with the results of `docker compose ls` (which still gives us the name of the compose file). 


Tested this on my Windows machine that has the older version of docker compose installed, and tested on my Mac that has the most up to date Docker, so the old path is working as it did prior and the new path now fixes the bug. 

Bug in question is https://sentry.io/organizations/architect-io/issues/3493163125/?project=6465948&referrer=slack