### PR TITLE
adding decorator to check that git/docker are installed for project init

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,6 +11,7 @@ import ProjectUtils from '../architect/project/project.utils';
 import BaseCommand from '../base-command';
 import { DockerComposeUtils } from '../common/docker-compose';
 import { ComposeConverter } from '../common/docker-compose/converter';
+import { RequiresDocker } from '../common/docker/helper';
 import { RequiresGit } from '../common/utils/git/helper';
 import { ComponentSlugUtils } from '../dependency-manager/spec/utils/slugs';
 
@@ -53,6 +54,7 @@ export abstract class InitCommand extends BaseCommand {
   }
 
   @RequiresGit()
+  @RequiresDocker({ compose: true })
   async runProjectCreation(project_name: string): Promise<void> {
     if (fs.existsSync(`./${project_name}`)) {
       console.log(chalk.red(`The folder ./${project_name} already exists. Please choose a different project name or remove the folder`));

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,6 +11,7 @@ import ProjectUtils from '../architect/project/project.utils';
 import BaseCommand from '../base-command';
 import { DockerComposeUtils } from '../common/docker-compose';
 import { ComposeConverter } from '../common/docker-compose/converter';
+import { RequiresGit } from '../common/utils/git/helper';
 import { ComponentSlugUtils } from '../dependency-manager/spec/utils/slugs';
 
 export abstract class InitCommand extends BaseCommand {
@@ -51,6 +52,7 @@ export abstract class InitCommand extends BaseCommand {
     return default_compose;
   }
 
+  @RequiresGit()
   async runProjectCreation(project_name: string): Promise<void> {
     if (fs.existsSync(`./${project_name}`)) {
       console.log(chalk.red(`The folder ./${project_name} already exists. Please choose a different project name or remove the folder`));

--- a/src/common/utils/git/helper.ts
+++ b/src/common/utils/git/helper.ts
@@ -1,0 +1,52 @@
+import which from 'which';
+
+class _GitHelper {
+  git_installed: boolean;
+
+  constructor() {
+    this.git_installed = this.checkGitInstalled();
+  }
+
+  static getTestHelper(): _GitHelper {
+    const helper = new _GitHelper();
+    helper.git_installed = true;
+    return helper;
+  }
+
+  checkGitInstalled(): boolean {
+    try {
+      which.sync('git');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  verifyGit(): void {
+    if (!this.git_installed) {
+       throw new Error('Architect requires git to be installed in order for this command to run.\nPlease install git and try again: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git');
+    }
+  }
+}
+
+// Create a singleton GitHelper
+export const GitHelper = process.env.TEST === '1' ? _GitHelper.getTestHelper() : new _GitHelper();
+
+/**
+ * Used to wrap `Command.run()` or `Command.runLocal()` methods when git is required.
+ * Should be used as close to the run method as possible so the checks for required git features happen
+ * before any work begins.
+ */
+export function RequiresGit(): (target: any, propertyKey: string, descriptor: PropertyDescriptor) => any {
+  return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+    const wrappedFunc = descriptor.value;
+    descriptor.value = function (this: any, ...args: any[]) {
+
+      // Verify that git is installed
+      GitHelper.verifyGit();
+
+      return wrappedFunc.apply(this, args);
+    };
+    return descriptor;
+  };
+}


### PR DESCRIPTION
## Overview
Added checks to project creation function to check that Docker/Compose and Git are all installed before the function/user can proceed

## Changes
* Added `RequiresGit` decorator to check that `git` is installed
* Added `RequiresGit` and `RequiresDocker` decorators to project init function

## Tests
* Uninstalled `git` to check that an error would be thrown
* Reinstalled `git` to ensure that error was no longer thrown