### PR TITLE
Fix issue causing only 1 service with an ingress to have it's URL displayed in `architect dev`

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -27,7 +27,7 @@ type TraefikHttpService = {
   provider: string;
 };
 
-const HOST_REGEX = new RegExp(/Host\(`(.*?)`\)/g);
+const HOST_REGEX = new RegExp(/Host\(`(.*?)`\)/);
 
 /**
  * Handles the logic for managing the `docker compose up` process.
@@ -391,7 +391,7 @@ export default class Dev extends BaseCommand {
           this.log('Opening', chalk.blue(url));
           opener(url);
           if (seen_urls.size === 0) {
-            this.log('(disable with --no-browser)');
+            this.log('(disable with --browser=false)');
           }
           seen_urls.add(url);
         }


### PR DESCRIPTION
Previously, we'd see something like this if two ingresses were configured (test and test-2)
```
Building containers... done

Once the containers are running they will be accessible via the following urls:
https://test.localhost.architect.sh:443/ => hellow-world--app

https://localhost:443/ => gateway:443
https://localhost:8080/ => gateway:8080
https://localhost:50001/ => hellow-world--app:8080
https://localhost:50002/ => hellow-world--app-2:8080
```

Now, we get the proper output:
```
Building containers... done

Once the containers are running they will be accessible via the following urls:
https://test.localhost.architect.sh:443/ => hellow-world--app
https://test-2.localhost.architect.sh:443/ => hellow-world--app-2

https://localhost:443/ => gateway:443
https://localhost:8080/ => gateway:8080
https://localhost:50001/ => hellow-world--app:8080
https://localhost:50002/ => hellow-world--app-2:8080
```


The problem was because we matched against `HOST_REGEX` that contained the global flag `/g`. This causes the RegExp object to keep a reference to `lastIndex` which means passing a new string to `regexp.exec(...)` doesn't work as expected as it'll look for a new match starting at `lastIndex`, assuming you're still matching against the previous string.

Our logic assumes that if we have a match, there's exactly 1 matched group, so we don't need `/g` and can just remove it to solve the issue.