### PR TITLE
Container restarts on startup of `architect dev`

### DIFF
--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -570,22 +570,23 @@ export class DockerComposeUtils {
           const state = container_state.State.toLowerCase();
           const health = container_state.Health.toLowerCase();
 
+          const bad_state = state !== 'running';
+          const bad_health = health === 'unhealthy';
+
           if (!service_data_dictionary[service_ref]) {
             service_data_dictionary[service_ref] = {
               last_restart_ms: Date.now(),
             };
 
             // Docker compose will only exit containers when stopping an up
-            // If we had no service data and the container state was exited
-            // it means that these containers were from an old instance and we
-            // are not yet in a bad state.
-            if (state === 'exited') {
+            // If we had no service data and the container state is bad,
+            // these containers may be from an old instance and we
+            // are not yet in a bad state. If they are still bad after 5s, they
+            // will be restarted.
+            if (bad_state) {
               continue;
             }
           }
-
-          const bad_state = state === 'exited' || state === 'dead';
-          const bad_health = health === 'unhealthy';
 
           if (bad_state || bad_health) {
             const service_data = service_data_dictionary[service_ref];

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -570,22 +570,22 @@ export class DockerComposeUtils {
           const state = container_state.State.toLowerCase();
           const health = container_state.Health.toLowerCase();
 
-          // Docker compose will only exit containers when stopping an up
-          // If we have no service data and the contianer state was exited
-          // it means that these containers were from an old instance and we
-          // are not yet in a bad state.
-          if (!service_data_dictionary[service_ref] && state == 'exited') {
-            continue;
-          }
-
           if (!service_data_dictionary[service_ref]) {
             service_data_dictionary[service_ref] = {
               last_restart_ms: Date.now(),
             };
+
+            // Docker compose will only exit containers when stopping an up
+            // If we had no service data and the container state was exited
+            // it means that these containers were from an old instance and we
+            // are not yet in a bad state.
+            if (state === 'exited') {
+              continue;
+            }
           }
 
-          const bad_state = state != 'running';
-          const bad_health = health == 'unhealthy';
+          const bad_state = state === 'exited' || state === 'dead';
+          const bad_health = health === 'unhealthy';
 
           if (bad_state || bad_health) {
             const service_data = service_data_dictionary[service_ref];


### PR DESCRIPTION
Goal is fixing https://github.com/architect-team/architect-cli/issues/686

This issue presented itself to me when containers were in weird non-exited states when running `architect dev`. For example, leaving a container paused, or the first iteration of the loop happening while a container was still being created (in the `created` state).

In order to prevent pre-emptive restarts, we check for _any_ state that sets `bad_state` to true, and if that happens to be on the first iteration of our loop, we led it ride for 5 seconds as any bad states I could simulate would get fixed automatically by  the compose up process.

Moving the
```javascript
if (bad_state) {
    continue
}
```
state as well was intentional - if a container hard-failed (e.g. started and got back into the `exited` state) within the first 5 seconds, we would never try to restart it because the `service_data_dictionary` would never get an entry. We would continually hit `if (!service_data_dictionary[service_ref] && state == 'exited')` and `continue` over and over again.

To fix this, we _always_ add the service to our `service_data_dictionary` so we know that we have knowledge of it, and only skip restarting if it's the first time we've seen it. Afterwards, any non-`'running'` state is considered bad and a restart will happen.