### PR TITLE
Change default project name for `architect dev`, allowing multiple envs w/ same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ npm install -g @architect-io/cli
 $ architect COMMAND
 running command...
 $ architect (--version)
-@architect-io/cli/1.24.0-rc.10 linux-x64 node-v16.16.0
+@architect-io/cli/1.24.0-rc.11 linux-x64 node-v16.17.0
 $ architect --help [COMMAND]
 USAGE
   $ architect COMMAND
@@ -462,7 +462,7 @@ EXAMPLES
   $ architect components mycomponent
 ```
 
-_See code: [src/commands/components/index.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/components/index.ts)_
+_See code: [src/commands/components/index.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/components/index.ts)_
 
 ## `architect components:register [COMPONENT]`
 
@@ -587,7 +587,7 @@ EXAMPLES
   $ architect component:versions --account=myaccount mycomponent
 ```
 
-_See code: [src/commands/components/versions.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/components/versions.ts)_
+_See code: [src/commands/components/versions.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/components/versions.ts)_
 
 ## `architect config`
 
@@ -625,7 +625,7 @@ EXAMPLES
   $ architect config:get log_level
 ```
 
-_See code: [src/commands/config/get.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/config/get.ts)_
+_See code: [src/commands/config/get.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/config/get.ts)_
 
 ## `architect config:set OPTION VALUE`
 
@@ -646,7 +646,7 @@ EXAMPLES
   $ architect config:set log_level info
 ```
 
-_See code: [src/commands/config/set.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/config/set.ts)_
+_See code: [src/commands/config/set.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/config/set.ts)_
 
 ## `architect config:view`
 
@@ -666,7 +666,7 @@ EXAMPLES
   $ architect config
 ```
 
-_See code: [src/commands/config/view.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/config/view.ts)_
+_See code: [src/commands/config/view.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/config/view.ts)_
 
 ## `architect deploy [CONFIGS_OR_COMPONENTS]`
 
@@ -707,7 +707,7 @@ EXAMPLES
   $ architect deploy ./myfolder/architect.yml --secret-file=./mysecrets.yml --environment=myenvironment --account=myaccount --auto-approve
 ```
 
-_See code: [src/commands/deploy.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/deploy.ts)_
+_See code: [src/commands/deploy.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/deploy.ts)_
 
 ## `architect destroy`
 
@@ -733,7 +733,7 @@ EXAMPLES
   $ architect destroy --account=myaccount --environment=myenvironment --auto-approve
 ```
 
-_See code: [src/commands/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/destroy.ts)_
+_See code: [src/commands/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/destroy.ts)_
 
 ## `architect dev [CONFIGS_OR_COMPONENTS]`
 
@@ -774,7 +774,7 @@ EXAMPLES
   $ architect dev --port=81 --browser=false --debug=true --secret-file=./mycomponent/mysecrets.yml ./mycomponent/architect.yml
 ```
 
-_See code: [src/commands/dev.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/dev.ts)_
+_See code: [src/commands/dev.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/dev.ts)_
 
 ## `architect doctor`
 
@@ -796,7 +796,7 @@ EXAMPLES
   $ architect doctor -o ./myoutput.yml
 ```
 
-_See code: [src/commands/doctor.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/doctor.ts)_
+_See code: [src/commands/doctor.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/doctor.ts)_
 
 ## `architect env [QUERY]`
 
@@ -1087,7 +1087,7 @@ EXAMPLES
   $ architect environments myenvironment
 ```
 
-_See code: [src/commands/environments/index.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/environments/index.ts)_
+_See code: [src/commands/environments/index.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/environments/index.ts)_
 
 ## `architect environments:create [ENVIRONMENT]`
 
@@ -1121,7 +1121,7 @@ EXAMPLES
   environment:create --account=myaccount --ttl=5days --description="My new temporary Architect environment" myenvironment
 ```
 
-_See code: [src/commands/environments/create.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/environments/create.ts)_
+_See code: [src/commands/environments/create.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/environments/create.ts)_
 
 ## `architect environments:destroy [ENVIRONMENT]`
 
@@ -1155,7 +1155,7 @@ EXAMPLES
   $ architect environment:deregister --account=myaccount --auto-approve --force myenvironment
 ```
 
-_See code: [src/commands/environments/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/environments/destroy.ts)_
+_See code: [src/commands/environments/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/environments/destroy.ts)_
 
 ## `architect environments:search [QUERY]`
 
@@ -1353,7 +1353,7 @@ EXAMPLES
   $ architect exec --account myaccount --environment myenvironment --replica 0 -- /bin/sh
 ```
 
-_See code: [src/commands/exec.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/exec.ts)_
+_See code: [src/commands/exec.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/exec.ts)_
 
 ## `architect help [COMMAND]`
 
@@ -1399,7 +1399,7 @@ EXAMPLES
   $ architect init --from-compose=mycompose.yml --component-file=architect.yml
 ```
 
-_See code: [src/commands/init.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/init.ts)_
 
 ## `architect link [COMPONENTPATH]`
 
@@ -1421,7 +1421,7 @@ EXAMPLES
   $ architect link -p ./mycomponent/architect.yml
 ```
 
-_See code: [src/commands/link/index.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/link/index.ts)_
+_See code: [src/commands/link/index.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/link/index.ts)_
 
 ## `architect link:list`
 
@@ -1438,7 +1438,7 @@ EXAMPLES
   $ architect link:list
 ```
 
-_See code: [src/commands/link/list.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/link/list.ts)_
+_See code: [src/commands/link/list.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/link/list.ts)_
 
 ## `architect login`
 
@@ -1461,7 +1461,7 @@ EXAMPLES
   $ architect login -e my-email-address@my-email-domain.com
 ```
 
-_See code: [src/commands/login.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/login.ts)_
 
 ## `architect logout`
 
@@ -1478,7 +1478,7 @@ EXAMPLES
   $ architect logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/logout.ts)_
 
 ## `architect logs [RESOURCE]`
 
@@ -1512,7 +1512,7 @@ EXAMPLES
   $ architect logs --follow --raw --timestamps
 ```
 
-_See code: [src/commands/logs.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/logs.ts)_
+_See code: [src/commands/logs.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/logs.ts)_
 
 ## `architect platform [QUERY]`
 
@@ -1665,7 +1665,7 @@ EXAMPLES
   $ architect platforms --account=myaccount myplatform
 ```
 
-_See code: [src/commands/platforms/index.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/platforms/index.ts)_
+_See code: [src/commands/platforms/index.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/platforms/index.ts)_
 
 ## `architect platforms:create [PLATFORM]`
 
@@ -1701,7 +1701,7 @@ EXAMPLES
   $ architect platforms:register --account=myaccount --type=kubernetes --kubeconfig=~/.kube/config --auto-approve
 ```
 
-_See code: [src/commands/platforms/create.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/platforms/create.ts)_
+_See code: [src/commands/platforms/create.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/platforms/create.ts)_
 
 ## `architect platforms:deregister [PLATFORM]`
 
@@ -1763,7 +1763,7 @@ EXAMPLES
   $ architect platforms:deregister --account=myaccount --auto-approve --force architect
 ```
 
-_See code: [src/commands/platforms/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/platforms/destroy.ts)_
+_See code: [src/commands/platforms/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/platforms/destroy.ts)_
 
 ## `architect platforms:register [PLATFORM]`
 
@@ -1868,7 +1868,7 @@ EXAMPLES
   $ architect register -a myaccount -t latest --arg NODE_ENV=dev ./architect.yml
 ```
 
-_See code: [src/commands/register.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/register.ts)_
+_See code: [src/commands/register.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/register.ts)_
 
 ## `architect secrets SECRETS_FILE`
 
@@ -1954,7 +1954,7 @@ EXAMPLES
   $ architect secrets --account=myaccount --environment=myenvironment ../mysecrets.yml
 ```
 
-_See code: [src/commands/secrets/download.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/secrets/download.ts)_
+_See code: [src/commands/secrets/download.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/secrets/download.ts)_
 
 ## `architect secrets:set SECRETS_FILE`
 
@@ -2012,7 +2012,7 @@ EXAMPLES
   $ architect secrets:set --account=myaccount --override ./mysecrets.yml
 ```
 
-_See code: [src/commands/secrets/upload.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/secrets/upload.ts)_
+_See code: [src/commands/secrets/upload.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/secrets/upload.ts)_
 
 ## `architect task COMPONENT TASK`
 
@@ -2020,7 +2020,7 @@ Execute a task in the given environment
 
 ```
 USAGE
-  $ architect task [COMPONENT] [TASK] [-l <value> | -a <value> |  |  | ] [-o <value> |  | -e <value> |  |
+  $ architect task [COMPONENT] [TASK] [-l <value> | -a <value> |  |  | ] [-o <value> |  | -e <value> |  | 
     | ]
 
 ARGUMENTS
@@ -2043,7 +2043,7 @@ EXAMPLES
   $ architect task --account=myaccount --environment=myenvironment mycomponent:latest mytask
 ```
 
-_See code: [src/commands/task.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/task.ts)_
+_See code: [src/commands/task.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/task.ts)_
 
 ## `architect task:exec COMPONENT TASK`
 
@@ -2051,7 +2051,7 @@ Execute a task in the given environment
 
 ```
 USAGE
-  $ architect task:exec [COMPONENT] [TASK] [-l <value> | -a <value> |  |  | ] [-o <value> |  | -e <value> |  |
+  $ architect task:exec [COMPONENT] [TASK] [-l <value> | -a <value> |  |  | ] [-o <value> |  | -e <value> |  | 
     | ]
 
 ARGUMENTS
@@ -2096,7 +2096,7 @@ EXAMPLES
   $ architect unlink -p mycomponent
 ```
 
-_See code: [src/commands/unlink.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/unlink.ts)_
+_See code: [src/commands/unlink.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/unlink.ts)_
 
 ## `architect validate [CONFIGS_OR_COMPONENTS]`
 
@@ -2126,7 +2126,7 @@ EXAMPLES
   $ architect validate ../mycomponent/architect.yml ../myothercomponent/architect.yml
 ```
 
-_See code: [src/commands/validate.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/validate.ts)_
+_See code: [src/commands/validate.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/validate.ts)_
 
 ## `architect whoami`
 
@@ -2146,5 +2146,5 @@ EXAMPLES
   $ architect whoami
 ```
 
-_See code: [src/commands/whoami.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.10/src/commands/whoami.ts)_
+_See code: [src/commands/whoami.ts](https://github.com/architect-team/architect-cli/blob/v1.24.0-rc.11/src/commands/whoami.ts)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 <!-- docs -->
 
 <p align="center">
-  <a href="//architect.io" target="blank"><img src="https://docs.architect.io/img/logo.svg" width="480" alt="Architect Logo" /></a>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.architect.io/logo/horizontal-inverted.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://cdn.architect.io/logo/horizontal.png">
+    <img width="320" alt="Architect Logo" src="https://cdn.architect.io/logo/horizontal.png">
+  </picture>
 </p>
 
 <p align="center">
@@ -2016,7 +2020,7 @@ Execute a task in the given environment
 
 ```
 USAGE
-  $ architect task [COMPONENT] [TASK] [-l <value> | -a <value> |  |  | ] [-o <value> |  | -e <value> |  | 
+  $ architect task [COMPONENT] [TASK] [-l <value> | -a <value> |  |  | ] [-o <value> |  | -e <value> |  |
     | ]
 
 ARGUMENTS
@@ -2047,7 +2051,7 @@ Execute a task in the given environment
 
 ```
 USAGE
-  $ architect task:exec [COMPONENT] [TASK] [-l <value> | -a <value> |  |  | ] [-o <value> |  | -e <value> |  | 
+  $ architect task:exec [COMPONENT] [TASK] [-l <value> | -a <value> |  |  | ] [-o <value> |  | -e <value> |  |
     | ]
 
 ARGUMENTS

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@architect-io/cli",
-  "version": "1.24.0-rc.11",
+  "version": "1.24.0-rc.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@architect-io/cli",
-      "version": "1.24.0-rc.11",
+      "version": "1.24.0-rc.12",
       "license": "GPL-3.0",
       "dependencies": {
         "@oclif/core": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@architect-io/cli",
   "description": "Command-line interface for Architect.io",
-  "version": "1.24.0-rc.11",
+  "version": "1.24.0-rc.12",
   "author": "Architect.io",
   "bin": {
     "architect": "./bin/run"

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -15,9 +15,9 @@ import { default as BaseCommand, default as Command } from '../base-command';
 import LocalDependencyManager, { ComponentConfigOpts } from '../common/dependency-manager/local-manager';
 import { DockerComposeUtils } from '../common/docker-compose';
 import DockerComposeTemplate from '../common/docker-compose/template';
+import { RequiresDocker } from '../common/docker/helper';
 import DeployUtils from '../common/utils/deploy.utils';
 import { booleanString } from '../common/utils/oclif';
-import { RequiresDocker } from '../common/docker/helper';
 import PortUtil from '../common/utils/port';
 
 type TraefikHttpService = {
@@ -404,7 +404,7 @@ export default class Dev extends BaseCommand {
     const { flags } = await this.parse(Dev);
 
     const config_dir = this.app.config.getConfigDir();
-    const project_name = DockerComposeUtils.getProjectName(config_dir, default_project_name);
+    const project_name = await DockerComposeUtils.getProjectName(default_project_name);
     const compose_file = flags['compose-file'] || DockerComposeUtils.buildComposeFilepath(config_dir, project_name);
 
     await fs.ensureFile(compose_file);

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -27,7 +27,7 @@ type TraefikHttpService = {
   provider: string;
 };
 
-const HOST_REGEX = new RegExp(/Host\(`(.*?)`\)/g);
+const HOST_REGEX = new RegExp(/Host\(`(.*?)`\)/);
 
 /**
  * Handles the logic for managing the `docker compose up` process.
@@ -391,7 +391,7 @@ export default class Dev extends BaseCommand {
           this.log('Opening', chalk.blue(url));
           opener(url);
           if (seen_urls.size === 0) {
-            this.log('(disable with --no-browser)');
+            this.log('(disable with --browser=false)');
           }
           seen_urls.add(url);
         }

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -403,9 +403,8 @@ export default class Dev extends BaseCommand {
   async buildImage(compose: DockerComposeTemplate, default_project_name: string): Promise<[string, string]> {
     const { flags } = await this.parse(Dev);
 
-    const config_dir = this.app.config.getConfigDir();
     const project_name = await DockerComposeUtils.getProjectName(default_project_name);
-    const compose_file = flags['compose-file'] || DockerComposeUtils.buildComposeFilepath(config_dir, project_name);
+    const compose_file = flags['compose-file'] || DockerComposeUtils.buildComposeFilepath(this.app.config.getConfigDir(), project_name);
 
     await fs.ensureFile(compose_file);
     await fs.writeFile(compose_file, yaml.dump(compose));
@@ -610,8 +609,9 @@ export default class Dev extends BaseCommand {
     });
 
     // By default, the project_name used in `docker compose up -p PROJECT_NAME` is the name of the
-    // first component in the list of components to run.
-    const default_project_name = flags.environment ? flags.environment : component_versions[0];
+    // first component in the list of components to run with 'arc' prepended so it's obvious that it's
+    // coming from us.
+    const default_project_name = flags.environment ? flags.environment : `arc-${component_versions[0]}`;
 
     await this.runCompose(compose, default_project_name, flags.port, gateway_admin_port);
   }

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -402,7 +402,7 @@ Alternatively, running "architect --% exec -- ls" will prevent the PowerShell pa
     // If no account is default to local first.
     if (!flags.account && flags.environment) {
       // If the env exists locally then just assume local
-      const is_local_env = await DockerComposeUtils.isLocalEnvironment(this.app.config.getConfigDir(), flags.environment);
+      const is_local_env = await DockerComposeUtils.isLocalEnvironment(flags.environment);
       if (is_local_env) {
         return await this.runLocal(args, flags);
       }

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -259,7 +259,7 @@ export default class Logs extends BaseCommand {
     // If no account is default to local first.
     if (!flags.account && flags.environment) {
       // If the env exists locally then just assume local
-      const is_local_env = await DockerComposeUtils.isLocalEnvironment(this.app.config.getConfigDir(), flags.environment);
+      const is_local_env = await DockerComposeUtils.isLocalEnvironment(flags.environment);
       if (is_local_env) {
         return await this.runLocal();
       }

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -99,7 +99,7 @@ export default class TaskExec extends BaseCommand {
     }
 
     const config_dir = this.app.config.getConfigDir();
-    const project_name = DockerComposeUtils.getProjectName(config_dir, `${parsed_slug.component_name}-task`);
+    const project_name = await DockerComposeUtils.getProjectName(`${parsed_slug.component_name}-task`);
     const compose_file = flags['compose-file'] || DockerComposeUtils.buildComposeFilepath(config_dir, project_name);
 
     let compose;

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -98,9 +98,8 @@ export default class TaskExec extends BaseCommand {
       throw new Error(`Error parsing component: ${err}`);
     }
 
-    const config_dir = this.app.config.getConfigDir();
-    const project_name = await DockerComposeUtils.getProjectName(`${parsed_slug.component_name}-task`);
-    const compose_file = flags['compose-file'] || DockerComposeUtils.buildComposeFilepath(config_dir, project_name);
+    const project_name = await DockerComposeUtils.getProjectName(`arc-${parsed_slug.component_name}-task`);
+    const compose_file = flags['compose-file'] || DockerComposeUtils.buildComposeFilepath(this.app.config.getConfigDir(), project_name);
 
     let compose;
     try {

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -91,21 +91,22 @@ export default class TaskExec extends BaseCommand {
   async runLocal(): Promise<void> {
     const { flags, args } = await this.parse(TaskExec);
 
-    const project_name = flags.environment || DockerComposeUtils.DEFAULT_PROJECT;
-    const compose_file = flags['compose-file'] || DockerComposeUtils.buildComposeFilepath(this.app.config.getConfigDir(), project_name);
+    let parsed_slug;
+    try {
+      parsed_slug = ComponentVersionSlugUtils.parse(args.component);
+    } catch (err) {
+      throw new Error(`Error parsing component: ${err}`);
+    }
+
+    const config_dir = this.app.config.getConfigDir();
+    const project_name = DockerComposeUtils.getProjectName(config_dir, `${parsed_slug.component_name}-task`);
+    const compose_file = flags['compose-file'] || DockerComposeUtils.buildComposeFilepath(config_dir, project_name);
 
     let compose;
     try {
       compose = DockerComposeUtils.loadDockerCompose(compose_file);
     } catch (err) {
       throw new Error(`Could not find docker compose file at ${compose_file}. Please run \`architect dev -e ${project_name} ${args.component}\` before executing any tasks in your local ${project_name} environment.`);
-    }
-
-    let parsed_slug;
-    try {
-      parsed_slug = ComponentVersionSlugUtils.parse(args.component);
-    } catch (err) {
-      throw new Error(`Error parsing component: ${err}`);
     }
 
     const slug = ResourceSlugUtils.build(parsed_slug.component_account_name, parsed_slug.component_name, 'tasks', args.task, parsed_slug.instance_name);

--- a/test/commands/components/index.test.ts
+++ b/test/commands/components/index.test.ts
@@ -48,7 +48,6 @@ describe('list components', () => {
     .nock(MOCK_API_HOST, api => api
       .get(`/components?q=`)
       .reply(200, { rows: components, count: components.length }))
-    .timeout(20000)
     .command(['components'])
     .it('list all components', () => {
       const log_spy_list = Components.prototype.log as SinonSpy;

--- a/test/commands/components/index.test.ts
+++ b/test/commands/components/index.test.ts
@@ -48,6 +48,7 @@ describe('list components', () => {
     .nock(MOCK_API_HOST, api => api
       .get(`/components?q=`)
       .reply(200, { rows: components, count: components.length }))
+    .timeout(20000)
     .command(['components'])
     .it('list all components', () => {
       const log_spy_list = Components.prototype.log as SinonSpy;


### PR DESCRIPTION
Default project name is now the name of the first component in the `architect dev` command. If you run multiple components at once (e.g. `architect dev architect.yml architect-2.yml`), the first architect.yml's component name is used. (Open to suggestions here, but prior it was always named `architect` so this is still better imo).

When using the `-e` flag, that still overrides this default, so `architect dev -e foobar` will run `docker compose ... -p foobar up`.

If you run `architect dev` on the same component multiple times, each subsequent compose is given a number (e.g. `hello-world`, `hello-world-1`, `hello-world-2`, etc). Used this instead of a UID/some random number because each instance creates new containers and we want to re-use those containers when possible. If we always create a new hash/uid/etc, there will be tons of stopped orphaned containers after a bunch of devs which isn't ideal.

Example of running Architect twice working now - 
<img width="948" alt="image" src="https://user-images.githubusercontent.com/1406391/187781452-3628b772-dff8-48fa-a4e1-fa9dd7286ffe.png">
(note - screenshot is slightly outdated, this would be `arc-cloud` and `arc-cloud-1` now)
