### PR TITLE
Make graph immutable

### DIFF
--- a/src/dependency-manager/graph/index.ts
+++ b/src/dependency-manager/graph/index.ts
@@ -9,7 +9,7 @@ import { GatewayNode } from './node/gateway';
 import { ServiceNode } from './node/service';
 import { TaskNode } from './node/task';
 
-export class DependencyGraph {
+export class DependencyGraphMutable {
   @Type(() => DependencyNode, {
     discriminator: {
       property: '__type',
@@ -254,3 +254,5 @@ export class DependencyGraph {
     return false;
   }
 }
+
+export type DependencyGraph = Readonly<DependencyGraphMutable>;

--- a/src/dependency-manager/manager.ts
+++ b/src/dependency-manager/manager.ts
@@ -708,6 +708,6 @@ export default abstract class DependencyManager {
       graph.validated = true;
     }
 
-    return graph;
+    return Object.freeze(graph) as DependencyGraph;
   }
 }

--- a/src/dependency-manager/manager.ts
+++ b/src/dependency-manager/manager.ts
@@ -2,7 +2,7 @@ import { classToPlain, plainToClass, serialize } from 'class-transformer';
 import { isMatch } from 'matcher';
 import { buildInterfacesRef, buildNodeRef, ComponentConfig } from './config/component-config';
 import { ArchitectContext, ComponentContext, SecretValue } from './config/component-context';
-import { DependencyGraph } from './graph';
+import { DependencyGraph, DependencyGraphMutable } from './graph';
 import { IngressEdge } from './graph/edge/ingress';
 import { OutputEdge } from './graph/edge/output';
 import { ServiceEdge } from './graph/edge/service';
@@ -576,7 +576,7 @@ export default abstract class DependencyManager {
 
     const interpolateObject = options.validate ? interpolateObjectOrReject : interpolateObjectLoose;
 
-    const graph = new DependencyGraph();
+    const graph = new DependencyGraphMutable();
 
     const context_map: Dictionary<ComponentContext> = {};
     const dependency_context_map: Dictionary<ComponentContext> = {};
@@ -708,6 +708,6 @@ export default abstract class DependencyManager {
       graph.validated = true;
     }
 
-    return Object.freeze(graph) as DependencyGraph;
+    return Object.freeze(graph);
   }
 }


### PR DESCRIPTION
## Overview
Lock the generated graph object once it has been created. 
`DependencyGraph` was converted to `DependencyGraphMutable`
`DependencyGraph` now is `Readonly<DependencyGraphMutable>`
This gives us full typescript linter support as well as runtime verification.

## Test
Run `npm run test`
Tested the `dev`, `register` and `deploy` commands to make sure nothing broke.