### PR TITLE
Add dev:list command

### DIFF
--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -8,17 +8,17 @@ import isCi from 'is-ci';
 import yaml from 'js-yaml';
 import opener from 'opener';
 import path from 'path';
-import { buildSpecFromPath, ComponentSlugUtils, ComponentSpec, ComponentVersionSlugUtils, Dictionary } from '../';
-import AccountUtils from '../architect/account/account.utils';
-import { EnvironmentUtils } from '../architect/environment/environment.utils';
-import { default as BaseCommand, default as Command } from '../base-command';
-import LocalDependencyManager, { ComponentConfigOpts } from '../common/dependency-manager/local-manager';
-import { DockerComposeUtils } from '../common/docker-compose';
-import DockerComposeTemplate from '../common/docker-compose/template';
-import { RequiresDocker } from '../common/docker/helper';
-import DeployUtils from '../common/utils/deploy.utils';
-import { booleanString } from '../common/utils/oclif';
-import PortUtil from '../common/utils/port';
+import { buildSpecFromPath, ComponentSlugUtils, ComponentSpec, ComponentVersionSlugUtils, Dictionary } from '../../';
+import AccountUtils from '../../architect/account/account.utils';
+import { EnvironmentUtils } from '../../architect/environment/environment.utils';
+import { default as BaseCommand, default as Command } from '../../base-command';
+import LocalDependencyManager, { ComponentConfigOpts } from '../../common/dependency-manager/local-manager';
+import { DockerComposeUtils } from '../../common/docker-compose';
+import DockerComposeTemplate from '../../common/docker-compose/template';
+import { RequiresDocker } from '../../common/docker/helper';
+import DeployUtils from '../../common/utils/deploy.utils';
+import { booleanString } from '../../common/utils/oclif';
+import PortUtil from '../../common/utils/port';
 
 type TraefikHttpService = {
   name: string;

--- a/src/commands/dev/list.ts
+++ b/src/commands/dev/list.ts
@@ -1,0 +1,31 @@
+import BaseCommand from '../../base-command';
+import BaseTable from '../../base-table';
+import { DockerComposeUtils } from '../../common/docker-compose';
+
+export default class DevList extends BaseCommand {
+  async auth_required(): Promise<boolean> {
+    return false;
+  }
+
+  static description = 'List all running dev instances.';
+  static examples = ['architect link:list'];
+
+  async run(): Promise<void> {
+    const local_env_map = await  DockerComposeUtils.getLocalEnvironmentContainerMap();
+    const table = new BaseTable({ head: ['Environment', 'Containers', 'Status'] });
+
+    for (const [env_name, containers] of Object.entries(local_env_map)) {
+      const container_names = containers.map(c => {
+        if ('com.docker.compose.service' in c.Config.Labels) {
+          return c.Config.Labels['com.docker.compose.service'];
+        }
+        // Fallback in case compose label isn't present for some reason - this is the image name
+        return c.Name;
+      }).join('\n');
+      const statuses = containers.map(c => c.State.Status).join('\n');
+      table.push([env_name, container_names, statuses]);
+    }
+
+    this.log(table.toString());
+  }
+}

--- a/src/common/docker-compose/template.ts
+++ b/src/common/docker-compose/template.ts
@@ -64,3 +64,13 @@ export default interface DockerComposeTemplate {
   services: { [key: string]: DockerService };
   volumes: { [key: string]: { external?: boolean } };
 }
+
+export interface DockerInspect {
+  State: {
+    Status: string
+  },
+  Name: string,
+  Config: {
+    Labels: { [key: string]: string}
+  }
+}

--- a/test/commands/dev/index.test.ts
+++ b/test/commands/dev/index.test.ts
@@ -2,14 +2,14 @@ import { expect, test } from '@oclif/test';
 import yaml from 'js-yaml';
 import path from 'path';
 import sinon from 'sinon';
-import { buildSpecFromYml, ComponentConfig, resourceRefToNodeRef } from '../../src';
-import AppService from '../../src/app-config/service';
-import Dev from '../../src/commands/dev';
-import { DockerComposeUtils } from '../../src/common/docker-compose';
-import DockerComposeTemplate from '../../src/common/docker-compose/template';
-import DeployUtils from '../../src/common/utils/deploy.utils';
-import * as ComponentBuilder from '../../src/dependency-manager/spec/utils/component-builder';
-import { MOCK_API_HOST } from '../utils/mocks';
+import { buildSpecFromYml, ComponentConfig, resourceRefToNodeRef } from '../../../src';
+import AppService from '../../../src/app-config/service';
+import Dev from '../../../src/commands/dev';
+import { DockerComposeUtils } from '../../../src/common/docker-compose';
+import DockerComposeTemplate from '../../../src/common/docker-compose/template';
+import DeployUtils from '../../../src/common/utils/deploy.utils';
+import * as ComponentBuilder from '../../../src/dependency-manager/spec/utils/component-builder';
+import { MOCK_API_HOST } from '../../utils/mocks';
 
 // set to true while working on tests for easier debugging; otherwise oclif/test eats the stdout/stderr
 const print = false;

--- a/test/commands/dev/list.test.ts
+++ b/test/commands/dev/list.test.ts
@@ -1,0 +1,123 @@
+import { expect } from '@oclif/test';
+import sinon, { SinonSpy } from 'sinon';
+import BaseTable from '../../../src/base-table';
+import { DockerComposeUtils } from '../../../src/common/docker-compose';
+import { mockArchitectAuth } from '../../utils/mocks';
+import DevList from '../../../src/commands/dev/list';
+import { inspect } from 'util';
+
+function createTestContainer(name: string, image_name?: string) {
+  const test_container: any = {
+    Name: image_name || 'image_name_not_used',
+    State: {
+      Status: 'running',
+    },
+    Config: {
+      Labels: {},
+    },
+  };
+
+  if (!image_name) {
+    test_container.Config.Labels['com.docker.compose.service'] = name;
+  }
+
+  return test_container;
+}
+
+describe('dev:list', () => {
+
+  // set to true while working on tests for easier debugging; otherwise oclif/test eats the stdout/stderr
+  const print = false;
+
+  const sample_env_1 = 'arc_test_env';
+  const sample_env_2 = 'arc_test_env_1';
+
+  const first_env: any = {};
+  first_env[sample_env_1] = [createTestContainer('container_name_1')];
+
+  const second_env = JSON.parse(JSON.stringify(first_env));
+  second_env[sample_env_1].push(createTestContainer('container_name_2'));
+  second_env[sample_env_1].push(createTestContainer('container_name_3'));
+
+  const third_env = JSON.parse(JSON.stringify(first_env));
+  third_env[sample_env_2] = [createTestContainer('container_name_uno')];
+
+  const fourth_env = { ...JSON.parse(JSON.stringify(third_env)), ...JSON.parse(JSON.stringify(second_env)) };
+  fourth_env[sample_env_2].push(createTestContainer('container_name_dos'));
+  fourth_env[sample_env_2].push(createTestContainer('container_name_tres'));
+
+  const header = { head: ['Environment', 'Containers', 'Status'] };
+  const empty_table = new BaseTable(header);
+
+  const one_env_one_container = new BaseTable(header);
+  one_env_one_container.push([sample_env_1, 'container_name_1', 'running']);
+
+  const one_env_many_containers = new BaseTable(header);
+  one_env_many_containers.push([sample_env_1, 'container_name_1\ncontainer_name_2\ncontainer_name_3', 'running\nrunning\nrunning']);
+
+  const many_env_one_container = new BaseTable(header);
+  many_env_one_container.push([sample_env_1, 'container_name_1', 'running']);
+  many_env_one_container.push([sample_env_2, 'container_name_uno', 'running']);
+
+  const many_env_many_containers = new BaseTable(header);
+  many_env_many_containers.push([sample_env_1, 'container_name_1\ncontainer_name_2\ncontainer_name_3', 'running\nrunning\nrunning']);
+  many_env_many_containers.push([sample_env_2, 'container_name_uno\ncontainer_name_dos\ncontainer_name_tres', 'running\nrunning\nrunning']);
+
+  const default_image_name_env = { 'test_env': [createTestContainer('container_name_not_used', 'image_name_is_used')] };
+  const default_image_name_table = new BaseTable(header);
+  default_image_name_table.push(['test_env', 'image_name_is_used', 'running']);
+
+  mockArchitectAuth
+    .stub(DockerComposeUtils, 'getLocalEnvironmentContainerMap', sinon.stub().returns({}))
+    .stub(DevList.prototype, 'log', sinon.fake.returns(null))
+    .command(['dev:list'])
+    .it('dev list no environments', ctx => {
+      const log_spy = DevList.prototype.log as SinonSpy;
+      expect(log_spy.firstCall.args[0]).to.equal(empty_table.toString());
+    });
+
+  mockArchitectAuth
+    .stub(DockerComposeUtils, 'getLocalEnvironmentContainerMap', sinon.stub().returns(first_env))
+    .stub(DevList.prototype, 'log', sinon.fake.returns(null))
+    .command(['dev:list'])
+    .it('dev list environment with one container', ctx => {
+      const log_spy = DevList.prototype.log as SinonSpy;
+      expect(log_spy.firstCall.args[0]).to.equal(one_env_one_container.toString());
+    });
+
+  mockArchitectAuth
+    .stub(DockerComposeUtils, 'getLocalEnvironmentContainerMap', sinon.stub().returns(second_env))
+    .stub(DevList.prototype, 'log', sinon.fake.returns(null))
+    .command(['dev:list'])
+    .it('dev list single environment with many containers', ctx => {
+      const log_spy = DevList.prototype.log as SinonSpy;
+      expect(log_spy.firstCall.args[0]).to.equal(one_env_many_containers.toString());
+    });
+
+  mockArchitectAuth
+    .stub(DockerComposeUtils, 'getLocalEnvironmentContainerMap', sinon.stub().returns(third_env))
+    .stub(DevList.prototype, 'log', sinon.fake.returns(null))
+    .command(['dev:list'])
+    .it('dev list multiple environments with one container', ctx => {
+      const log_spy = DevList.prototype.log as SinonSpy;
+      expect(log_spy.firstCall.args[0]).to.equal(many_env_one_container.toString());
+    });
+
+  mockArchitectAuth
+    .stub(DockerComposeUtils, 'getLocalEnvironmentContainerMap', sinon.stub().returns(fourth_env))
+    .stub(DevList.prototype, 'log', sinon.fake.returns(null))
+    .command(['dev:list'])
+    .it('dev list multiple environments with many containers', ctx => {
+      const log_spy = DevList.prototype.log as SinonSpy;
+      expect(log_spy.firstCall.args[0]).to.equal(many_env_many_containers.toString());
+    });
+  
+  mockArchitectAuth
+    .stub(DockerComposeUtils, 'getLocalEnvironmentContainerMap', sinon.stub().returns(default_image_name_env))
+    .stub(DevList.prototype, 'log', sinon.fake.returns(null))
+    .command(['dev:list'])
+    .it('dev list fallback to image name works', ctx => {
+      const log_spy = DevList.prototype.log as SinonSpy;
+      expect(log_spy.firstCall.args[0]).to.equal(default_image_name_table.toString());
+    });
+});


### PR DESCRIPTION
**Note: I have this set to merge into https://github.com/architect-team/architect-cli/pull/692 just so the diff is cleaner, but https://github.com/architect-team/architect-cli/pull/692 should be merged first and this can then point at rc instead.**


Adds the `architect dev:list` command which displays your active dev environments, their containers, and those containers statuses.

Example output:
```
~/code/architect/architect-cli (dev-list) » architect dev:list                    
┌────────────────────┬─────────────────────┬─────────┐
│ Environment        │ Containers          │ Status  │
├────────────────────┼─────────────────────┼─────────┤
│ arc-hellow-world-1 │ hellow-world--app   │ running │
│                    │ hellow-world--app-2 │ running │
├────────────────────┼─────────────────────┼─────────┤
│ arc-hellow-world   │ hellow-world--app   │ running │
│                    │ hellow-world--app-2 │ running │
└────────────────────┴─────────────────────┴─────────┘
```

Or in screenshot form:
![image](https://user-images.githubusercontent.com/1406391/187998705-53abc5a8-6069-45c8-8865-7a407440ab56.png)


(Updated this to Draft because I want to think about if it's reasonable to add tests for this or if it's mostly just testing docker commands and we'd have to stub literally everything)