### PR TITLE
Prevent `architect register` failures in docker buildx from throwing Sentry errors

### DIFF
--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -240,8 +240,7 @@ export default class ComponentRegister extends BaseCommand {
         });
       } catch (err: any) {
         fs.removeSync(compose_file);
-        console.log(chalk.red(err));
-        process.exit(err.exitCode || 1);
+        this.error(new ArchitectError(err.message, false));
       }
     }
 

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -240,7 +240,8 @@ export default class ComponentRegister extends BaseCommand {
         });
       } catch (err: any) {
         fs.removeSync(compose_file);
-        this.error(err);
+        console.log(chalk.red(err));
+        process.exit(err.exitCode || 1);
       }
     }
 

--- a/src/common/docker/helper.ts
+++ b/src/common/docker/helper.ts
@@ -1,5 +1,6 @@
 import execa, { ExecaSyncError } from 'execa';
 import which from 'which';
+import { ArchitectError } from '../../dependency-manager/utils/errors';
 
 
 /**
@@ -51,6 +52,7 @@ interface DockerInfo {
   has_compose: boolean;
   plugins: string[];
 }
+
 class _DockerHelper {
   docker_installed: boolean;
   docker_info: DockerInfo;
@@ -117,25 +119,25 @@ class _DockerHelper {
 
   verifyDocker(): void {
     if (!this.docker_installed) {
-       throw new Error('Architect requires Docker to be installed.\nPlease install docker and try again: https://docs.docker.com/engine/install/');
+       throw new ArchitectError('Architect requires Docker to be installed.\nPlease install docker and try again: https://docs.docker.com/engine/install/', false);
     }
   }
 
   verifyBuildX(): void {
     if (!this.docker_info.has_buildx) {
-      throw new Error("'docker buildx' is not available.\nDocker engine must be updated - visit https://docs.docker.com/engine/install/ or install updates via Docker Desktop.");
+      throw new ArchitectError("'docker buildx' is not available.\nDocker engine must be updated - visit https://docs.docker.com/engine/install/ or install updates via Docker Desktop.", false);
     }
   }
 
   verifyCompose(): void {
     if (!this.docker_info.has_compose) {
-      throw new Error("'docker compose' is not available.\nDocker engine must be updated - visit https://docs.docker.com/engine/install/ or install updates via Docker Desktop.");
+      throw new ArchitectError("'docker compose' is not available.\nDocker engine must be updated - visit https://docs.docker.com/engine/install/ or install updates via Docker Desktop.", false);
     }
   }
 
   verifyDaemon() {
     if (!this.daemonRunning()) {
-      throw new Error('Docker daemon is not running. Please start it and try again.');
+      throw new ArchitectError('Docker daemon is not running. Please start it and try again.', false);
     }
   }
 }

--- a/src/dependency-manager/utils/errors.ts
+++ b/src/dependency-manager/utils/errors.ts
@@ -45,7 +45,17 @@ const addLineNumbers = (value: string, errors: ValidationError[]): void => {
   }
 };
 
-export class ArchitectError extends Error { }
+export class ArchitectError extends Error {
+  // When track is true, the exception will be captured by endSentryTransaction.
+  // Should be set to false when a raised error is an issue on the users end that doesn't have
+  // anything actionable for us to do.
+  track: boolean;
+
+  constructor(msg?: string, track?: boolean) {
+    super(msg);
+    this.track = track === undefined ? true : track;
+  }
+}
 
 export class ValidationError {
   component: string;

--- a/src/dependency-manager/utils/errors.ts
+++ b/src/dependency-manager/utils/errors.ts
@@ -51,9 +51,9 @@ export class ArchitectError extends Error {
   // anything actionable for us to do.
   track: boolean;
 
-  constructor(msg?: string, track?: boolean) {
+  constructor(msg?: string, track = true) {
     super(msg);
-    this.track = track === undefined ? true : track;
+    this.track = track;
   }
 }
 

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -186,7 +186,8 @@ export default class SentryService {
         await this.writeCommandHistoryToFileSystem();
       }
 
-      if (error) {
+      // If error.track is undefined, assume it's true - only skip capturing exceptions if track is explicitly set to false
+      if (error && error.track !== false) {
         Sentry.withScope(async scope => {
           Sentry.captureException(error, scope);
         });

--- a/test/commands/register.test.ts
+++ b/test/commands/register.test.ts
@@ -300,6 +300,7 @@ describe('register', function () {
 
   mockArchitectAuth
     .stub(DockerBuildXUtils, 'dockerBuildX', sinon.stub().throws('Some internal docker build exception'))
+    .stub(process, 'exit', sinon.stub().throws('Process exited'))
     .nock(MOCK_API_HOST, api => api
       .get(`/accounts/examples`)
       .reply(200, mock_account_response)
@@ -309,9 +310,9 @@ describe('register', function () {
     .command(['register', 'examples/database-seeding/architect.yml', '-t', '1.0.0', '-a', 'examples'])
     .catch(err => {
       expect(process.exitCode).eq(1);
-      expect(`${err}`).to.contain('Some internal docker build exception');
+      expect(`${err}`).to.contain('Process exited');
     })
-    .it('rejects with the original error message if docker buildx inspect fails');
+    .it('process.exit() is called if docker buildx bake fails');
 
   mockArchitectAuth
     .stub(fs, 'move', sinon.stub())

--- a/test/commands/register.test.ts
+++ b/test/commands/register.test.ts
@@ -86,7 +86,7 @@ describe('register', function () {
     });
 
   mockArchitectAuth
-    .stub(DockerBuildXUtils, 'convertToBuildxPlatforms', sinon.stub().throws('Some internal docker build exception'))
+    .stub(DockerBuildXUtils, 'convertToBuildxPlatforms', sinon.stub().throws(new Error('Some internal docker build exception')))
     .nock(MOCK_API_HOST, api => api
       .get(`/accounts/examples`)
       .reply(200, mock_account_response)
@@ -262,7 +262,7 @@ describe('register', function () {
     .command(['register', 'examples/hello-world/architect.yml', '-a', 'examples'])
     .catch(err => {
       expect(process.exitCode).eq(1);
-      expect(err.message).to.contain('Friendly error message from server');
+      expect(`${err}`).to.contain('Friendly error message from server');
     })
     .it('rejects with informative error message if account is unavailable');
 
@@ -299,8 +299,7 @@ describe('register', function () {
     });
 
   mockArchitectAuth
-    .stub(DockerBuildXUtils, 'dockerBuildX', sinon.stub().throws('Some internal docker build exception'))
-    .stub(process, 'exit', sinon.stub().throws('Process exited'))
+    .stub(DockerBuildXUtils, 'dockerBuildX', sinon.stub().throws(new Error('Some internal docker build exception')))
     .nock(MOCK_API_HOST, api => api
       .get(`/accounts/examples`)
       .reply(200, mock_account_response)
@@ -310,9 +309,9 @@ describe('register', function () {
     .command(['register', 'examples/database-seeding/architect.yml', '-t', '1.0.0', '-a', 'examples'])
     .catch(err => {
       expect(process.exitCode).eq(1);
-      expect(`${err}`).to.contain('Process exited');
+      expect(err.message).to.contain('Some internal docker build exception');
     })
-    .it('process.exit() is called if docker buildx bake fails');
+    .it('rejects with the original error message if docker buildx inspect fails');
 
   mockArchitectAuth
     .stub(fs, 'move', sinon.stub())


### PR DESCRIPTION
Log the error from `docker buildx bake` and exit the process (with whatever error code buildx bake returned with) so that we don't get sentry logs about this.

As we're just running a docker command here, the most likely cause of failure is somebody trying to register a Dockerfile that can't be build properly (for any reason - syntax errors, copying a file that doesn't exist, running a command that fails, etc). This isn't something we can fix, so we shouldn't be throwing an error and should just be informing the user.