### PR TITLE
Add safeguard to `docker info` call to prevent errors when daemon isn't running

### DIFF
--- a/src/common/docker/helper.ts
+++ b/src/common/docker/helper.ts
@@ -88,7 +88,17 @@ class _DockerHelper {
   }
 
   getDockerInfo(): DockerInfo {
-    const docker_info = execa.sync('docker', ['info', '--format', '{{json .}}']).stdout;
+    let docker_info;
+    try {
+      docker_info = execa.sync('docker', ['info', '--format', '{{json .}}']).stdout;
+    } catch {
+      return {
+        daemon_running: false,
+        has_buildx: false,
+        has_compose: false,
+        plugins: [],
+      };
+    }
 
     const docker_json: DockerInfoJSON = JSON.parse(docker_info);
     const plugins = docker_json.ClientInfo.Plugins.map((plugin) => plugin.Name);


### PR DESCRIPTION
I wasn't able to reproduce this error myself (On wsl2 without the daemon running, `docker info` still works) - however, TJ did get an error here:
```
module: @oclif/core@1.9.0
task: toCached
plugin: @architect-io/cli
root: /home/tj/code/cli
See more details with DEBUG=*
(node:25875) Error Plugin: @architect-io/cli: Command failed with exit code 1: docker info --format {{json .}}

The command 'docker' could not be found in this WSL 2 distro.
We recommend to activate the WSL integration in Docker Desktop settings.
```

which clearly means there's a way for `which.sync('docker')`` to return true, but `docker info` doesn't work, so we now try/catch so the user gets a better error message.