### PR TITLE
Fix https to https issue

### DIFF
--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -350,7 +350,7 @@ export class DockerComposeUtils {
           }
           const protocol = component_interface?.protocol || parseUrl(component_interface?.url).protocol;
           if (protocol) {
-            service_to.labels.push(`traefik.http.services.${traefik_service}-service.loadbalancer.server.scheme=${protocol}`)
+            service_to.labels.push(`traefik.http.services.${traefik_service}-service.loadbalancer.server.scheme=${protocol}`);
           }
         }
       }

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -366,7 +366,7 @@ export class DockerComposeUtils {
     }
     try {
       // Slice removes the :
-      return (new URL(url)).protocol.slice(0, -1)
+      return (new URL(url)).protocol.slice(0, -1);
     } catch {
       return undefined;
     }

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -348,10 +348,8 @@ export class DockerComposeUtils {
             service_to.labels.push(`traefik.http.routers.${traefik_service}.tls=true`);
           }
 
-          const url_protocol = this.getUrlProtocol(component_interface?.url);
-          const protocol = component_interface?.protocol || url_protocol;
-          if (protocol) {
-            service_to.labels.push(`traefik.http.services.${traefik_service}-service.loadbalancer.server.scheme=${protocol}`);
+          if (component_interface?.protocol) {
+            service_to.labels.push(`traefik.http.services.${traefik_service}-service.loadbalancer.server.scheme=${component_interface?.protocol}`);
           }
         }
       }

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -1,4 +1,3 @@
-import { parseUrl } from '@sentry/utils';
 import chalk from 'chalk';
 import execa, { Options } from 'execa';
 import fs from 'fs-extra';
@@ -348,7 +347,9 @@ export class DockerComposeUtils {
             service_to.labels.push(`traefik.http.routers.${traefik_service}.entrypoints=web`);
             service_to.labels.push(`traefik.http.routers.${traefik_service}.tls=true`);
           }
-          const protocol = component_interface?.protocol || parseUrl(component_interface?.url).protocol;
+
+          const url_protocol = this.getUrlProtocol(component_interface?.url);
+          const protocol = component_interface?.protocol || url_protocol;
           if (protocol) {
             service_to.labels.push(`traefik.http.services.${traefik_service}-service.loadbalancer.server.scheme=${protocol}`);
           }
@@ -357,6 +358,18 @@ export class DockerComposeUtils {
     }
 
     return compose;
+  }
+
+  private static getUrlProtocol(url?: string): string | undefined {
+    if (!url) {
+      return undefined;
+    }
+    try {
+      // Slice removes the :
+      return (new URL(url)).protocol.slice(0, -1)
+    } catch {
+      return undefined;
+    }
   }
 
   public static getConfigPaths(input: string): string[] {

--- a/src/dependency-manager/spec/transform/component-transform.ts
+++ b/src/dependency-manager/spec/transform/component-transform.ts
@@ -49,12 +49,26 @@ export const transformOutputDefinitionSpec = (key: string, output_spec: string |
   }
 };
 
+const getProtocol = (url: string): string | undefined => {
+  try {
+    return (new URL(url)).protocol.slice(0, -1);
+  } catch {
+    return undefined;
+  }
+};
+
 export const transformComponentInterfaceSpec = function (_: string, interface_spec: ComponentInterfaceSpec | string): ComponentInterfaceConfig {
-  return typeof interface_spec === 'string' ? { url: interface_spec } : interface_spec;
+  return typeof interface_spec === 'string' ? {
+    url: interface_spec,
+    protocol: getProtocol(interface_spec),
+  } : {
+    ...interface_spec,
+    protocol: getProtocol(interface_spec.url),
+  };
 };
 
 export const transformComponentSpec = (spec: ComponentSpec): ComponentConfig => {
-  const secrets = transformDictionary(transformSecretDefinitionSpec, deepmerge(spec.parameters || {}, spec.secrets ||{})); // TODO: update
+  const secrets = transformDictionary(transformSecretDefinitionSpec, deepmerge(spec.parameters || {}, spec.secrets || {})); // TODO: update
   const outputs = transformDictionary(transformOutputDefinitionSpec, spec.outputs);
   const services = transformDictionary(transformServiceSpec, spec.services, spec.metadata);
   const tasks = transformDictionary(transformTaskSpec, spec.tasks, spec.metadata);

--- a/test/commands/dev/index.test.ts
+++ b/test/commands/dev/index.test.ts
@@ -418,6 +418,7 @@ describe('local dev environment', function () {
           `traefik.http.routers.${seed_app_ref}-main.rule=Host(\`app.arc.localhost\`)`,
           `traefik.http.routers.${seed_app_ref}-main.service=${seed_app_ref}-main-service`,
           `traefik.http.services.${seed_app_ref}-main-service.loadbalancer.server.port=3000`,
+          `traefik.http.services.${seed_app_ref}-main-service.loadbalancer.server.scheme=http`
         ],
         "build": {
           "context": path.resolve('./examples/database-seeding'),
@@ -485,6 +486,7 @@ describe('local dev environment', function () {
           `traefik.http.routers.${hello_api_ref}-hello.rule=Host(\`hello.arc.localhost\`)`,
           `traefik.http.routers.${hello_api_ref}-hello.service=${hello_api_ref}-hello-service`,
           `traefik.http.services.${hello_api_ref}-hello-service.loadbalancer.server.port=3000`,
+          `traefik.http.services.${hello_api_ref}-hello-service.loadbalancer.server.scheme=http`
         ],
         "external_links": [
           "gateway:hello.arc.localhost"
@@ -542,6 +544,7 @@ describe('local dev environment', function () {
           `traefik.http.services.${hello_api_ref}-hello-service.loadbalancer.server.port=3000`,
           "traefik.http.routers.hello-world--api-hello.entrypoints=web",
           "traefik.http.routers.hello-world--api-hello.tls=true",
+          `traefik.http.services.${hello_api_ref}-hello-service.loadbalancer.server.scheme=http`,
         ],
         "external_links": [
           "gateway:hello.localhost.architect.sh"
@@ -569,6 +572,7 @@ describe('local dev environment', function () {
           "--providers.docker=true",
           "--providers.docker.exposedByDefault=false",
           "--providers.docker.constraints=Label(`traefik.port`,`443`)",
+          "--serversTransport.insecureSkipVerify=true",
           "--entryPoints.web.http.redirections.entryPoint.scheme=https",
           "--entryPoints.web.http.redirections.entryPoint.permanent=true",
           "--entryPoints.web.http.redirections.entryPoint.to=:443",

--- a/test/dependency-manager/interfaces.test.ts
+++ b/test/dependency-manager/interfaces.test.ts
@@ -292,6 +292,7 @@ describe('interfaces spec v1', () => {
           `traefik.http.routers.${leaf_api_ref}-api.rule=Host(\`public.arc.localhost\`)`,
           `traefik.http.routers.${leaf_api_ref}-api.service=${leaf_api_ref}-api-service`,
           `traefik.http.services.${leaf_api_ref}-api-service.loadbalancer.server.port=8080`,
+          `traefik.http.services.${leaf_api_ref}-api-service.loadbalancer.server.scheme=http`
         ],
         image: 'api:latest',
         ports: ['50001:8080'],
@@ -329,6 +330,7 @@ describe('interfaces spec v1', () => {
           `traefik.http.routers.${other_leaf_api_ref}-api.rule=Host(\`publicv1.arc.localhost\`)`,
           `traefik.http.routers.${other_leaf_api_ref}-api.service=${other_leaf_api_ref}-api-service`,
           `traefik.http.services.${other_leaf_api_ref}-api-service.loadbalancer.server.port=8080`,
+          `traefik.http.services.${other_leaf_api_ref}-api-service.loadbalancer.server.scheme=http`
         ],
         image: 'api:latest',
         ports: ['50003:8080'],
@@ -393,9 +395,11 @@ describe('interfaces spec v1', () => {
         `traefik.http.routers.${api_ref}-app.rule=Host(\`app.arc.localhost\`)`,
         `traefik.http.routers.${api_ref}-app.service=${api_ref}-app-service`,
         `traefik.http.services.${api_ref}-app-service.loadbalancer.server.port=8080`,
+        `traefik.http.services.${api_ref}-app-service.loadbalancer.server.scheme=http`,
         `traefik.http.routers.${api_ref}-admin.rule=Host(\`admin.arc.localhost\`)`,
         `traefik.http.routers.${api_ref}-admin.service=${api_ref}-admin-service`,
         `traefik.http.services.${api_ref}-admin-service.loadbalancer.server.port=8081`,
+        `traefik.http.services.${api_ref}-admin-service.loadbalancer.server.scheme=http`
       ],
       "external_links": [
         "gateway:app.arc.localhost",
@@ -476,15 +480,19 @@ describe('interfaces spec v1', () => {
         `traefik.http.routers.${api_ref}-app.rule=Host(\`app.arc.localhost\`)`,
         `traefik.http.routers.${api_ref}-app.service=${api_ref}-app-service`,
         `traefik.http.services.${api_ref}-app-service.loadbalancer.server.port=8080`,
+        `traefik.http.services.${api_ref}-app-service.loadbalancer.server.scheme=http`,
         `traefik.http.routers.${api_ref}-admin.rule=Host(\`staff.arc.localhost\`)`,
         `traefik.http.routers.${api_ref}-admin.service=${api_ref}-admin-service`,
         `traefik.http.services.${api_ref}-admin-service.loadbalancer.server.port=8081`,
+        `traefik.http.services.${api_ref}-admin-service.loadbalancer.server.scheme=http`,
         `traefik.http.routers.${api_ref}-admin2.rule=Host(\`staff2.arc.localhost\`)`,
         `traefik.http.routers.${api_ref}-admin2.service=${api_ref}-admin2-service`,
         `traefik.http.services.${api_ref}-admin2-service.loadbalancer.server.port=8081`,
+        `traefik.http.services.${api_ref}-admin2-service.loadbalancer.server.scheme=http`,
         `traefik.http.routers.${api_ref}-admin3.rule=Host(\`staff3.arc.localhost\`)`,
         `traefik.http.routers.${api_ref}-admin3.service=${api_ref}-admin3-service`,
         `traefik.http.services.${api_ref}-admin3-service.loadbalancer.server.port=8081`,
+        `traefik.http.services.${api_ref}-admin3-service.loadbalancer.server.scheme=http`,
       ],
       "external_links": [
         "gateway:app.arc.localhost",

--- a/test/dependency-manager/interpolation.test.ts
+++ b/test/dependency-manager/interpolation.test.ts
@@ -1314,8 +1314,9 @@ describe('interpolation spec v1', () => {
     expect(node.config.interfaces).to.deep.eq({
       api: {
         url: `http://${api_ref}:8080`,
+        protocol: 'http',
         ingress: {
-          subdomain: 'test'
+          subdomain: 'test',
         }
       }
     });
@@ -1363,12 +1364,14 @@ describe('interpolation spec v1', () => {
     expect(node.config.interfaces).to.deep.eq({
       api: {
         url: `http://${api_ref}:8080`,
+        protocol: 'http',
         ingress: {
           ip_whitelist: ['127.0.0.1']
         }
       },
       api2: {
         url: `http://${api_ref}:8080`,
+        protocol: 'http',
         ingress: {
           ip_whitelist: ['127.0.0.1/32']
         }
@@ -1421,12 +1424,14 @@ describe('interpolation spec v1', () => {
     expect(node.config.interfaces).to.deep.eq({
       api: {
         url: `http://${api_ref}:8080`,
+        protocol: 'http',
         ingress: {
           ip_whitelist: ['1.2.3.4']
         }
       },
       api2: {
         url: `http://${api_ref}:8080`,
+        protocol: 'http',
         ingress: {
           ip_whitelist: ['127.0.0.1/32']
         }

--- a/test/dependency-manager/interpolation.test.ts
+++ b/test/dependency-manager/interpolation.test.ts
@@ -231,6 +231,7 @@ describe('interpolation spec v1', () => {
         `traefik.http.routers.${web_ref}-main.rule=Host(\`public.arc.localhost\`)`,
         `traefik.http.routers.${web_ref}-main.service=${web_ref}-main-service`,
         `traefik.http.services.${web_ref}-main-service.loadbalancer.server.port=8080`,
+        `traefik.http.services.${web_ref}-main-service.loadbalancer.server.scheme=http`,
       ],
       external_links: [
         'gateway:public.arc.localhost'
@@ -319,6 +320,7 @@ describe('interpolation spec v1', () => {
       `traefik.http.routers.${backend_interface_ref}.rule=Host(\`main.arc.localhost\`)`,
       `traefik.http.routers.${backend_interface_ref}.service=${backend_interface_ref}-service`,
       `traefik.http.services.${backend_interface_ref}-service.loadbalancer.server.port=8081`,
+      `traefik.http.services.${backend_interface_ref}-service.loadbalancer.server.scheme=http`
     ])
   });
 


### PR DESCRIPTION
## Issue
Traefik by default assumes that the downstream system is http. This is not always true since some systems handle their own https connections. 

## Fix
This does two main things.
1. Tell Traefik to ignore self signed certs in the downstream.
2. Tell the load balancer which protocol to use if its defined. This will defer to the protocol field but also attempt to parse the url if available.

## Test
Tested with our local stack and everything seems to be working.