### PR TITLE
Add output type to dev list

### DIFF
--- a/src/commands/dev/list.ts
+++ b/src/commands/dev/list.ts
@@ -62,7 +62,7 @@ export default class DevList extends BaseCommand {
         };
       }
     }
-    this.log(util.inspect(output, false, 5));
+    this.log(JSON.stringify(output, null, 2));
   }
 
   @RequiresDocker({ compose: true })

--- a/src/commands/dev/list.ts
+++ b/src/commands/dev/list.ts
@@ -1,6 +1,10 @@
+import { Flags } from '@oclif/core';
+import * as util from 'util';
+import { Dictionary } from '../..';
 import BaseCommand from '../../base-command';
 import BaseTable from '../../base-table';
 import { DockerComposeUtils } from '../../common/docker-compose';
+import { DockerInspect } from '../../common/docker-compose/template';
 import { RequiresDocker } from '../../common/docker/helper';
 
 export default class DevList extends BaseCommand {
@@ -8,26 +12,68 @@ export default class DevList extends BaseCommand {
     return false;
   }
 
+  static flags = {
+    format: Flags.string({
+      char: 'f',
+      description: `Format to output data in. Table or JSON`,
+      default: 'table',
+      options: ['TABLE', 'table', 'JSON', 'json'],
+    }),
+  };
+
   static description = 'List all running dev instances.';
   static examples = ['architect link:list'];
 
-  @RequiresDocker({ compose: true })
-  async run(): Promise<void> {
-    const local_env_map = await  DockerComposeUtils.getLocalEnvironmentContainerMap();
+  outputTable(local_env_map: Dictionary<DockerInspect[]>): void {
     const table = new BaseTable({ head: ['Environment', 'Containers', 'Status'] });
 
     for (const [env_name, containers] of Object.entries(local_env_map)) {
-      const container_names = containers.map(c => {
-        if ('com.docker.compose.service' in c.Config.Labels) {
-          return c.Config.Labels['com.docker.compose.service'];
-        }
-        // Fallback in case compose label isn't present for some reason - this is the image name
-        return c.Name;
-      }).join('\n');
-      const statuses = containers.map(c => c.State.Status).join('\n');
+      const container_names = this.getContainerNames(containers).join('\n');
+      const statuses = this.getContainerStates(containers).join('\n');
       table.push([env_name, container_names, statuses]);
     }
 
     this.log(table.toString());
+  }
+
+  getContainerStates(containers: DockerInspect[]): string[] {
+    return containers.map(c => c.State.Status);
+  }
+
+  getContainerNames(containers: DockerInspect[]): string[] {
+    return containers.map(c => {
+      if ('com.docker.compose.service' in c.Config.Labels) {
+        return c.Config.Labels['com.docker.compose.service'];
+      }
+      // Fallback in case compose label isn't present for some reason - this is the image name
+      return c.Name;
+    });
+  }
+
+  outputJSON(local_env_map: Dictionary<DockerInspect[]>): void {
+    const output: Dictionary<any> = {};
+    for (const [env_name, containers] of Object.entries(local_env_map)) {
+      output[env_name] = {} as Dictionary<any>;
+      const container_names = this.getContainerNames(containers);
+      const statuses = this.getContainerStates(containers);
+      for (let i = 0; i < container_names.length; i++) {
+        output[env_name][container_names[i]] = {
+          status: statuses[i],
+        };
+      }
+    }
+    this.log(util.inspect(output, false, 5));
+  }
+
+  @RequiresDocker({ compose: true })
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(DevList);
+
+    const local_env_map = await DockerComposeUtils.getLocalEnvironmentContainerMap();
+    if (flags.format.toLowerCase() === 'table') {
+      this.outputTable(local_env_map);
+    } else {
+      this.outputJSON(local_env_map);
+    }
   }
 }

--- a/test/commands/dev/list.test.ts
+++ b/test/commands/dev/list.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@oclif/test';
 import sinon, { SinonSpy } from 'sinon';
-import * as util from 'util';
 import BaseTable from '../../../src/base-table';
 import DevList from '../../../src/commands/dev/list';
 import { DockerComposeUtils } from '../../../src/common/docker-compose';
@@ -141,9 +140,9 @@ describe('dev:list', () => {
     .stub(DockerComposeUtils, 'getLocalEnvironmentContainerMap', sinon.stub().returns(fourth_env))
     .stub(DevList.prototype, 'log', sinon.fake.returns(null))
     .command(['dev:list', '-f=json'])
-    .it('dev list multiple environments with many containers', ctx => {
+    .it('dev list multiple environments with many containers', () => {
       const log_spy = DevList.prototype.log as SinonSpy;
-      expect(log_spy.firstCall.args[0]).to.equal(util.inspect(many_env_many_containers_json, false, 5));
+      expect(log_spy.firstCall.args[0]).to.equal(JSON.stringify(many_env_many_containers_json, null, 2));
     });
 
   mockArchitectAuth


### PR DESCRIPTION
## Overview
Dev list allows a user to understand what is running in the background, but if you want to automate behavior based on it, you need to create a special parser to read the data. This allows us to output the same format in json which is much easier to read.


## Changes
Add `--format` to dev list. Default behavior does not change, but you can also choose json.


## Tests
Added 1 new unit test
Tested it out
<img width="1152" alt="image" src="https://user-images.githubusercontent.com/532523/190725644-2c652489-b82f-417f-acc0-77354e723fe9.png">
