### PR TITLE
Dont always try to setRawMode in runLocal, only do so if tty

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -373,8 +373,9 @@ Alternatively, running "architect --% exec -- ls" will prevent the PowerShell pa
     const service = await DockerComposeUtils.getLocalServiceForEnvironment(compose_file, args.resource);
 
     const compose_args = ['-f', compose_file, '-p', environment_name, 'exec'];
+    const use_tty = flags.tty && process.stdout.isTTY;
     // https://docs.docker.com/compose/reference/exec/
-    if (!flags.tty || !process.stdout.isTTY) {
+    if (!use_tty) {
       compose_args.push('-T');
     }
     compose_args.push(service.name);
@@ -383,7 +384,7 @@ Alternatively, running "architect --% exec -- ls" will prevent the PowerShell pa
       compose_args.push(arg);
     }
 
-    await DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit' }, true);
+    await DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit' }, use_tty);
   }
 
   async run(): Promise<void> {

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -454,7 +454,7 @@ export class DockerComposeUtils {
 
   @RequiresDocker({ compose: true })
   public static dockerCompose(args: string[], execa_opts?: Options, use_console = false): execa.ExecaChildProcess<string> {
-    if (use_console) {
+    if (use_console && process.stdin.isTTY) {
       process.stdin.setRawMode(true);
     }
     const cmd = execa('docker', ['compose', ...args], execa_opts);

--- a/src/common/docker/buildx.utils.ts
+++ b/src/common/docker/buildx.utils.ts
@@ -80,7 +80,7 @@ export default class DockerBuildXUtils {
 
   @RequiresDocker({ buildx: true })
   public static async dockerBuildX(args: string[], docker_builder_name: string, execa_opts?: Options, use_console = false): Promise<execa.ExecaChildProcess<string>> {
-    if (use_console) {
+    if (use_console && process.stdin.isTTY) {
       process.stdin.setRawMode(true);
     }
     const cmd = execa('docker', [`--context=${docker_builder_name}-context`, 'buildx', '--builder', docker_builder_name, ...args], execa_opts);


### PR DESCRIPTION
Saw Michael ran into this issue on Friday and noticed that the tty testing I was doing a month or so back was almost exclusively in the `runRemote` method and I didn't verify that local worked. We always passed `true` which attempted to call `process.stdin.setRawMode(true)`, which only works if `process.stdin` is a tty ReadStream.

sentry error: https://sentry.io/organizations/architect-io/issues/3598979632/?project=6465948&referrer=slack