### PR TITLE
Fix issue where if the terminal is closed, the socket isnt cleaned up but still exists

### DIFF
--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -101,11 +101,11 @@ class UpProcessManager {
     let recreated_socket = false;
     this.server.on('error', (e: any) => {
       if (e.code === 'EADDRINUSE' && this.server && !recreated_socket) {
+        recreated_socket = true;
         // Socket already exists (likely from a previous run that didnt get cleaned up properly)
         // Remove it and listen again creating a new socket.
         fs.rmSync(this.socket);
         this.server.listen(this.socket);
-        recreated_socket = true;
       } else {
         throw e;
       }

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -98,12 +98,16 @@ class UpProcessManager {
       });
     });
 
+    let recreated_socket = false;
     this.server.on('error', (e: any) => {
-      if (e.code === 'EADDRINUSE' && this.server) {
+      if (e.code === 'EADDRINUSE' && this.server && !recreated_socket) {
         // Socket already exists (likely from a previous run that didnt get cleaned up properly)
         // Remove it and listen again creating a new socket.
         fs.rmSync(this.socket);
         this.server.listen(this.socket);
+        recreated_socket = true;
+      } else {
+        throw e;
       }
     });
 

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -89,7 +89,7 @@ class UpProcessManager {
     const compose_process = DockerComposeUtils.dockerCompose(compose_args,
       { stdout: 'pipe', stdin: 'ignore', detached: !this.is_windows });
 
-    this.server = net.createServer().listen(this.socket);
+    this.server = net.createServer();
     this.server.on('connection', (socket) => {
       socket.on('data', (d) => {
         if (d.toString('utf-8') === 'stop') {
@@ -110,6 +110,8 @@ class UpProcessManager {
         throw e;
       }
     });
+
+    this.server.listen(this.socket);
 
     return compose_process;
   }

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -98,6 +98,15 @@ class UpProcessManager {
       });
     });
 
+    this.server.on('error', (e: any) => {
+      if (e.code === 'EADDRINUSE' && this.server) {
+        // Socket already exists (likely from a previous run that didnt get cleaned up properly)
+        // Remove it and listen again creating a new socket.
+        fs.rmSync(this.socket);
+        this.server.listen(this.socket);
+      }
+    });
+
     return compose_process;
   }
 

--- a/src/commands/dev/stop.ts
+++ b/src/commands/dev/stop.ts
@@ -49,6 +49,11 @@ export default class DevStop extends BaseCommand {
     return false;
   }
 
+  runComposeStop(project: string): void {
+    const compose_file = DockerComposeUtils.buildComposeFilepath(this.app.config.getConfigDir(), project);
+    DockerComposeUtils.dockerCompose(['-p', project, '-f', compose_file, 'stop']);
+  }
+
   @RequiresDocker({ compose: true })
   async run(): Promise<void> {
     const { args } = await this.parse(DevStop);
@@ -79,11 +84,19 @@ export default class DevStop extends BaseCommand {
       socket.write('stop', () => {
         socket.end();
       });
+
+      socket.on('error', (e: any) => {
+        if (e.code === 'ECONNREFUSED') {
+          socket.end();
+          this.runComposeStop(name);
+        } else {
+          throw new Error(e);
+        }
+      });
     } else {
-      // If there's no socket, dev is running in detached mode and we can stop it with docker compose without
+      // If there's no socket at all, dev is running in detached mode and we can stop it with docker compose without
       // working about the health check restarting anything.
-      const compose_file = DockerComposeUtils.buildComposeFilepath(this.app.config.getConfigDir(), name);
-      DockerComposeUtils.dockerCompose(['-p', name, '-f', compose_file, 'stop']);
+      this.runComposeStop(name);
     }
 
     CliUx.ux.action.start(chalk.blue(`Waiting for ${name} to stop...`));

--- a/src/commands/dev/stop.ts
+++ b/src/commands/dev/stop.ts
@@ -90,7 +90,7 @@ export default class DevStop extends BaseCommand {
           socket.end();
           this.runComposeStop(name);
         } else {
-          throw new Error(e);
+          throw e;
         }
       });
     } else {

--- a/src/commands/dev/stop.ts
+++ b/src/commands/dev/stop.ts
@@ -81,9 +81,6 @@ export default class DevStop extends BaseCommand {
     const socket_path = socketPath(path.join(this.app.config.getConfigDir(), LocalPaths.LOCAL_DEPLOY_PATH, name));
     if (fs.existsSync(socket_path)) {
       const socket = net.createConnection(socket_path);
-      socket.write('stop', () => {
-        socket.end();
-      });
 
       socket.on('error', (e: any) => {
         if (e.code === 'ECONNREFUSED') {
@@ -92,6 +89,10 @@ export default class DevStop extends BaseCommand {
         } else {
           throw e;
         }
+      });
+
+      socket.write('stop', () => {
+        socket.end();
       });
     } else {
       // If there's no socket at all, dev is running in detached mode and we can stop it with docker compose without

--- a/test/commands/dev/stop.test.ts
+++ b/test/commands/dev/stop.test.ts
@@ -28,6 +28,9 @@ describe('dev:stop', () => {
     write: () => {
       return;
     },
+    on: () => {
+      return;
+    }
   };
 
   mockArchitectAuth


### PR DESCRIPTION
Note: This is only a problem on Unix environments. Windows sockets get cleaned up automatically when the process that spawned them is closed, so closing the powershell / cmd window with the `architect dev` process closes the socket. 


To reproduce the issue on Unix systems:

- Run `architect dev`, once it starts, close the terminal window
- In a new window, `architect dev:stop` will throw an error because the socket exists but nobody is listening.
- If you stop the docker containers yourself, and run `architect dev` again, it blows up because the socket already exists.
- Only workaround without this change is to manually `rm` the socket