### PR TITLE
544 no dev instances console message

### DIFF
--- a/src/commands/dev/list.ts
+++ b/src/commands/dev/list.ts
@@ -32,7 +32,7 @@ export default class DevList extends BaseCommand {
       table.push([env_name, container_names, statuses]);
     }
     if (!table.length) {
-      this.log('There have no active dev instances yet. Use `architect dev` to create one.');
+      this.log('There are no active dev instances yet. Use `architect dev` to create one.');
     } else {
       this.log(table.toString());
     }

--- a/src/commands/dev/list.ts
+++ b/src/commands/dev/list.ts
@@ -1,5 +1,4 @@
 import { Flags } from '@oclif/core';
-import * as util from 'util';
 import { Dictionary } from '../..';
 import BaseCommand from '../../base-command';
 import BaseTable from '../../base-table';
@@ -32,8 +31,11 @@ export default class DevList extends BaseCommand {
       const statuses = this.getContainerStates(containers).join('\n');
       table.push([env_name, container_names, statuses]);
     }
-
-    this.log(table.toString());
+    if (!table.length) {
+      this.log('There have no active dev instances yet. Use `architect dev` to create one.');
+    } else {
+      this.log(table.toString());
+    }
   }
 
   getContainerStates(containers: DockerInspect[]): string[] {
@@ -57,7 +59,11 @@ export default class DevList extends BaseCommand {
         };
       }
     }
-    this.log(JSON.stringify(output, null, 2));
+    if (!Object.keys(output).length) {
+      this.log('There are no active dev instances yet. Use `architect dev` to create one.');
+    } else {
+      this.log(JSON.stringify(output, null, 2));
+    }
   }
 
   @RequiresDocker({ compose: true })


### PR DESCRIPTION
## Overview
Architect dev:list displays empty column headers instead of a message similar to components or environments when none are found.

## Purpose
Update dev:list to display a similar message as components or environments when no running services are found. 

## Changes
Add table length and json length check before printing to console. Print friendly alternative message if no services are running.

## Tests

### Running dev instances: 
```sh
architect dev:list
architect dev:list --format json
```
### No Running dev instances:
```sh
architect dev:list
architect dev:list --format json
architect dev:list --format JSON
architect dev:list --format table
architect dev:list --format TABLE
```

## Docs
N/A

## Pictures
please see: https://gitlab.com/architect-io/architect-cli/-/issues/544
