### PR TITLE
always print json format when json format flag is specified

### DIFF
--- a/src/commands/dev/list.ts
+++ b/src/commands/dev/list.ts
@@ -59,11 +59,7 @@ export default class DevList extends BaseCommand {
         };
       }
     }
-    if (!Object.keys(output).length) {
-      this.log('There are no active dev instances yet. Use `architect dev` to create one.');
-    } else {
-      this.log(JSON.stringify(output, null, 2));
-    }
+    this.log(JSON.stringify(output, null, 2));
   }
 
   @RequiresDocker({ compose: true })


### PR DESCRIPTION
update output for json dev empty to be empty set

---
### Edit

Tested just to be sure the changes will only affect output when using  json format flag specifically.
```
architect-local dev:list --format JSON
{}
architect-local dev:list --format json
{}
architect-local dev:list --format table
There are no active dev instances yet. Use `architect dev` to create one.
architect-local dev:list --format TABLE
There are no active dev instances yet. Use `architect dev` to create one.
architect-local dev:list
There are no active dev instances yet. Use `architect dev` to create one.
```
