### PR TITLE
Default to track=false for ArchitectError

### DIFF
--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -565,7 +565,7 @@ export default class Dev extends BaseCommand {
       this.downloadFileAndCache('https://storage.googleapis.com/architect-ci-ssl/privkey.pem', path.join(this.app.config.getConfigDir(), 'privkey.pem')),
     ]).catch((err) => {
       this.warn(chalk.yellow('We are unable to download the neccessary ssl certificates. Please try again or use --ssl=false to temporarily disable ssl'));
-      this.error(new ArchitectError(err.message, false));
+      this.error(new ArchitectError(err.message));
     });
   }
 
@@ -585,7 +585,7 @@ $ architect dev:stop ${environment}
 
 To continue running the other environment and create a new one you can run the \`dev\` command with the \`-e\` flag
 $ architect dev -e new_env_name_here .`));
-      this.error(new ArchitectError("Environment name already in use.", false));
+      this.error(new ArchitectError("Environment name already in use."));
     }
   }
 

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -250,7 +250,7 @@ export default class ComponentRegister extends BaseCommand {
         });
       } catch (err: any) {
         fs.removeSync(compose_file);
-        this.error(new ArchitectError(err.message, false));
+        this.error(new ArchitectError(err.message));
       }
     }
 

--- a/src/common/docker/helper.ts
+++ b/src/common/docker/helper.ts
@@ -135,25 +135,25 @@ class _DockerHelper {
 
   verifyDocker(): void {
     if (!this.docker_installed) {
-      throw new ArchitectError('Architect requires Docker to be installed.\nPlease install docker and try again: https://docs.docker.com/engine/install/', false);
+      throw new ArchitectError('Architect requires Docker to be installed.\nPlease install docker and try again: https://docs.docker.com/engine/install/');
     }
   }
 
   verifyBuildX(): void {
     if (!this.docker_info.buildx) {
-      throw new ArchitectError("'docker buildx' is not available.\nDocker engine must be updated - visit https://docs.docker.com/engine/install/ or install updates via Docker Desktop.", false);
+      throw new ArchitectError("'docker buildx' is not available.\nDocker engine must be updated - visit https://docs.docker.com/engine/install/ or install updates via Docker Desktop.");
     }
   }
 
   verifyCompose(): void {
     if (!this.docker_info.compose) {
-      throw new ArchitectError("'docker compose' is not available.\nDocker engine must be updated - visit https://docs.docker.com/engine/install/ or install updates via Docker Desktop.", false);
+      throw new ArchitectError("'docker compose' is not available.\nDocker engine must be updated - visit https://docs.docker.com/engine/install/ or install updates via Docker Desktop.");
     }
   }
 
   verifyDaemon() {
     if (!this.daemonRunning()) {
-      throw new ArchitectError('Docker daemon is not running. Please start it and try again.', false);
+      throw new ArchitectError('Docker daemon is not running. Please start it and try again.');
     }
   }
 

--- a/src/dependency-manager/utils/errors.ts
+++ b/src/dependency-manager/utils/errors.ts
@@ -47,11 +47,10 @@ const addLineNumbers = (value: string, errors: ValidationError[]): void => {
 
 export class ArchitectError extends Error {
   // When track is true, the exception will be captured by endSentryTransaction.
-  // Should be set to false when a raised error is an issue on the users end that doesn't have
-  // anything actionable for us to do.
+  // Set to true when constructing an error that should be reported via Sentry.
   track: boolean;
 
-  constructor(msg?: string, track = true) {
+  constructor(msg?: string, track = false) {
     super(msg);
     this.track = track;
   }


### PR DESCRIPTION
I checked existing ArchitectError's to see if any are things we should actually be alerted of, and no existing ArchitectErrors or errors that extend ArchitectError were something actionable. They are all handled exceptions that report useful info back to the user, so we don't need to receive alerts about them.