### PR TITLE
548 http/https validation error

### DIFF
--- a/examples/nestjs-microservices/simple/architect.yml
+++ b/examples/nestjs-microservices/simple/architect.yml
@@ -1,10 +1,9 @@
 name: nestjs-simple
-description: Simple NestJS microservice that uses TCP for inter-process communication
+description: Simple NestJS microservice
 homepage: https://github.com/architect-team/architect-cli/tree/main/examples/nestjs-microservices/simple
 keywords:
   - nestjs
   - examples
-  - tcp
   - microservices
 
 interfaces:
@@ -22,7 +21,6 @@ services:
     interfaces:
       main:
         port: 8080
-        protocol: tcp
     debug:
       command: npm run start:dev
       build:

--- a/src/dependency-manager/manager.ts
+++ b/src/dependency-manager/manager.ts
@@ -21,7 +21,6 @@ import { validateOrRejectSpec } from './spec/utils/spec-validator';
 import { Dictionary, transformDictionary } from './utils/dictionary';
 import { ArchitectError, ValidationError, ValidationErrors } from './utils/errors';
 import { interpolateObjectLoose, interpolateObjectOrReject, replaceInterpolationBrackets } from './utils/interpolation';
-
 export default abstract class DependencyManager {
 
   account?: string;
@@ -378,7 +377,8 @@ export default abstract class DependencyManager {
 
       const component_interfaces = node.config.interfaces;
       for (const [component_name, component_interface] of Object.entries(component_interfaces)) {
-        if (component_interface.protocol !== 'http' && component_interface.protocol !== 'https') {
+        const valid_protocol = [undefined, 'http', 'https'];
+        if (valid_protocol.indexOf(component_interface.protocol) === -1) {
           throw new ArchitectError(`Protocol '${component_interface.protocol}' is detected in component '${component_name}'. We currently only support 'http' and 'https' protocols.`);
         }
       }

--- a/src/dependency-manager/manager.ts
+++ b/src/dependency-manager/manager.ts
@@ -371,6 +371,19 @@ export default abstract class DependencyManager {
   }
 
   validateGraph(graph: DependencyGraph): void {
+    // Check for protocols that are not http or https
+    for (const node of graph.nodes) {
+      if (node.is_external) continue;
+      if (!(node instanceof ComponentNode)) continue;
+
+      const component_interfaces = node.config.interfaces;
+      for (const [component_name, component_interface] of Object.entries(component_interfaces)) {
+        if (component_interface.protocol !== 'http' && component_interface.protocol !== 'https') {
+          throw new ArchitectError(`Protocol '${component_interface.protocol}' is detected in component '${component_name}'. We currently only support 'http' and 'https' protocols.`);
+        }
+      }
+    }
+
     // Check for duplicate subdomains
     const seen_subdomains: Dictionary<string[]> = {};
     for (const ingress_edge of graph.edges.filter((edge) => edge instanceof IngressEdge)) {
@@ -562,6 +575,7 @@ export default abstract class DependencyManager {
   }
 
   async getGraph(component_specs: ComponentSpec[], all_secrets: SecretsDict = {}, options?: GraphOptions): Promise<DependencyGraph> {
+    console.log("in getGraph()");
     options = {
       ...{
         interpolate: true,

--- a/src/dependency-manager/manager.ts
+++ b/src/dependency-manager/manager.ts
@@ -575,7 +575,6 @@ export default abstract class DependencyManager {
   }
 
   async getGraph(component_specs: ComponentSpec[], all_secrets: SecretsDict = {}, options?: GraphOptions): Promise<DependencyGraph> {
-    console.log("in getGraph()");
     options = {
       ...{
         interpolate: true,

--- a/test/dependency-manager/graph.test.ts
+++ b/test/dependency-manager/graph.test.ts
@@ -28,7 +28,7 @@ describe('graph', () => {
           interfaces:
             mysql:
               port: 3306
-              protocol: mysql
+              protocol: https
 
         core:
           environment:

--- a/test/dependency-manager/interfaces.test.ts
+++ b/test/dependency-manager/interfaces.test.ts
@@ -681,7 +681,6 @@ describe('interfaces spec v1', () => {
           interfaces:
             smtp:
               port: 1025
-              protocol: smtp
               username: test-user
               password: test-pass
             dashboard: 1080
@@ -721,7 +720,7 @@ describe('interfaces spec v1', () => {
 
     const test_node = graph.getNodeByRef(app_ref) as ServiceNode;
     expect(test_node.config.environment).to.deep.eq({
-      SMTP_ADDR: `smtp://test-user:test-pass@${mail_ref}:1025`,
+      SMTP_ADDR: `http://test-user:test-pass@${mail_ref}:1025`,
       SMTP_USER: 'test-user',
       SMTP_PASS: 'test-pass',
     });

--- a/test/dependency-manager/validation.test.ts
+++ b/test/dependency-manager/validation.test.ts
@@ -1357,6 +1357,38 @@ services:
     expect(process.exitCode).eq(1);
   });
 
+   it('valid component with protocol of undefined', async () => {
+    const component_config = `
+      name: test/component
+      interfaces:
+        main: \${{ services.app.interfaces.mysql.url }}
+      services:
+        app:
+          image: mysql:5.6.35
+          command: mysqld
+          interfaces:
+            mysql:
+              port: 3306
+              protocol: https
+      `;
+    mock_fs({
+      '/component.yml': component_config,
+    });
+    const manager = new LocalDependencyManager(axios.create(), {
+      'test/component': '/component.yml',
+    });
+
+    let err;
+    try {
+      await manager.getGraph([
+        await manager.loadComponentSpec('test/component'),
+      ], {}, { interpolate: false });
+    } catch (e: any) {
+      err = e;
+    }
+    expect(err).to.be.undefined;
+  });
+
   it('invalid component interface number', async () => {
     const component_config = `
       name: test/component


### PR DESCRIPTION
## Overview
Closes https://gitlab.com/architect-io/architect-cli/-/issues/548.  
Since Traefik only supports http/https protocols, we want to throw an error if other protocols are provided.


## Changes
Add a validation error to validateGraph if the protocol is not http, https, or undefined.


## Tests
- Add a protocol (Ex. tcp) to a component interface
```
interfaces:
      main: 3000
      protocol: tcp
```
- architect dev .

