### PR TITLE
Allow account selection if component account is not found

### DIFF
--- a/src/architect/account/account.utils.ts
+++ b/src/architect/account/account.utils.ts
@@ -37,7 +37,15 @@ export default class AccountUtils {
     return account.id === "dev";
   }
 
-  static async getAccount(app: AppService, account_name?: string, options?: { account_message?: string, ask_local_account?: boolean, is_component_account_name?: boolean }): Promise<Account> {
+  static async isValidAccount(app: AppService, account_name: string): Promise<boolean> {
+    const { data: user_data } = await app.api.get('/users/me');
+    if (user_data.memberships?.length > 0) {
+      return user_data.memberships.some((membership: Membership) => membership.account.name === account_name);
+    }
+    return false;
+  }
+
+  static async getAccount(app: AppService, account_name?: string, options?: { account_message?: string, ask_local_account?: boolean }): Promise<Account> {
     const config_account = app.config.defaultAccount();
     // Set the account name from the config only if an account name wasn't set as cli flag
     if (config_account && !account_name && !options?.ask_local_account) {
@@ -70,17 +78,6 @@ export default class AccountUtils {
       ]);
 
       return this.getLocalAccount();
-    }
-
-    if (options?.is_component_account_name) {
-      const { data: user_data } = await app.api.get('/users/me');
-      if (user_data.memberships?.length > 0) {
-        const account = user_data.memberships.find((membership: Membership) => membership.account.name === account_name);
-        if (!account) {
-          console.log(chalk.yellow(`The account name '${account_name}' was found as part of the component name in your architect.yml file. Either that account does not exist or you do not have permission to access it. You can select from a valid list of your accounts below.\n`));
-          account_name = '';
-        }
-      }
     }
 
     let account: Account;

--- a/src/architect/user/user.utils.ts
+++ b/src/architect/user/user.utils.ts
@@ -1,10 +1,19 @@
 import AppService from "../../app-config/service";
+import Account from "../account/account.entity";
+import User from "./user.entity";
+
+export default interface Membership {
+  id: string;
+  user: User;
+  account: Account;
+  role: string;
+}
 
 export default class UserUtils {
 
   static async isAdmin(app: AppService, account_id: string): Promise<boolean> {
     const { data: user } = await app.api.get('/users/me');
-    const membership = user.memberships?.find((membership: any) => membership.account.id === account_id);
+    const membership = user.memberships?.find((membership: Membership) => membership.account.id === account_id);
     return !!membership && membership.role !== 'MEMBER';
   }
 }

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -123,7 +123,17 @@ export default class ComponentRegister extends BaseCommand {
     validateInterpolation(component_spec);
 
     const { component_account_name, component_name } = ComponentSlugUtils.parse(component_spec.name);
-    const selected_account = await AccountUtils.getAccount(this.app, component_account_name || flags.account, { is_component_account_name: component_account_name !== undefined});
+    let is_valid_component_account;
+    if (component_account_name) {
+      is_valid_component_account = await AccountUtils.isValidAccount(this.app, component_account_name);
+      if (!is_valid_component_account) {
+        console.log(chalk.yellow(`The account name '${component_account_name}' was found as part of the component name in your architect.yml file. Either that account does not exist or you do not have permission to access it. You can select from a valid list of your accounts below.\n`));
+      }
+      component_spec.name = component_name;
+    }
+    const account_name = is_valid_component_account ? component_account_name : flags.account;
+    const selected_account = await AccountUtils.getAccount(this.app, account_name);
+    
     if (flags.environment) { // will throw an error if a user specifies an environment that doesn't exist
       await EnvironmentUtils.getEnvironment(this.app.api, selected_account, flags.environment);
     }

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -123,8 +123,7 @@ export default class ComponentRegister extends BaseCommand {
     validateInterpolation(component_spec);
 
     const { component_account_name, component_name } = ComponentSlugUtils.parse(component_spec.name);
-    const selected_account = await AccountUtils.getAccount(this.app, component_account_name || flags.account);
-
+    const selected_account = await AccountUtils.getAccount(this.app, component_account_name || flags.account, { is_component_account_name: component_account_name !== undefined});
     if (flags.environment) { // will throw an error if a user specifies an environment that doesn't exist
       await EnvironmentUtils.getEnvironment(this.app.api, selected_account, flags.environment);
     }
@@ -142,8 +141,8 @@ export default class ComponentRegister extends BaseCommand {
     }
 
     const getImage = (ref: string) => {
-      const { component_account_name, component_name, resource_type, resource_name } = ResourceSlugUtils.parse(ref);
-      const ref_with_account = ResourceSlugUtils.build(component_account_name || selected_account.name, component_name, resource_type, resource_name);
+      const { component_name, resource_type, resource_name } = ResourceSlugUtils.parse(ref);
+      const ref_with_account = ResourceSlugUtils.build(selected_account.name, component_name, resource_type, resource_name);
       const image = `${this.app.config.registry_host}/${ref_with_account}:${tag}`;
       return image;
     };
@@ -171,8 +170,8 @@ export default class ComponentRegister extends BaseCommand {
         const ref_label = service.labels.find(label => label.startsWith('architect.ref='));
         if (!ref_label) continue;
         const ref = ref_label.replace('architect.ref=', '');
-        const { component_account_name, component_name, resource_type, resource_name } = ResourceSlugUtils.parse(ref);
-        const ref_with_account = ResourceSlugUtils.build(component_account_name || selected_account.name, component_name, resource_type, resource_name);
+        const { component_name, resource_type, resource_name } = ResourceSlugUtils.parse(ref);
+        const ref_with_account = ResourceSlugUtils.build(selected_account.name, component_name, resource_type, resource_name);
 
         const buildx_platforms: string[] = DockerBuildXUtils.convertToBuildxPlatforms(flags['architecture']);
 
@@ -264,7 +263,7 @@ export default class ComponentRegister extends BaseCommand {
 
       delete service.debug; // we don't need to compare the debug block for remotely-deployed components
 
-      const ref = ResourceSlugUtils.build(component_account_name || selected_account.name, component_name, 'services', service_name);
+      const ref = ResourceSlugUtils.build(selected_account.name, component_name, 'services', service_name);
       const image = image_mapping[ref];
       if (image) {
         const digest = await this.getDigest(image);
@@ -281,7 +280,7 @@ export default class ComponentRegister extends BaseCommand {
 
       delete task.debug; // we don't need to compare the debug block for remotely-deployed components
 
-      const ref = ResourceSlugUtils.build(component_account_name || selected_account.name, component_name, 'tasks', task_name);
+      const ref = ResourceSlugUtils.build(selected_account.name, component_name, 'tasks', task_name);
       const image = image_mapping[ref];
       if (image) {
         const digest = await this.getDigest(image);

--- a/test/commands/register.test.ts
+++ b/test/commands/register.test.ts
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
 import fs from 'fs-extra';
 import yaml from 'js-yaml';
-import sinon, { SinonStub } from 'sinon';
+import sinon, { SinonSpy, SinonStub } from 'sinon';
 import { ServiceSpec, TaskSpec, validateSpec } from '../../src';
 import { DockerComposeUtils } from '../../src/common/docker-compose';
 import DockerComposeTemplate from '../../src/common/docker-compose/template';
 import DockerBuildXUtils from '../../src/common/docker/buildx.utils';
+import AccountUtils from '../../src/architect/account/account.utils';
 import { IF_EXPRESSION_REGEX } from '../../src/dependency-manager/spec/utils/interpolation';
 import { mockArchitectAuth, MOCK_API_HOST, MOCK_REGISTRY_HOST } from '../utils/mocks';
 
@@ -59,6 +60,7 @@ describe('register', function () {
     });
 
   mockArchitectAuth
+    .stub(AccountUtils, 'isValidAccount', sinon.stub().returns(false))
     .stub(DockerBuildXUtils, 'convertToBuildxPlatforms', sinon.stub().returns([]))
     .nock(MOCK_API_HOST, api => api
       .get(`/accounts/examples`)
@@ -248,6 +250,7 @@ describe('register', function () {
     });
 
   mockArchitectAuth
+    .stub(AccountUtils, 'isValidAccount', sinon.stub().returns(false))
     .nock(MOCK_API_HOST, api => api
       .get('/accounts/examples')
       .reply(403, {
@@ -636,4 +639,29 @@ describe('register', function () {
       expect(compose.secondCall).null;
     });
 
+  mockArchitectAuth
+    .stub(AccountUtils, 'isValidAccount', sinon.stub().returns(false))
+    .nock(MOCK_REGISTRY_HOST, api => api
+      .persist()
+      .head(/.*/)
+      .reply(200, '', { 'docker-content-digest': 'some-digest' })
+    )
+    .nock(MOCK_API_HOST, api => api
+      .get(`/accounts/examples`)
+      .reply(200, mock_architect_account_response)
+    )
+    .nock(MOCK_API_HOST, api => api
+      .persist()
+      .post(/\/accounts\/.*\/components/)
+      .reply(200, {})
+    )
+    .stdout({ print })
+    .stderr({ print })
+    .command(['register', 'test/mocks/register/architect.yml', '-a', 'examples'])
+    .it('register with invalid account in architect.yml will use account from command instead', ctx => {
+      const is_valid_account = AccountUtils.isValidAccount as SinonSpy;
+      expect(is_valid_account.getCalls().length).to.equal(1);
+      expect(ctx.stdout).to.contain(`The account name 'invalid-account' was found as part of the component name in your architect.yml file. Either that account does not exist or you do not have permission to access it.`);
+      expect(ctx.stdout).to.contain('Successfully registered component');
+    });
 });

--- a/test/mocks/register/architect.yml
+++ b/test/mocks/register/architect.yml
@@ -1,0 +1,15 @@
+name: invalid-account/hello-world
+description: Test invalid account in register command
+
+services:
+  api:
+    build:
+      context: .
+    interfaces:
+      main: 3000
+
+interfaces:
+  hello:
+    url: ${{ services.api.interfaces.main.url }}
+    ingress:
+      subdomain: hello


### PR DESCRIPTION
## Overview
Closes: https://gitlab.com/architect-io/architect-cli/-/issues/550  
When an invalid account name is specified in architect.yml, we inform the user with an error message and allow them to choose one of their existing accounts. 


## Changes
Search for the component account in user's list of accounts. If it's not found, print out the error message.


## Tests
- Change the component name in an architect.yml to `name: invalid-account-name/hello-world`
- Run `architect-local register .`

