### PR TITLE
556 ignore 409 status for env create

### DIFF
--- a/src/commands/environments/create.ts
+++ b/src/commands/environments/create.ts
@@ -86,10 +86,14 @@ export default class EnvironmentCreate extends BaseCommand {
     });
 
     const environment_url = `${this.app.config.app_host}/${account.name}/environments/${environment_name}`;
-    const environment_create_outcome = _environment_already_exists ?
-      chalk.yellow(`Unable to create new environment '${environment_name}'. Environment name already in use for account '${account.name}'`) :
-      chalk.green(`Environment created: ${environment_url}`);
 
-    CliUx.ux.action.stop(environment_create_outcome);
+    CliUx.ux.action.stop();
+
+    if (_environment_already_exists) {
+      this.warn(`Unable to create new environment '${environment_name}'. Environment name already in use for account '${account.name}'`);
+      return;
+    }
+
+    this.log(chalk.green(`Environment created: ${environment_url}`));
   }
 }

--- a/src/commands/environments/create.ts
+++ b/src/commands/environments/create.ts
@@ -76,10 +76,20 @@ export default class EnvironmentCreate extends BaseCommand {
     if (flags.ttl) {
       dto.ttl = flags.ttl;
     }
-    await this.app.api.post(`/accounts/${account.id}/environments`, dto);
+
+    let _environment_already_exists = false;
+    await this.app.api.post(`/accounts/${account.id}/environments`, dto, {
+      validateStatus: function (status): boolean {
+        _environment_already_exists = status === 409;
+        return status === 201 || _environment_already_exists;
+      },
+    });
 
     const environment_url = `${this.app.config.app_host}/${account.name}/environments/${environment_name}`;
-    CliUx.ux.action.stop();
-    this.log(chalk.green(`Environment created: ${environment_url}`));
+    const environment_create_outcome = _environment_already_exists ?
+      chalk.yellow(`Unable to create new environment '${environment_name}'. Environment name already in use for account '${account.name}'`) :
+      chalk.green(`Environment created: ${environment_url}`);
+
+    CliUx.ux.action.stop(environment_create_outcome);
   }
 }

--- a/test/commands/environments/create.test.ts
+++ b/test/commands/environments/create.test.ts
@@ -1,25 +1,26 @@
 import { expect } from '@oclif/test';
-import { mockArchitectAuth, MOCK_API_HOST } from '../../utils/mocks';
+import { mockArchitectAuth, MOCK_API_HOST, MOCK_APP_HOST } from '../../utils/mocks';
 
 describe('environment:create', () => {
-
   // set to true while working on tests for easier debugging; otherwise oclif/test eats the stdout/stderr
   const print = false;
 
   const mock_account = {
     id: 'test-account-id',
-    name: 'test-account'
+    name: 'test-account',
   };
 
   const mock_env = {
     id: 'test-env-id',
-    name: 'test-env'
+    name: 'test-env',
   };
 
   const mock_cluster = {
     id: 'test-cluster-id',
-    name: 'test-cluster'
+    name: 'test-cluster',
   };
+
+  const mock_url = `${MOCK_APP_HOST}/${mock_account.name}/environments/${mock_env.name}`;
 
   const create_environment = mockArchitectAuth()
     .nock(MOCK_API_HOST, api => api
@@ -34,10 +35,23 @@ describe('environment:create', () => {
     .stdout({ print })
     .stderr({ print });
 
+  const create_duplicate_environment = mockArchitectAuth()
+    .nock(MOCK_API_HOST, api => api
+      .get(`/accounts/${mock_account.name}`)
+      .reply(200, mock_account))
+    .nock(MOCK_API_HOST, api => api
+      .get(`/accounts/${mock_account.id}/clusters/${mock_cluster.name}`)
+      .reply(200, mock_cluster))
+    .nock(MOCK_API_HOST, api => api
+      .post(`/accounts/${mock_account.id}/environments`)
+      .reply(409))
+    .stdout({ print })
+    .stderr({ print });
+
   create_environment
     .command(['environment:create', mock_env.name, '-a', mock_account.name, '--cluster', mock_cluster.name])
     .it('should create an environment with the cluster flag', ctx => {
-      expect(ctx.stdout).to.contain('Environment created');
+      expect(ctx.stderr).to.contain(`Environment created: ${mock_url}`);
     });
 
   create_environment
@@ -45,14 +59,21 @@ describe('environment:create', () => {
     .command(['environment:create', mock_env.name, '-a', mock_account.name])
     .it('should create an environment with the cluster environment variable', ctx => {
       expect(ctx.stdout).to.contain(`Using cluster from environment variables: ${mock_cluster.name}`);
-      expect(ctx.stdout).to.contain('Environment created');
+      expect(ctx.stderr).to.contain(`Environment created: ${mock_url}`);
+    });
+
+  create_duplicate_environment
+    .env({ ARCHITECT_CLUSTER: mock_cluster.name })
+    .command(['environment:create', mock_env.name, '-a', mock_account.name])
+    .it('should print warning when an environment name already is registerd for an account', ctx => {
+      expect(ctx.stderr).to.contain(`Unable to create new environment '${mock_env.name}'. Environment name already in use for account '${mock_account.name}'`);
     });
 
   create_environment
     .command(['environment:create', mock_env.name, '-a', mock_account.name, '--platform', mock_cluster.name])
     .it('should create an environment with the platform flag, but with a deprecation warning', ctx => {
       expect(ctx.stderr).to.contain('Warning: The "platform" flag has been deprecated. Use "cluster" instead.');
-      expect(ctx.stdout).to.contain('Environment created');
+      expect(ctx.stderr).to.contain(`Environment created: ${mock_url}`);
     });
 
   create_environment
@@ -60,7 +81,7 @@ describe('environment:create', () => {
     .command(['environment:create', mock_env.name, '-a', mock_account.name])
     .it('should create an environment with the platform environment variable', ctx => {
       expect(ctx.stdout).to.contain(`Using cluster from environment variables: ${mock_cluster.name}`);
-      expect(ctx.stdout).to.contain('Environment created');
+      expect(ctx.stderr).to.contain(`Environment created: ${mock_url}`);
     });
 
   mockArchitectAuth()

--- a/test/commands/environments/create.test.ts
+++ b/test/commands/environments/create.test.ts
@@ -65,7 +65,7 @@ describe('environment:create', () => {
   create_duplicate_environment
     .env({ ARCHITECT_CLUSTER: mock_cluster.name })
     .command(['environment:create', mock_env.name, '-a', mock_account.name])
-    .it('should print warning when an environment name already is registerd for an account', ctx => {
+    .it('should print warning when an environment name is already in use for an account', ctx => {
       expect(ctx.stderr).to.contain(`Unable to create new environment '${mock_env.name}'. Environment name already in use for account '${mock_account.name}'`);
     });
 

--- a/test/commands/environments/create.test.ts
+++ b/test/commands/environments/create.test.ts
@@ -51,7 +51,8 @@ describe('environment:create', () => {
   create_environment
     .command(['environment:create', mock_env.name, '-a', mock_account.name, '--cluster', mock_cluster.name])
     .it('should create an environment with the cluster flag', ctx => {
-      expect(ctx.stderr).to.contain(`Environment created: ${mock_url}`);
+      expect(ctx.stdout).to.contain(`Environment created: ${mock_url}`);
+      expect(ctx.stderr).to.contain('done');
     });
 
   create_environment
@@ -59,7 +60,7 @@ describe('environment:create', () => {
     .command(['environment:create', mock_env.name, '-a', mock_account.name])
     .it('should create an environment with the cluster environment variable', ctx => {
       expect(ctx.stdout).to.contain(`Using cluster from environment variables: ${mock_cluster.name}`);
-      expect(ctx.stderr).to.contain(`Environment created: ${mock_url}`);
+      expect(ctx.stdout).to.contain(`Environment created: ${mock_url}`);
     });
 
   create_duplicate_environment
@@ -73,7 +74,7 @@ describe('environment:create', () => {
     .command(['environment:create', mock_env.name, '-a', mock_account.name, '--platform', mock_cluster.name])
     .it('should create an environment with the platform flag, but with a deprecation warning', ctx => {
       expect(ctx.stderr).to.contain('Warning: The "platform" flag has been deprecated. Use "cluster" instead.');
-      expect(ctx.stderr).to.contain(`Environment created: ${mock_url}`);
+      expect(ctx.stdout).to.contain(`Environment created: ${mock_url}`);
     });
 
   create_environment
@@ -81,7 +82,7 @@ describe('environment:create', () => {
     .command(['environment:create', mock_env.name, '-a', mock_account.name])
     .it('should create an environment with the platform environment variable', ctx => {
       expect(ctx.stdout).to.contain(`Using cluster from environment variables: ${mock_cluster.name}`);
-      expect(ctx.stderr).to.contain(`Environment created: ${mock_url}`);
+      expect(ctx.stdout).to.contain(`Environment created: ${mock_url}`);
     });
 
   mockArchitectAuth()

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -6,23 +6,26 @@ import { DockerComposeUtils } from '../../src/common/docker-compose';
 import DockerBuildXUtils from '../../src/common/docker/buildx.utils';
 
 export const MOCK_API_HOST = 'http://mock.api.localhost';
+export const MOCK_APP_HOST = 'http://mock.app.localhost';
 export const MOCK_REGISTRY_HOST = 'http://mock.registry.localhost';
 
-export const TMP_DIR = path.join(__dirname, '../tmp')
+export const TMP_DIR = path.join(__dirname, '../tmp');
 
 export const mockArchitectAuth = () =>
   test
     .stub(AuthClient.prototype, 'init', () => { })
     .stub(AuthClient.prototype, 'loginFromCli', () => { })
-    .stub(AuthClient.prototype, 'generateBrowserUrl', () => { return 'http://mockurl.com' })
+    .stub(AuthClient.prototype, 'generateBrowserUrl', () => {
+ return 'http://mockurl.com';
+})
     .stub(AuthClient.prototype, 'loginFromBrowser', () => { })
     .stub(AuthClient.prototype, 'logout', () => { })
     .stub(AuthClient.prototype, 'dockerLogin', () => { })
     .stub(AuthClient.prototype, 'getToken', () => {
       return {
         account: 'test-user',
-        password: 'test-password'
-      }
+        password: 'test-password',
+      };
     })
     .stub(AuthClient.prototype, 'refreshToken', () => { })
     .stub(DockerComposeUtils, 'dockerCompose', () => { })
@@ -32,4 +35,4 @@ export const mockArchitectAuth = () =>
     .stub(DockerBuildXUtils, 'getBuilder', () => { })
     .stub(SecretUtils, 'getSecrets', () => [])
     .stub(SecretUtils, 'batchUpdateSecrets', () => [])
-    .stub(DockerBuildXUtils, 'convertToBuildxPlatforms', () => { })
+    .stub(DockerBuildXUtils, 'convertToBuildxPlatforms', () => { });


### PR DESCRIPTION
## Overview

Please see https://gitlab.com/architect-io/architect-cli/-/issues/556

 To enable cleaner CI configurations and to ensure that jobs don't pass on real errors, we should only warn on 409s when creating an environment. 


## Changes
add validateStatus to environment:create command to manually append 409 as a passing status code. Add warning if http reply status code is 409.


## Tests
### test/commands/environments/create.test.ts

```typescript
  create_duplicate_environment
    .env({ ARCHITECT_CLUSTER: mock_cluster.name })
    .command(['environment:create', mock_env.name, '-a', mock_account.name])
    .it('should print warning when an environment name is already in use for an account', ctx => {
      expect(ctx.stderr).to.contain(`Unable to create new environment '${mock_env.name}'. Environment name already in use for account '${mock_account.name}'`);
    });
```

## Docs
TODO?


## Pictures (update 11/8/22)
![image](https://user-images.githubusercontent.com/99742088/200630916-1f9c3958-121d-41b6-b0a4-68ec8ca5000d.png)
