### PR TITLE
554 re-enable http/https validation

### DIFF
--- a/test/dependency-manager/graph.test.ts
+++ b/test/dependency-manager/graph.test.ts
@@ -28,7 +28,7 @@ describe('graph', () => {
           interfaces:
             mysql:
               port: 3306
-              protocol: https
+              protocol: mysql
 
         core:
           environment:

--- a/test/dependency-manager/interfaces.test.ts
+++ b/test/dependency-manager/interfaces.test.ts
@@ -681,6 +681,7 @@ describe('interfaces spec v1', () => {
           interfaces:
             smtp:
               port: 1025
+              protocol: smtp
               username: test-user
               password: test-pass
             dashboard: 1080
@@ -720,7 +721,7 @@ describe('interfaces spec v1', () => {
 
     const test_node = graph.getNodeByRef(app_ref) as ServiceNode;
     expect(test_node.config.environment).to.deep.eq({
-      SMTP_ADDR: `http://test-user:test-pass@${mail_ref}:1025`,
+      SMTP_ADDR: `smtp://test-user:test-pass@${mail_ref}:1025`,
       SMTP_USER: 'test-user',
       SMTP_PASS: 'test-pass',
     });


### PR DESCRIPTION
## Overview
Closes https://gitlab.com/architect-io/architect-cli/-/issues/554.  
Re-enable the check for non-http/https protocols through gateway.


## Changes
If ingress has subdomain, check if the protocol is either http or https. Otherwise, throw an error.


## Tests
Have 2 components:  
Component 1   
```
      name: component
      dependencies:
        dependency: latest
      services:
        app:
          interfaces:
            main: 
              port: 8080
              protocol: tcp
          environment:
            API_URL: \${{ dependencies.dependency.interfaces.api.url }}
      interfaces:
        app:
          url: \${{ services.app.interfaces.main.url }}
          ingress:
            subdomain: app
```
Component 2    
```
      name: dependency
      services:
        api:
          interfaces:
            api: 443
      interfaces:
        api: \${{ services.api.interfaces.api.url }}
```
This will fail because the protocol `tcp` in component 1 is exposed to public through ingress. If you comment out the ingress section, then the application won't fail.
