### PR TITLE
Remove account name from component name in tests, examples, and spec descriptions

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -78,7 +78,7 @@ export default class Deploy extends DeployCommand {
   static description = 'Create a deploy job on Architect Cloud';
 
   static examples = [
-    'architect deploy myaccount/mycomponent:latest',
+    'architect deploy mycomponent:latest',
     'architect deploy ./myfolder/architect.yml --secret-file=./mysecrets.yml --environment=myenvironment --account=myaccount --auto-approve',
   ];
 
@@ -199,7 +199,7 @@ export default class Deploy extends DeployCommand {
   static args = [{
     sensitive: false,
     name: 'configs_or_components',
-    description: 'Path to an architect.yml file or component `account/component:latest`. Multiple components are accepted.',
+    description: 'Path to an architect.yml file or component `component:latest`. Multiple components are accepted.',
   }];
 
   // overrides the oclif default parse to allow for configs_or_components to be a list of components

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -644,7 +644,7 @@ $ architect dev -e new_env_name_here .`));
       component_versions.push(component_version);
     }
 
-    let account_name: string | undefined;  // TODO: error if no account name found
+    let account_name;
     if (flags.account) {
       const account = await AccountUtils.getAccount(this.app, flags.account);
       account_name = account.name;

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -644,23 +644,24 @@ $ architect dev -e new_env_name_here .`));
       component_versions.push(component_version);
     }
 
+    let account_name: string | undefined;  // TODO: error if no account name found
+    if (flags.account) {
+      const account = await AccountUtils.getAccount(this.app, flags.account);
+      account_name = account.name;
+    } else {
+      const config_account = this.app.config.defaultAccount();
+      if (config_account) {
+        account_name = config_account;
+      }
+    }
     const dependency_manager = new LocalDependencyManager(
       this.app.api,
+      account_name,
       linked_components,
     );
 
     dependency_manager.use_ssl = flags.ssl;
     dependency_manager.external_addr = (flags.ssl ? this.app.config.external_https_address : this.app.config.external_http_address) + `:${flags.port}`;
-
-    if (flags.account) {
-      const account = await AccountUtils.getAccount(this.app, flags.account);
-      dependency_manager.account = account.name;
-    } else {
-      const config_account = this.app.config.defaultAccount();
-      if (config_account) {
-        dependency_manager.account = config_account;
-      }
-    }
 
     if (flags.environment) {
       dependency_manager.environment = flags.environment;

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -373,7 +373,7 @@ export default class Dev extends BaseCommand {
   static args = [{
     sensitive: false,
     name: 'configs_or_components',
-    description: 'Path to an architect.yml file or component `account/component:latest`. Multiple components are accepted.',
+    description: 'Path to an architect.yml file or component `component:latest`. Multiple components are accepted.',
   }];
 
   // overrides the oclif default parse to allow for configs_or_components to be a list of components

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -176,9 +176,8 @@ export default class ComponentRegister extends BaseCommand {
       await EnvironmentUtils.getEnvironment(this.app.api, selected_account, flags.environment);
     }
 
-    const dependency_manager = new LocalDependencyManager(this.app.api);
+    const dependency_manager = new LocalDependencyManager(this.app.api, selected_account.name);
     dependency_manager.environment = 'production';
-    dependency_manager.account = selected_account.name;
 
     const graph = await dependency_manager.getGraph([classToClass(component_spec)], undefined, { interpolate: false, validate: false });
     // Tmp fix to register host overrides

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -166,6 +166,7 @@ export default class ComponentRegister extends BaseCommand {
       if (!is_valid_component_account) {
         console.log(chalk.yellow(`The account name '${component_account_name}' was found as part of the component name in your architect.yml file. Either that account does not exist or you do not have permission to access it. You can select from a valid list of your accounts below.\n`));
       }
+      console.log(chalk.yellow('Including account name as part of the component name is being deprecated. Use the `-a` flag instead to specify an account.'));
       component_spec.name = component_name;
     }
     const account_name = is_valid_component_account ? component_account_name : flags.account;

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -27,7 +27,7 @@ export default class ComponentValidate extends BaseCommand {
   static args = [{
     sensitive: false,
     name: 'configs_or_components',
-    description: 'Path to an architect.yml file or component `account/component:latest`. Multiple components are accepted.',
+    description: 'Path to an architect.yml file or component `component:latest`. Multiple components are accepted.',
   }];
 
   // overrides the oclif default parse to allow for configs_or_components to be a list of components

--- a/src/common/dependency-manager/local-manager.ts
+++ b/src/common/dependency-manager/local-manager.ts
@@ -33,7 +33,7 @@ export default class LocalDependencyManager extends DependencyManager {
       ...options,
     };
 
-    const { component_account_name, component_name, tag, instance_name } = ComponentVersionSlugUtils.parse(component_string);
+    const { component_name, tag, instance_name } = ComponentVersionSlugUtils.parse(component_string);
     const component_ref = this.getComponentRef(component_string);
 
     if (this.loaded_components[component_ref]) {

--- a/src/common/dependency-manager/local-manager.ts
+++ b/src/common/dependency-manager/local-manager.ts
@@ -19,9 +19,10 @@ export default class LocalDependencyManager extends DependencyManager {
 
   loaded_components: Dictionary<ComponentSpec> = {};
 
-  constructor(api: AxiosInstance, linked_components: Dictionary<string> = {}) {
+  constructor(api: AxiosInstance, account?: string, linked_components: Dictionary<string> = {}) {
     super();
     this.api = api;
+    this.account = account;
     this.linked_components = linked_components;
   }
 
@@ -49,10 +50,9 @@ export default class LocalDependencyManager extends DependencyManager {
       instance_date: this.now,
     };
 
-    const account_name = component_account_name || this.account;
-    const linked_component_key = component_ref in this.linked_components ? component_ref : ComponentSlugUtils.build(account_name, component_name);
+    const linked_component_key = component_ref in this.linked_components ? component_ref : ComponentSlugUtils.build(this.account, component_name);
     const linked_component = this.linked_components[linked_component_key];
-    if (!linked_component && !account_name) {
+    if (!linked_component && !this.account) {
       throw new ArchitectError(`Didn't find link for component '${component_ref}'.\nPlease run 'architect link' or specify an account via '--account <account>'.`);
     }
 
@@ -66,7 +66,7 @@ export default class LocalDependencyManager extends DependencyManager {
     } else {
       console.log(`Didn't find link for component '${component_ref}'. Attempting to download from Architect...`);
       // Load remote component config
-      const { data: component_version } = await this.api.get(`/accounts/${account_name}/components/${component_name}/versions/${tag}`).catch((err) => {
+      const { data: component_version } = await this.api.get(`/accounts/${this.account}/components/${component_name}/versions/${tag}`).catch((err) => {
         err.message = `Could not download component for ${component_ref}. \n${err.message}`;
         throw err;
       });

--- a/src/dependency-manager/manager.ts
+++ b/src/dependency-manager/manager.ts
@@ -289,8 +289,8 @@ export default abstract class DependencyManager {
     }
 
     const component_ref = component_spec.metadata.ref;
-    const { component_account_name, component_name, instance_name } = ComponentSlugUtils.parse(component_ref);
-    const component_ref_with_account = component_account_name ? component_ref : ComponentSlugUtils.build(this.account, component_name, instance_name);
+    const { component_name, instance_name } = ComponentSlugUtils.parse(component_ref);
+    const component_ref_with_account = ComponentSlugUtils.build(this.account, component_name, instance_name);
 
     const component_secrets = new Set(Object.keys({ ...component_spec.parameters, ...component_spec.secrets })); // TODO: 404: update
 

--- a/src/dependency-manager/spec/component-spec.ts
+++ b/src/dependency-manager/spec/component-spec.ts
@@ -309,7 +309,7 @@ export class ComponentSpec {
       additionalProperties: ComponentSlugUtils.Description,
     },
 
-    description: 'A key-value set of dependencies and their respective tags. Reference each dependency by component name (e.g. `cloud: latest` or `architect/cloud: latest`)',
+    description: 'A key-value set of dependencies and their respective tags. Reference each dependency by component name (e.g. `cloud: latest`)',
   })
   dependencies?: Dictionary<string>;
 

--- a/src/dependency-manager/spec/utils/slugs.ts
+++ b/src/dependency-manager/spec/utils/slugs.ts
@@ -74,7 +74,7 @@ function parseCurry<S extends string, P extends ParsedSlug>() {
 }
 
 export class ComponentSlugUtils extends SlugUtils {
-  public static Description = `${Slugs.ArchitectSlugDescription}; optionally can be prefixed with a valid Architect account and separated by a slash (e.g. architect/component-name).`;
+  public static Description = Slugs.ArchitectSlugDescription;
 
   static RegexName = `(?:(?<component_account_name>${Slugs.ArchitectSlugRegexBase})${Slugs.NAMESPACE_DELIMITER})?(?<component_name>${Slugs.ArchitectSlugRegexBase})`;
   static RegexInstance = `(?:${Slugs.INSTANCE_DELIMITER}(?<instance_name>${Slugs.ComponentTagRegexBase}))?`;

--- a/test/commands/validate.test.ts
+++ b/test/commands/validate.test.ts
@@ -8,7 +8,7 @@ import { mockArchitectAuth } from '../utils/mocks';
 
 describe('architect validate component', function () {
   const subdomain_token_to_config_yaml_string = (subdomain_token: string): string =>
-    `name: tests/validatesubdomain
+    `name: validatesubdomain
 services:
   validatesubdomain:
     build:
@@ -84,17 +84,16 @@ interfaces:
     .command(['validate', 'test/mocks/validationerrors/architect.yml'])
     .catch(err => {
       expect(err.name).to.contain('ValidationErrors');
-      expect(err.name).to.contain('component: tests/validation_errors');
+      expect(err.name).to.contain('component: validation_errors');
       expect(err.name).to.contain(`file: ${path.resolve(`test/mocks/validationerrors/architect.yml`)}`);
     })
     .it('correctly displays prettyValidationErrors error message to screen in place of a stacktrace', ctx => {
-      expect(ctx.stderr).to.contain('›  1 | name: tests/validation_errors');
-      expect(ctx.stderr).to.contain('must contain only lower alphanumeric and single hyphens or underscores in the middle; max length 32; optionally can be prefixed with a valid Architect account and separated by a slash (e.g. architect/component-name).');
+      expect(ctx.stderr).to.contain('›  1 | name: validation_errors');
+      expect(ctx.stderr).to.contain('must contain only lower alphanumeric and single hyphens or underscores in the middle; max length 32');
       expect(ctx.stdout).to.equal('');
     });
 
   describe('expect fail for invalid subdomain', () => {
-
     const invalid_subdomain_tokens = [
       '_',
       '-',
@@ -172,7 +171,7 @@ interfaces:
       'd______D',
     ];
 
-    const tmp_test_file = path.normalize(untildify("~/some_fake_file.yml"));
+    const tmp_test_file = path.normalize(untildify('~/some_fake_file.yml'));
     for (const invalid_subdomain_token of invalid_subdomain_tokens) {
       mockArchitectAuth()
         .stub(fs, 'readFileSync', sinon.fake.returns(subdomain_token_to_config_yaml_string(invalid_subdomain_token)))
@@ -197,7 +196,6 @@ interfaces:
   }).timeout(20000);
 
   describe('expect pass for valid subdomain', () => {
-
     const valid_subdomain_tokens = [
       '*',
       '@',
@@ -218,7 +216,7 @@ interfaces:
       'a-b-c-d-eFG-H',
     ];
 
-    const tmp_test_file = path.normalize(untildify("~/some_fake_file.yml"));
+    const tmp_test_file = path.normalize(untildify('~/some_fake_file.yml'));
     for (const valid_subdomain_token of valid_subdomain_tokens) {
       mockArchitectAuth()
         .stub(fs, 'readFileSync', sinon.fake.returns(subdomain_token_to_config_yaml_string(valid_subdomain_token)))
@@ -229,10 +227,9 @@ interfaces:
         .stderr({ print })
         .command(['validate', tmp_test_file])
         .it(`'${valid_subdomain_token}'`, ctx => {
-          expect(ctx.stdout).to.contain('tests/validatesubdomain');
+          expect(ctx.stdout).to.contain('validatesubdomain');
           expect(ctx.stdout).to.contain(tmp_test_file);
         });
     }
   }).timeout(20000);
-
 });

--- a/test/dependency-manager/components.test.ts
+++ b/test/dependency-manager/components.test.ts
@@ -791,8 +791,8 @@ describe('components spec v1', function () {
     });
 
     it('test account scoping', async () => {
-      // TODO: This test maybe should remain until account name is no longer supported in component name
-      // Can be refactored to test dependency names can contain account name but components cant?
+      // This test still uses account name in components/dependencies to verify backwards compatibility
+      // and ensure the various combos do not throw any validation errors
       const combinations = [
         {
           cloud: 'architect/cloud',

--- a/test/dependency-manager/components.test.ts
+++ b/test/dependency-manager/components.test.ts
@@ -27,7 +27,7 @@ describe('components spec v1', function () {
         '/stack/architect.yml': component_config_yml,
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'cloud': '/stack',
       });
       const graph = await manager.getGraph([
@@ -95,8 +95,7 @@ describe('components spec v1', function () {
       nock('http://localhost').get(`/accounts/architect/components/cloud/versions/v1`)
         .reply(200, { tag: 'v1', config: component_config_json, service: { url: 'cloud:v1' } });
 
-      const manager = new LocalDependencyManager(axios.create());
-      manager.account = 'architect';
+      const manager = new LocalDependencyManager(axios.create(), 'architect');
 
       const graph = await manager.getGraph([
         await manager.loadComponentSpec('cloud:v1'),
@@ -132,8 +131,7 @@ describe('components spec v1', function () {
       nock('http://localhost').get(`/accounts/architect/components/cloud/versions/v1`)
         .reply(200, { tag: 'v1', config: component_config, service: { url: 'cloud:v1' } });
 
-      const manager = new LocalDependencyManager(axios.create());
-      manager.account = 'architect';
+      const manager = new LocalDependencyManager(axios.create(), 'architect');
 
       const graph = await manager.getGraph([
         await manager.loadComponentSpec('cloud:v1'),
@@ -180,7 +178,7 @@ describe('components spec v1', function () {
         '/stack/architect.yml': yaml.dump(component_config),
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'cloud': '/stack/architect.yml',
       });
       const graph = await manager.getGraph([
@@ -304,7 +302,7 @@ describe('components spec v1', function () {
         '/stack/concourse/architect.yml': yaml.dump(concourse_component_config),
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'cloud': '/stack/cloud/architect.yml',
         'ci': '/stack/concourse/architect.yml',
       });
@@ -354,7 +352,7 @@ describe('components spec v1', function () {
         },
         interfaces: {},
         dependencies: {
-          'examples/hello-world2': 'latest',
+          'hello-world2': 'latest',
         },
       };
 
@@ -369,7 +367,7 @@ describe('components spec v1', function () {
         },
         interfaces: {},
         dependencies: {
-          'examples/hello-circular-world': 'latest',
+          'hello-circular-world': 'latest',
         },
       };
 
@@ -384,7 +382,7 @@ describe('components spec v1', function () {
         },
         interfaces: {},
         dependencies: {
-          'examples/hello-world': 'latest',
+          'hello-world': 'latest',
         },
       };
 
@@ -393,13 +391,13 @@ describe('components spec v1', function () {
       });
 
       nock('http://localhost').get(`/accounts/examples/components/hello-world2/versions/latest`)
-        .reply(200, { tag: 'latest', config: component_config2, service: { url: 'examples/hello-world2:latest' } });
+        .reply(200, { tag: 'latest', config: component_config2, service: { url: 'hello-world2:latest' } });
 
       nock('http://localhost').get(`/accounts/examples/components/hello-circular-world/versions/latest`)
-        .reply(200, { tag: 'latest', config: circular_component_config, service: { url: 'examples/hello-circular-world:latest' } });
+        .reply(200, { tag: 'latest', config: circular_component_config, service: { url: 'hello-circular-world:latest' } });
 
-      const manager = new LocalDependencyManager(axios.create(), {
-        'examples/hello-world': '/stack/architect.yml',
+      const manager = new LocalDependencyManager(axios.create(), 'examples', {
+        'hello-world': '/stack/architect.yml',
       });
       await manager.getGraph([
         await manager.loadComponentSpec('examples/hello-world:latest'),
@@ -420,7 +418,7 @@ describe('components spec v1', function () {
         },
         interfaces: {},
         dependencies: {
-          'examples/hello-world-b': 'latest',
+          'hello-world-b': 'latest',
           'hello-world-c': 'latest',
         },
       };
@@ -458,15 +456,14 @@ describe('components spec v1', function () {
       });
 
       nock('http://localhost').get(`/accounts/examples/components/hello-world-b/versions/latest`)
-        .reply(200, { tag: 'latest', config: component_config_b, service: { url: 'examples/hello-world-b:latest' } });
+        .reply(200, { tag: 'latest', config: component_config_b, service: { url: 'hello-world-b:latest' } });
 
       nock('http://localhost').get(`/accounts/examples/components/hello-world-c/versions/latest`)
-        .reply(200, { tag: 'latest', config: component_config_c, service: { url: 'examples/hello-world-c:latest' } });
+        .reply(200, { tag: 'latest', config: component_config_c, service: { url: 'hello-world-c:latest' } });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'examples', {
         'hello-world-a': '/stack/architect.yml',
       });
-      manager.account = 'examples';
       await manager.getGraph(await manager.loadComponentSpecs('hello-world-a:latest'));
     });
 
@@ -483,8 +480,7 @@ describe('components spec v1', function () {
       nock('http://localhost').get(`/accounts/architect/components/cloud/versions/v1`)
         .reply(200, { tag: 'v1', config: component_config_json, service: { url: 'cloud:v1' } });
 
-      const manager = new LocalDependencyManager(axios.create());
-      manager.account = 'architect';
+      const manager = new LocalDependencyManager(axios.create(), 'architect');
 
       const component_config = await manager.loadComponentSpec('cloud:v1');
       const graph = await manager.getGraph([component_config]);
@@ -523,8 +519,7 @@ describe('components spec v1', function () {
       nock('http://localhost').get(`/accounts/architect/components/cloud/versions/v1`)
         .reply(200, { tag: 'v1', config: component_config_json, service: { url: 'cloud:v1' } });
 
-      const manager = new LocalDependencyManager(axios.create());
-      manager.account = 'architect';
+      const manager = new LocalDependencyManager(axios.create(), 'architect');
 
       const component_config = await manager.loadComponentSpec('cloud:v1');
       const graph = await manager.getGraph([component_config]);
@@ -550,7 +545,7 @@ describe('components spec v1', function () {
       const component_a = `
         name: component-a
         dependencies:
-          examples/component-b: v1
+          component-b: v1
         services:
           app:
             image: test:v1
@@ -579,31 +574,31 @@ describe('components spec v1', function () {
         `;
 
       nock('http://localhost').get(`/accounts/examples/components/component-a/versions/v1`)
-        .reply(200, { tag: 'v1', config: yaml.load(component_a), service: { url: 'examples/component-a:v1' } });
+        .reply(200, { tag: 'v1', config: yaml.load(component_a), service: { url: 'component-a:v1' } });
 
       nock('http://localhost').get(`/accounts/examples/components/component-b/versions/v1`)
-        .reply(200, { tag: 'v1', config: yaml.load(component_b_v1), service: { url: 'examples/component-b:v1' } });
+        .reply(200, { tag: 'v1', config: yaml.load(component_b_v1), service: { url: 'component-b:v1' } });
 
       nock('http://localhost').get(`/accounts/examples/components/component-b/versions/v2`)
-        .reply(200, { tag: 'v2', config: yaml.load(component_b_v2), service: { url: 'examples/component-b:v2' } });
+        .reply(200, { tag: 'v2', config: yaml.load(component_b_v2), service: { url: 'component-b:v2' } });
 
-      const manager = new LocalDependencyManager(axios.create());
+      const manager = new LocalDependencyManager(axios.create(), 'examples');
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('examples/component-a:v1'),
-        await manager.loadComponentSpec('examples/component-b:v1'),
-        await manager.loadComponentSpec('examples/component-b:v2@v2'),
+        await manager.loadComponentSpec('component-a:v1'),
+        await manager.loadComponentSpec('component-b:v1'),
+        await manager.loadComponentSpec('component-b:v2@v2'),
       ], {
         '*': { test_required: 'foo1' },
-        'examples/component-b': {
+        'component-b': {
           test_required: 'foo3',
         },
-        'examples/component-b@v2': {
+        'component-b@v2': {
           test_required: 'foo2',
         },
       });
 
-      const api_ref = resourceRefToNodeRef('examples/component-b.services.api');
-      const api2_ref = resourceRefToNodeRef('examples/component-b.services.api@v2');
+      const api_ref = resourceRefToNodeRef('component-b.services.api');
+      const api2_ref = resourceRefToNodeRef('component-b.services.api@v2');
 
       const node_b_v1 = graph.getNodeByRef(api_ref) as ServiceNode;
       expect(node_b_v1.config.environment.TEST_REQUIRED).to.eq('foo3');
@@ -634,7 +629,7 @@ describe('components spec v1', function () {
         '/stack/cloud/architect.yml': yaml.dump(cloud_component_config),
       });
 
-      const manager = new LocalDependencyManager(axios.create(), { 'cloud': '/stack/cloud/architect.yml' });
+      const manager = new LocalDependencyManager(axios.create(), 'architect', { 'cloud': '/stack/cloud/architect.yml' });
       const graph = await manager.getGraph([
         await manager.loadComponentSpec('cloud:latest', { interfaces: { api: 'api-interface' } }),
       ]);
@@ -653,7 +648,7 @@ describe('components spec v1', function () {
       const component_a = `
       name: component-a
       dependencies:
-        examples/component-b: latest
+        component-b: latest
       services:
         app:
           image: test:v1
@@ -662,7 +657,7 @@ describe('components spec v1', function () {
       const component_b = `
       name: component-b
       dependencies:
-        examples/component-c: latest
+        component-c: latest
       services:
         api:
           image: test:v1
@@ -681,18 +676,18 @@ describe('components spec v1', function () {
         '/c/architect.yaml': component_c,
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
-        'examples/component-a': '/a/architect.yaml',
-        'examples/component-b': '/b/architect.yaml',
-        'examples/component-c': '/c/architect.yaml',
+      const manager = new LocalDependencyManager(axios.create(), 'examples', {
+        'component-a': '/a/architect.yaml',
+        'component-b': '/b/architect.yaml',
+        'component-c': '/c/architect.yaml',
       });
       const graph = await manager.getGraph([
-        ...await manager.loadComponentSpecs('examples/component-a'),
+        ...await manager.loadComponentSpecs('component-a'),
       ]);
 
-      const a_ref = resourceRefToNodeRef('examples/component-a.services.app');
-      const b_ref = resourceRefToNodeRef('examples/component-b.services.api');
-      const c_ref = resourceRefToNodeRef('examples/component-c.services.api');
+      const a_ref = resourceRefToNodeRef('component-a.services.app');
+      const b_ref = resourceRefToNodeRef('component-b.services.api');
+      const c_ref = resourceRefToNodeRef('component-c.services.api');
 
       expect(graph.nodes.map((n) => n.ref)).has.members([
         a_ref,
@@ -705,25 +700,25 @@ describe('components spec v1', function () {
       const component_a = `
       name: component-a
       dependencies:
-        examples/component-c: latest
+        component-c: latest
       services:
         app:
           image: test:v1
           environment:
-            C_ADDR: \${{ dependencies.examples/component-c.interfaces.api.url }}
-            C_EXT_ADDR: \${{ dependencies.examples/component-c.ingresses.api.url }}
+            C_ADDR: \${{ dependencies.component-c.interfaces.api.url }}
+            C_EXT_ADDR: \${{ dependencies.component-c.ingresses.api.url }}
       `;
 
       const component_b = `
       name: component-b
       dependencies:
-        examples/component-c: latest
+        component-c: latest
       services:
         api:
           image: test:v1
           environment:
-            C_ADDR: \${{ dependencies.examples/component-c.interfaces.api.url }}
-            C_EXT_ADDR: \${{ dependencies.examples/component-c.ingresses.api.url }}
+            C_ADDR: \${{ dependencies.component-c.interfaces.api.url }}
+            C_EXT_ADDR: \${{ dependencies.component-c.ingresses.api.url }}
       `;
 
       const component_c = `
@@ -743,19 +738,19 @@ describe('components spec v1', function () {
         '/c/architect.yaml': component_c,
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
-        'examples/component-a': '/a/architect.yaml',
-        'examples/component-b': '/b/architect.yaml',
-        'examples/component-c': '/c/architect.yaml',
+      const manager = new LocalDependencyManager(axios.create(), 'examples', {
+        'component-a': '/a/architect.yaml',
+        'component-b': '/b/architect.yaml',
+        'component-c': '/c/architect.yaml',
       });
       const graph = await manager.getGraph([
-        ...await manager.loadComponentSpecs('examples/component-a'),
-        ...await manager.loadComponentSpecs('examples/component-b'),
+        ...await manager.loadComponentSpecs('component-a'),
+        ...await manager.loadComponentSpecs('component-b'),
       ]);
 
-      const a_ref = resourceRefToNodeRef('examples/component-a.services.app');
-      const b_ref = resourceRefToNodeRef('examples/component-b.services.api');
-      const c_ref = resourceRefToNodeRef('examples/component-c.services.api');
+      const a_ref = resourceRefToNodeRef('component-a.services.app');
+      const b_ref = resourceRefToNodeRef('component-b.services.api');
+      const c_ref = resourceRefToNodeRef('component-c.services.api');
 
       const a_node = graph.getNodeByRef(a_ref) as ServiceNode;
       expect(a_node.config.environment).to.deep.equal({
@@ -787,7 +782,7 @@ describe('components spec v1', function () {
         '/stack/architect.yml': component_config_yml,
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'cloud': '/stack',
       });
       const config = await manager.loadComponentSpec('cloud:latest');
@@ -884,7 +879,7 @@ describe('components spec v1', function () {
           '/stack/api/architect.yml': api_component_config_yml,
         });
 
-        const manager = new LocalDependencyManager(axios.create(), {
+        const manager = new LocalDependencyManager(axios.create(), 'architect', {
           [combination.cloud]: '/stack/cloud',
           [combination.api]: '/stack/api',
           [combination.dependency]: '/stack/api',

--- a/test/dependency-manager/components.test.ts
+++ b/test/dependency-manager/components.test.ts
@@ -13,7 +13,7 @@ describe('components spec v1', function () {
   describe('standard components', function () {
     it('simple local component', async () => {
       const component_config_yml = `
-        name: architect/cloud
+        name: cloud
         services:
           app:
             interfaces:
@@ -21,120 +21,124 @@ describe('components spec v1', function () {
           api:
             interfaces:
               main: 8080
-      `
+      `;
 
       mock_fs({
         '/stack/architect.yml': component_config_yml,
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'architect/cloud': '/stack'
+        'cloud': '/stack',
       });
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('architect/cloud:latest')
+        await manager.loadComponentSpec('cloud:latest'),
       ]);
 
-      const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
-      const api_ref = resourceRefToNodeRef('architect/cloud.services.api');
+      const app_ref = resourceRefToNodeRef('cloud.services.app');
+      const api_ref = resourceRefToNodeRef('cloud.services.api');
 
       expect(graph.nodes.map((n) => n.ref)).has.members([
         app_ref,
         api_ref,
-      ])
-      expect(graph.edges.map((e) => e.toString())).has.members([])
+      ]);
+      expect(graph.edges.map((e) => e.toString())).has.members([]);
 
       const template = await DockerComposeUtils.generate(graph);
       const expected_compose: DockerComposeTemplate = {
-        "services": {
+        'services': {
           [app_ref]: {
-            "environment": {},
-            "ports": [
-              "50000:8080",
+            'environment': {},
+            'ports': [
+              '50000:8080',
             ],
-            "build": {
-              "context": path.resolve("/stack")
+            'build': {
+              'context': path.resolve('/stack'),
             },
-            "image": app_ref,
-            labels: ['architect.ref=architect/cloud.services.app']
+            'image': app_ref,
+            labels: ['architect.ref=cloud.services.app'],
           },
           [api_ref]: {
-            "environment": {},
-            "ports": [
-              "50001:8080"
+            'environment': {},
+            'ports': [
+              '50001:8080',
             ],
-            "build": {
-              "context": path.resolve("/stack")
+            'build': {
+              'context': path.resolve('/stack'),
             },
             image: api_ref,
-            labels: ['architect.ref=architect/cloud.services.api']
+            labels: ['architect.ref=cloud.services.api'],
           },
         },
-        "version": "3",
-        "volumes": {},
+        'version': '3',
+        'volumes': {},
       };
       expect(template).to.be.deep.equal(expected_compose);
     });
 
     it('simple remote component', async () => {
       const component_config_json = {
-        name: 'architect/cloud',
+        name: 'cloud',
         services: {
           app: {
             interfaces: {
-              main: 8080
-            }
+              main: 8080,
+            },
           },
           api: {
             interfaces: {
-              main: 8080
-            }
-          }
-        }
+              main: 8080,
+            },
+          },
+        },
       };
 
       nock('http://localhost').get(`/accounts/architect/components/cloud/versions/v1`)
-        .reply(200, { tag: 'v1', config: component_config_json, service: { url: 'architect/cloud:v1' } });
+        .reply(200, { tag: 'v1', config: component_config_json, service: { url: 'cloud:v1' } });
 
       const manager = new LocalDependencyManager(axios.create());
+      manager.account = 'architect';
+
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('architect/cloud:v1')
+        await manager.loadComponentSpec('cloud:v1'),
       ]);
-      const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
-      const api_ref = resourceRefToNodeRef('architect/cloud.services.api');
+      const app_ref = resourceRefToNodeRef('cloud.services.app');
+      const api_ref = resourceRefToNodeRef('cloud.services.api');
 
       expect(graph.nodes.map((n) => n.ref)).has.members([
         app_ref,
         api_ref,
-      ])
-      expect(graph.edges.map((e) => e.toString())).has.members([])
+      ]);
+      expect(graph.edges.map((e) => e.toString())).has.members([]);
     });
 
     it('simple remote component with override', async () => {
       const component_config = {
-        name: 'architect/cloud',
+        name: 'cloud',
         secrets: {
-          log_level: 'info'
+          log_level: 'info',
         },
         services: {
           app: {
             interfaces: {
-              main: 8080
+              main: 8080,
             },
             environment: {
-              LOG_LEVEL: '${{ secrets.log_level }}'
-            }
-          }
-        }
+              LOG_LEVEL: '${{ secrets.log_level }}',
+            },
+          },
+        },
       };
 
       nock('http://localhost').get(`/accounts/architect/components/cloud/versions/v1`)
-        .reply(200, { tag: 'v1', config: component_config, service: { url: 'architect/cloud:v1' } });
+        .reply(200, { tag: 'v1', config: component_config, service: { url: 'cloud:v1' } });
 
       const manager = new LocalDependencyManager(axios.create());
+      manager.account = 'architect';
+
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('architect/cloud:v1')
+        await manager.loadComponentSpec('cloud:v1'),
       ], { '*': { log_level: 'debug' } });
-      const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
+      const app_ref = resourceRefToNodeRef('cloud.services.app');
       expect(graph.nodes.map((n) => n.ref)).has.members([app_ref]);
       expect(graph.edges.map((e) => e.toString())).has.members([]);
       const app_node = graph.getNodeByRef(app_ref) as ServiceNode;
@@ -143,33 +147,33 @@ describe('components spec v1', function () {
 
     it('local component with edges', async () => {
       const component_config = {
-        name: 'architect/cloud',
+        name: 'cloud',
         services: {
           app: {
             interfaces: {
-              main: 8080
+              main: 8080,
             },
             depends_on: ['api'],
             environment: {
-              API_ADDR: '${{ services.api.interfaces.main.url }}'
-            }
+              API_ADDR: '${{ services.api.interfaces.main.url }}',
+            },
           },
           api: {
             interfaces: {
-              main: 8080
+              main: 8080,
             },
             depends_on: ['db'],
             environment: {
-              DB_ADDR: '${{ services.db.interfaces.main.url }}'
-            }
+              DB_ADDR: '${{ services.db.interfaces.main.url }}',
+            },
           },
           db: {
             interfaces: {
-              main: 5432
-            }
-          }
+              main: 5432,
+            },
+          },
         },
-        interfaces: {}
+        interfaces: {},
       };
 
       mock_fs({
@@ -177,79 +181,79 @@ describe('components spec v1', function () {
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'architect/cloud': '/stack/architect.yml'
+        'cloud': '/stack/architect.yml',
       });
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('architect/cloud:latest')
+        await manager.loadComponentSpec('cloud:latest'),
       ]);
-      const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
-      const api_ref = resourceRefToNodeRef('architect/cloud.services.api');
-      const db_ref = resourceRefToNodeRef('architect/cloud.services.db');
+      const app_ref = resourceRefToNodeRef('cloud.services.app');
+      const api_ref = resourceRefToNodeRef('cloud.services.api');
+      const db_ref = resourceRefToNodeRef('cloud.services.db');
       expect(graph.nodes.map((n) => n.ref)).has.members([
         app_ref,
         api_ref,
-        db_ref
-      ])
+        db_ref,
+      ]);
       expect(graph.edges.map((e) => e.toString())).has.members([
         `${app_ref} [service->main] -> ${api_ref} [main]`,
-        `${api_ref} [service->main] -> ${db_ref} [main]`
-      ])
+        `${api_ref} [service->main] -> ${db_ref} [main]`,
+      ]);
       // Test secret values
       const app_node = graph.getNodeByRef(app_ref) as ServiceNode;
-      expect(app_node.config.environment.API_ADDR).eq(`http://${api_ref}:8080`)
+      expect(app_node.config.environment.API_ADDR).eq(`http://${api_ref}:8080`);
 
       const api_node = graph.getNodeByRef(api_ref) as ServiceNode;
-      expect(api_node.config.environment.DB_ADDR).eq(`http://${db_ref}:5432`)
+      expect(api_node.config.environment.DB_ADDR).eq(`http://${db_ref}:5432`);
 
       const template = await DockerComposeUtils.generate(graph);
       const expected_compose: DockerComposeTemplate = {
-        "services": {
+        'services': {
           [api_ref]: {
-            "depends_on": [
-              `${db_ref}`
+            'depends_on': [
+              `${db_ref}`,
             ],
-            "environment": {
-              "DB_ADDR": `http://${db_ref}:5432`
+            'environment': {
+              'DB_ADDR': `http://${db_ref}:5432`,
             },
-            "ports": [
-              "50001:8080",
+            'ports': [
+              '50001:8080',
             ],
-            "build": {
-              "context": path.resolve("/stack")
+            'build': {
+              'context': path.resolve('/stack'),
             },
             image: api_ref,
-            labels: ['architect.ref=architect/cloud.services.api']
+            labels: ['architect.ref=cloud.services.api'],
           },
           [app_ref]: {
-            "depends_on": [
-              `${api_ref}`
+            'depends_on': [
+              `${api_ref}`,
             ],
-            "environment": {
-              "API_ADDR": `http://${api_ref}:8080`
+            'environment': {
+              'API_ADDR': `http://${api_ref}:8080`,
             },
-            "ports": [
-              "50000:8080"
+            'ports': [
+              '50000:8080',
             ],
-            "build": {
-              "context": path.resolve("/stack")
+            'build': {
+              'context': path.resolve('/stack'),
             },
             image: app_ref,
-            labels: ['architect.ref=architect/cloud.services.app']
+            labels: ['architect.ref=cloud.services.app'],
           },
           [db_ref]: {
-            "environment": {},
-            "ports": [
-              "50002:5432"
+            'environment': {},
+            'ports': [
+              '50002:5432',
             ],
-            "build": {
-              "context": path.resolve("/stack")
+            'build': {
+              'context': path.resolve('/stack'),
             },
             image: db_ref,
-            labels: ['architect.ref=architect/cloud.services.db']
-          }
+            labels: ['architect.ref=cloud.services.db'],
+          },
         },
-        "version": "3",
-        "volumes": {},
+        'version': '3',
+        'volumes': {},
       };
       expect(template).to.be.deep.equal(expected_compose);
     });
@@ -260,17 +264,17 @@ describe('components spec v1', function () {
         services: {
           api: {
             interfaces: {
-              main: 8080
+              main: 8080,
             },
             environment: {
-              CONCOURSE_ADDR: '${{ dependencies.ci.interfaces.web.url }}'
-            }
-          }
+              CONCOURSE_ADDR: '${{ dependencies.ci.interfaces.web.url }}',
+            },
+          },
         },
         dependencies: {
-          'ci': '6.2'
+          'ci': '6.2',
         },
-        interfaces: {}
+        interfaces: {},
       };
 
       const concourse_component_config = {
@@ -280,20 +284,20 @@ describe('components spec v1', function () {
             interfaces: {
               main: 8080,
             },
-            image: 'concourse/concourse:6.2'
+            image: 'concourse/concourse:6.2',
           },
           worker: {
             interfaces: {},
             image: 'concourse/concourse:6.2',
             environment: {
-              CONCOURSE_TSA_HOST: '${{ services.web.interfaces.main.host }}'
-            }
-          }
+              CONCOURSE_TSA_HOST: '${{ services.web.interfaces.main.host }}',
+            },
+          },
         },
         interfaces: {
-          web: '${{ services.web.interfaces.main.url }}'
-        }
-      }
+          web: '${{ services.web.interfaces.main.url }}',
+        },
+      };
 
       mock_fs({
         '/stack/cloud/architect.yml': yaml.dump(cloud_component_config),
@@ -302,7 +306,7 @@ describe('components spec v1', function () {
 
       const manager = new LocalDependencyManager(axios.create(), {
         'cloud': '/stack/cloud/architect.yml',
-        'ci': '/stack/concourse/architect.yml'
+        'ci': '/stack/concourse/architect.yml',
       });
       const graph = await manager.getGraph([
         ...await manager.loadComponentSpecs('cloud:latest'),
@@ -317,17 +321,17 @@ describe('components spec v1', function () {
 
         ci_ref,
         web_ref,
-        worker_ref
-      ])
+        worker_ref,
+      ]);
       expect(graph.edges.map((e) => e.toString())).has.members([
         `${worker_ref} [service->main] -> ${web_ref} [main]`,
         `${ci_ref} [web] -> ${web_ref} [main]`,
-        `${api_ref} [service->web] -> ${ci_ref} [web]`
-      ])
+        `${api_ref} [service->web] -> ${ci_ref} [web]`,
+      ]);
 
       // Test secret values
       const api_node = graph.getNodeByRef(api_ref) as ServiceNode;
-      expect(api_node.config.environment.CONCOURSE_ADDR).eq(`http://${web_ref}:8080`)
+      expect(api_node.config.environment.CONCOURSE_ADDR).eq(`http://${web_ref}:8080`);
       expect(api_node.config.name).to.eq('api');
       expect(api_node.config.metadata.tag).to.eq('latest');
       expect(api_node.config.metadata.ref).to.eq('cloud.services.api');
@@ -340,48 +344,48 @@ describe('components spec v1', function () {
 
     it('circular component dependency is not rejected', async () => {
       const component_config = {
-        name: 'examples/hello-world',
+        name: 'hello-world',
         services: {
           api: {
             interfaces: {
-              main: 8080
-            }
-          }
+              main: 8080,
+            },
+          },
         },
         interfaces: {},
         dependencies: {
-          'examples/hello-world2': 'latest'
-        }
+          'examples/hello-world2': 'latest',
+        },
       };
 
       const component_config2 = {
-        name: 'examples/hello-world2',
+        name: 'hello-world2',
         services: {
           api: {
             interfaces: {
-              main: 8080
-            }
-          }
+              main: 8080,
+            },
+          },
         },
         interfaces: {},
         dependencies: {
-          'examples/hello-circular-world': 'latest'
-        }
+          'examples/hello-circular-world': 'latest',
+        },
       };
 
       const circular_component_config = {
-        name: 'examples/hello-circular-world',
+        name: 'hello-circular-world',
         services: {
           api: {
             interfaces: {
-              main: 8080
-            }
-          }
+              main: 8080,
+            },
+          },
         },
         interfaces: {},
         dependencies: {
-          'examples/hello-world': 'latest'
-        }
+          'examples/hello-world': 'latest',
+        },
       };
 
       mock_fs({
@@ -410,30 +414,30 @@ describe('components spec v1', function () {
         services: {
           api: {
             interfaces: {
-              main: 8080
-            }
-          }
+              main: 8080,
+            },
+          },
         },
         interfaces: {},
         dependencies: {
           'examples/hello-world-b': 'latest',
-          'hello-world-c': 'latest'
-        }
+          'hello-world-c': 'latest',
+        },
       };
 
       const component_config_b = {
-        name: 'examples/hello-world-b',
+        name: 'hello-world-b',
         services: {
           api: {
             interfaces: {
-              main: 8080
-            }
-          }
+              main: 8080,
+            },
+          },
         },
         interfaces: {},
         dependencies: {
-          'hello-world-c': 'latest'
-        }
+          'hello-world-c': 'latest',
+        },
       };
 
       const component_config_c = {
@@ -441,12 +445,12 @@ describe('components spec v1', function () {
         services: {
           api: {
             interfaces: {
-              main: 8080
-            }
-          }
+              main: 8080,
+            },
+          },
         },
         interfaces: {},
-        dependencies: {}
+        dependencies: {},
       };
 
       mock_fs({
@@ -468,79 +472,83 @@ describe('components spec v1', function () {
 
     it('component with only one task', async () => {
       const component_config_json = {
-        name: 'architect/cloud',
+        name: 'cloud',
         tasks: {
           syncer: {
-            schedule: '*/1 * * * *'
+            schedule: '*/1 * * * *',
           },
-        }
+        },
       };
 
       nock('http://localhost').get(`/accounts/architect/components/cloud/versions/v1`)
-        .reply(200, { tag: 'v1', config: component_config_json, service: { url: 'architect/cloud:v1' } });
+        .reply(200, { tag: 'v1', config: component_config_json, service: { url: 'cloud:v1' } });
 
       const manager = new LocalDependencyManager(axios.create());
-      const component_config = await manager.loadComponentSpec('architect/cloud:v1');
+      manager.account = 'architect';
+
+      const component_config = await manager.loadComponentSpec('cloud:v1');
       const graph = await manager.getGraph([component_config]);
 
-      const syncer_ref = resourceRefToNodeRef('architect/cloud.tasks.syncer');
+      const syncer_ref = resourceRefToNodeRef('cloud.tasks.syncer');
 
       expect(graph.nodes.map((n) => n.ref)).has.members([
         syncer_ref,
-      ])
+      ]);
       const task_node = graph.getNodeByRef(syncer_ref) as TaskNode;
       expect(task_node.__type).equals('task');
       expect(task_node.config.schedule).equals('*/1 * * * *');
       expect(task_node.config.name).equals('syncer');
-      expect(task_node.config.metadata.ref).equals('architect/cloud.tasks.syncer');
+      expect(task_node.config.metadata.ref).equals('cloud.tasks.syncer');
 
-      expect(graph.edges.map((e) => e.toString())).has.members([])
+      expect(graph.edges.map((e) => e.toString())).has.members([]);
     });
 
     it('component with one task and one service', async () => {
       const component_config_json = {
-        name: 'architect/cloud',
+        name: 'cloud',
         tasks: {
           syncer: {
-            schedule: '*/1 * * * *'
+            schedule: '*/1 * * * *',
           },
         },
         services: {
           app: {
             interfaces: {
-              main: 8080
-            }
-          }
-        }
+              main: 8080,
+            },
+          },
+        },
       };
 
       nock('http://localhost').get(`/accounts/architect/components/cloud/versions/v1`)
-        .reply(200, { tag: 'v1', config: component_config_json, service: { url: 'architect/cloud:v1' } });
+        .reply(200, { tag: 'v1', config: component_config_json, service: { url: 'cloud:v1' } });
 
       const manager = new LocalDependencyManager(axios.create());
-      const component_config = await manager.loadComponentSpec('architect/cloud:v1');
+      manager.account = 'architect';
+
+      const component_config = await manager.loadComponentSpec('cloud:v1');
       const graph = await manager.getGraph([component_config]);
 
-      const syncer_ref = resourceRefToNodeRef('architect/cloud.tasks.syncer');
-      const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
+      const syncer_ref = resourceRefToNodeRef('cloud.tasks.syncer');
+      const app_ref = resourceRefToNodeRef('cloud.services.app');
 
       expect(graph.nodes.map((n) => n.ref)).has.members([
         syncer_ref,
         app_ref,
-      ])
+      ]);
       const task_node = graph.getNodeByRef(syncer_ref) as TaskNode;
       expect(task_node.__type).equals('task');
       expect(task_node.config.schedule).equals('*/1 * * * *');
       expect(task_node.config.name).equals('syncer');
 
-      expect(graph.edges.map((e) => e.toString())).has.members([])
+      expect(graph.edges.map((e) => e.toString())).has.members([]);
     });
 
     it('component B:v2 and component A with dependency B:v1', async () => {
       // TODO: Validate lack of services/tasks
       // TODO: Validate lack of image/build context
       const component_a = `
-        name: examples/component-a
+        name: component-a
         dependencies:
           examples/component-b: v1
         services:
@@ -549,7 +557,7 @@ describe('components spec v1', function () {
         `;
 
       const component_b_v1 = `
-        name: examples/component-b
+        name: component-b
         secrets:
           test_required:
         services:
@@ -560,7 +568,7 @@ describe('components spec v1', function () {
         `;
 
       const component_b_v2 = `
-        name: examples/component-b
+        name: component-b
         secrets:
           test_required:
         services:
@@ -583,15 +591,15 @@ describe('components spec v1', function () {
       const graph = await manager.getGraph([
         await manager.loadComponentSpec('examples/component-a:v1'),
         await manager.loadComponentSpec('examples/component-b:v1'),
-        await manager.loadComponentSpec('examples/component-b:v2@v2')
+        await manager.loadComponentSpec('examples/component-b:v2@v2'),
       ], {
         '*': { test_required: 'foo1' },
         'examples/component-b': {
-          test_required: 'foo3'
+          test_required: 'foo3',
         },
         'examples/component-b@v2': {
-          test_required: 'foo2'
-        }
+          test_required: 'foo2',
+        },
       });
 
       const api_ref = resourceRefToNodeRef('examples/component-b.services.api');
@@ -605,45 +613,45 @@ describe('components spec v1', function () {
 
     it('environment ingress context produces the correct values for a simple external interface', async () => {
       const cloud_component_config = {
-        name: 'architect/cloud',
+        name: 'cloud',
         services: {
           api: {
             interfaces: {
-              main: 8080
+              main: 8080,
             },
             environment: {
-              EXTERNAL_APP_URL: "${{ ingresses['api-interface'].url }}",
-              EXTERNAL_APP_URL2: "${{ environment.ingresses['architect/cloud']['api-interface'].url }}",
-            }
-          }
+              EXTERNAL_APP_URL: '${{ ingresses[\'api-interface\'].url }}',
+              EXTERNAL_APP_URL2: '${{ environment.ingresses[\'cloud\'][\'api-interface\'].url }}',
+            },
+          },
         },
         interfaces: {
           'api-interface': '${{ services.api.interfaces.main.url }}',
-        }
+        },
       };
 
       mock_fs({
         '/stack/cloud/architect.yml': yaml.dump(cloud_component_config),
       });
 
-      const manager = new LocalDependencyManager(axios.create(), { 'architect/cloud': '/stack/cloud/architect.yml' });
+      const manager = new LocalDependencyManager(axios.create(), { 'cloud': '/stack/cloud/architect.yml' });
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('architect/cloud:latest', { interfaces: { api: 'api-interface' } })
+        await manager.loadComponentSpec('cloud:latest', { interfaces: { api: 'api-interface' } }),
       ]);
 
-      const api_ref = resourceRefToNodeRef('architect/cloud.services.api');
+      const api_ref = resourceRefToNodeRef('cloud.services.api');
 
       expect(graph.edges.filter(e => e instanceof IngressEdge).length).eq(1);
       const ingress_edge = graph.edges.find(e => e instanceof IngressEdge);
       expect(ingress_edge!.interface_mappings).to.deep.equal([{ interface_from: 'api', interface_to: 'api-interface' }]);
       const cloud_api_node = graph.getNodeByRef(api_ref) as ServiceNode;
-      expect(cloud_api_node.config.environment['EXTERNAL_APP_URL']).eq('http://api.arc.localhost');
-      expect(cloud_api_node.config.environment['EXTERNAL_APP_URL2']).eq('http://api.arc.localhost');
+      expect(cloud_api_node.config.environment.EXTERNAL_APP_URL).eq('http://api.arc.localhost');
+      expect(cloud_api_node.config.environment.EXTERNAL_APP_URL2).eq('http://api.arc.localhost');
     });
 
     it('component with deep dependencies', async () => {
       const component_a = `
-      name: examples/component-a
+      name: component-a
       dependencies:
         examples/component-b: latest
       services:
@@ -652,7 +660,7 @@ describe('components spec v1', function () {
       `;
 
       const component_b = `
-      name: examples/component-b
+      name: component-b
       dependencies:
         examples/component-c: latest
       services:
@@ -661,7 +669,7 @@ describe('components spec v1', function () {
       `;
 
       const component_c = `
-      name: examples/component-c
+      name: component-c
       services:
         api:
           image: test:v1
@@ -676,7 +684,7 @@ describe('components spec v1', function () {
       const manager = new LocalDependencyManager(axios.create(), {
         'examples/component-a': '/a/architect.yaml',
         'examples/component-b': '/b/architect.yaml',
-        'examples/component-c': '/c/architect.yaml'
+        'examples/component-c': '/c/architect.yaml',
       });
       const graph = await manager.getGraph([
         ...await manager.loadComponentSpecs('examples/component-a'),
@@ -689,13 +697,13 @@ describe('components spec v1', function () {
       expect(graph.nodes.map((n) => n.ref)).has.members([
         a_ref,
         b_ref,
-        c_ref
-      ])
+        c_ref,
+      ]);
     });
 
     it('components with shared dependencies', async () => {
       const component_a = `
-      name: examples/component-a
+      name: component-a
       dependencies:
         examples/component-c: latest
       services:
@@ -707,7 +715,7 @@ describe('components spec v1', function () {
       `;
 
       const component_b = `
-      name: examples/component-b
+      name: component-b
       dependencies:
         examples/component-c: latest
       services:
@@ -719,7 +727,7 @@ describe('components spec v1', function () {
       `;
 
       const component_c = `
-      name: examples/component-c
+      name: component-c
       services:
         api:
           image: test:v1
@@ -738,7 +746,7 @@ describe('components spec v1', function () {
       const manager = new LocalDependencyManager(axios.create(), {
         'examples/component-a': '/a/architect.yaml',
         'examples/component-b': '/b/architect.yaml',
-        'examples/component-c': '/c/architect.yaml'
+        'examples/component-c': '/c/architect.yaml',
       });
       const graph = await manager.getGraph([
         ...await manager.loadComponentSpecs('examples/component-a'),
@@ -752,19 +760,19 @@ describe('components spec v1', function () {
       const a_node = graph.getNodeByRef(a_ref) as ServiceNode;
       expect(a_node.config.environment).to.deep.equal({
         C_ADDR: `http://${c_ref}:8080`,
-        C_EXT_ADDR: `http://api.arc.localhost`
-      })
+        C_EXT_ADDR: `http://api.arc.localhost`,
+      });
 
       const b_node = graph.getNodeByRef(b_ref) as ServiceNode;
       expect(b_node.config.environment).to.deep.equal({
         C_ADDR: `http://${c_ref}:8080`,
-        C_EXT_ADDR: `http://api.arc.localhost`
-      })
+        C_EXT_ADDR: `http://api.arc.localhost`,
+      });
     });
 
     it('validation does not run if validate is set to false', async () => {
       const component_config_yml = `
-        name: architect/cloud
+        name: cloud
         secrets:
           app_replicas:
             default: 1
@@ -773,72 +781,74 @@ describe('components spec v1', function () {
             interfaces:
               main: 8080
             replicas: \${{ secrets.app_replicas }}
-      `
+      `;
 
       mock_fs({
         '/stack/architect.yml': component_config_yml,
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'architect/cloud': '/stack'
+        'cloud': '/stack',
       });
-      const config = await manager.loadComponentSpec('architect/cloud:latest');
+      const config = await manager.loadComponentSpec('cloud:latest');
 
       await manager.getGraph([config], { '*': { app_replicas: '<redacted>' } }, { interpolate: true, validate: false });
     });
 
     it('test account scoping', async () => {
+      // TODO: This test maybe should remain until account name is no longer supported in component name
+      // Can be refactored to test dependency names can contain account name but components cant?
       const combinations = [
         {
           cloud: 'architect/cloud',
           api: 'architect/cloud-api',
           dependency: 'architect/cloud-api',
-          account: 'architect'
+          account: 'architect',
         },
         {
           cloud: 'architect/cloud',
           api: 'cloud-api',
           dependency: 'architect/cloud-api',
-          account: 'architect'
+          account: 'architect',
         },
         {
           cloud: 'architect/cloud',
           api: 'architect/cloud-api',
           dependency: 'cloud-api',
-          account: 'architect'
+          account: 'architect',
         },
         {
           cloud: 'architect/cloud',
           api: 'cloud-api',
           dependency: 'cloud-api',
-          account: 'architect'
+          account: 'architect',
         },
         // Other
         {
           cloud: 'architect/cloud',
           api: 'architect/cloud-api',
           dependency: 'architect/cloud-api',
-          account: 'other'
+          account: 'other',
         },
         {
           cloud: 'architect/cloud',
           api: 'cloud-api',
           dependency: 'architect/cloud-api',
-          account: 'other'
+          account: 'other',
         },
         {
           cloud: 'architect/cloud',
           api: 'architect/cloud-api',
           dependency: 'cloud-api',
-          account: 'other'
+          account: 'other',
         },
         {
           cloud: 'architect/cloud',
           api: 'cloud-api',
           dependency: 'cloud-api',
-          account: 'other'
+          account: 'other',
         },
-      ]
+      ];
 
       for (const combination of combinations) {
         const cloud_component_config_yml = `
@@ -852,7 +862,7 @@ describe('components spec v1', function () {
             environment:
               API_ADDR: \${{ dependencies.${combination.dependency}.interfaces.api.url }}
               EXT_API_ADDR: \${{ dependencies.${combination.dependency}.ingresses.api.url }}
-      `
+      `;
         const api_component_config_yml = `
         name: ${combination.api}
         secrets:
@@ -867,7 +877,7 @@ describe('components spec v1', function () {
               main: 8080
             environment:
               CORS: \${{ ingresses.api.consumers }}
-      `
+      `;
 
         mock_fs({
           '/stack/cloud/architect.yml': cloud_component_config_yml,
@@ -891,8 +901,8 @@ describe('components spec v1', function () {
           'gateway',
           resourceRefToNodeRef(`${combination.account && cloud_account_name === combination.account ? '' : `${cloud_account_name}/`}cloud.services.app`),
           api_node_ref,
-          resourceRefToNodeRef(`${(combination.account && api_account_name === combination.account) || !api_account_name ? '' : `${api_account_name}/`}cloud-api`)
-        ])
+          resourceRefToNodeRef(`${(combination.account && api_account_name === combination.account) || !api_account_name ? '' : `${api_account_name}/`}cloud-api`),
+        ]);
 
         expect(graph.edges).lengthOf(3);
 

--- a/test/dependency-manager/config.test.ts
+++ b/test/dependency-manager/config.test.ts
@@ -5,20 +5,20 @@ import { buildSpecFromPath } from '../../src';
 describe('config spec v1', () => {
   it('simple configs', async () => {
     const component_yml = `
-      name: test/component
+      name: component
       services:
         stateless-app:
           interfaces:
             main: 8080
       interfaces:
         frontend: \${{ services['stateless-app'].interfaces.main.url }}
-      `
+      `;
     mock_fs({
       '/architect.yml': component_yml,
     });
 
     const component_spec = buildSpecFromPath('/architect.yml');
-    expect(component_spec.interfaces?.frontend).to.eq("${{ services['stateless-app'].interfaces.main.url }}")
+    expect(component_spec.interfaces?.frontend).to.eq('${{ services[\'stateless-app\'].interfaces.main.url }}');
   });
 
   /*
@@ -27,7 +27,7 @@ describe('config spec v1', () => {
     const component_yml = `
       .frontend_interface: &frontend_interface_ref
         frontend: \${{ services['stateless-app'].interfaces.main.url }}
-      name: test/component
+      name: component
       services:
         stateless-app:
           interfaces:

--- a/test/dependency-manager/debug.test.ts
+++ b/test/dependency-manager/debug.test.ts
@@ -39,7 +39,7 @@ describe('debug spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'examnples', {
       'examples/hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
@@ -74,13 +74,13 @@ describe('debug spec v1', () => {
     `;
 
     nock('http://localhost').get('/accounts/examples/components/hello-world/versions/latest')
-      .reply(200, { tag: 'latest', config: yaml.load(component_config), service: { url: 'examples/hello-world:latest' } });
+      .reply(200, { tag: 'latest', config: yaml.load(component_config), service: { url: 'hello-world:latest' } });
 
-    const manager = new LocalDependencyManager(axios.create());
+    const manager = new LocalDependencyManager(axios.create(), 'examples');
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('examples/hello-world', {}, true),
+      await manager.loadComponentSpec('hello-world', {}, true),
     ]);
-    const api_ref = resourceRefToNodeRef('examples/hello-world.services.api');
+    const api_ref = resourceRefToNodeRef('hello-world.services.api');
     const node = graph.getNodeByRef(api_ref) as ServiceNode;
     expect(node.config.environment).to.deep.eq({
       NODE_ENV: 'production',

--- a/test/dependency-manager/debug.test.ts
+++ b/test/dependency-manager/debug.test.ts
@@ -9,7 +9,7 @@ import LocalDependencyManager from '../../src/common/dependency-manager/local-ma
 describe('debug spec v1', () => {
   it('debug block does apply for local component', async () => {
     const component_config = `
-    name: examples/hello-world
+    name: hello-world
 
     services:
       api:
@@ -33,7 +33,7 @@ describe('debug spec v1', () => {
     interfaces:
       echo:
         url: \${{ services.api.interfaces.main.url }}
-    `
+    `;
 
     mock_fs({
       '/stack/architect.yml': component_config,
@@ -47,15 +47,15 @@ describe('debug spec v1', () => {
     ]);
     const api_ref = resourceRefToNodeRef('examples/hello-world.services.api');
     const node = graph.getNodeByRef(api_ref) as ServiceNode;
-    expect(node.config.command).to.deep.eq(['bash', '-c', 'echo "debug"'])
+    expect(node.config.command).to.deep.eq(['bash', '-c', 'echo "debug"']);
     expect(node.config.environment).to.deep.eq({
-      NODE_ENV: 'development'
+      NODE_ENV: 'development',
     });
   });
 
   it('debug block does not apply for remote component', async () => {
     const component_config = `
-    name: examples/hello-world
+    name: hello-world
 
     services:
       api:
@@ -71,7 +71,7 @@ describe('debug spec v1', () => {
     interfaces:
       echo:
         url: \${{ services.api.interfaces.main.url }}
-    `
+    `;
 
     nock('http://localhost').get('/accounts/examples/components/hello-world/versions/latest')
       .reply(200, { tag: 'latest', config: yaml.load(component_config), service: { url: 'examples/hello-world:latest' } });
@@ -83,7 +83,7 @@ describe('debug spec v1', () => {
     const api_ref = resourceRefToNodeRef('examples/hello-world.services.api');
     const node = graph.getNodeByRef(api_ref) as ServiceNode;
     expect(node.config.environment).to.deep.eq({
-      NODE_ENV: 'production'
+      NODE_ENV: 'production',
     });
   });
 });

--- a/test/dependency-manager/dependencies.test.ts
+++ b/test/dependency-manager/dependencies.test.ts
@@ -47,7 +47,7 @@ describe('dependencies', () => {
       '/stack/cloud/architect.yml': cloud_config,
       '/stack/server/architect.yml': server_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/cloud/architect.yml',
       'server': '/stack/server/architect.yml'
     });

--- a/test/dependency-manager/depends-on.test.ts
+++ b/test/dependency-manager/depends-on.test.ts
@@ -27,7 +27,7 @@ describe('graph depends_on', () => {
     mock_fs({
       '/stack/architect.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
@@ -78,7 +78,7 @@ describe('graph depends_on', () => {
     mock_fs({
       '/stack/architect.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
@@ -125,7 +125,7 @@ describe('graph depends_on', () => {
     mock_fs({
       '/stack/architect.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
@@ -175,7 +175,7 @@ describe('graph depends_on', () => {
     mock_fs({
       '/stack/architect.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
@@ -233,7 +233,7 @@ describe('graph depends_on', () => {
       '/stack/architect.yml': component_config,
       '/stack/dependency.yml': dependency_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml',
       'dependency': '/stack/dependency.yml',
     });
@@ -295,7 +295,7 @@ describe('graph depends_on', () => {
       '/stack/architect.yml': component_config,
       '/stack/dependency.yml': dependency_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml',
       'dependency': '/stack/dependency.yml',
     });
@@ -355,7 +355,7 @@ describe('graph depends_on', () => {
       '/stack/architect.yml': component_config,
       '/stack/dependency.yml': dependency_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml',
       'dependency': '/stack/dependency.yml',
     });
@@ -411,7 +411,7 @@ describe('graph depends_on', () => {
       '/stack/architect.yml': component_config,
       '/stack/dependency.yml': dependency_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml',
       'dependency': '/stack/dependency.yml',
     });
@@ -476,7 +476,7 @@ describe('graph depends_on', () => {
       '/stack/architect.yml': component_config,
       '/stack/dependency.yml': dependency_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml',
       'dependency': '/stack/dependency.yml',
     });

--- a/test/dependency-manager/depends-on.test.ts
+++ b/test/dependency-manager/depends-on.test.ts
@@ -1,14 +1,13 @@
 import { expect } from '@oclif/test';
 import axios from 'axios';
 import mock_fs from 'mock-fs';
-import LocalDependencyManager from '../../src/common/dependency-manager/local-manager';
 import { resourceRefToNodeRef, ServiceNode } from '../../src';
+import LocalDependencyManager from '../../src/common/dependency-manager/local-manager';
 
 describe('graph depends_on', () => {
-
   it('happy path depends_on', async () => {
     const component_config = `
-      name: architect/cloud
+      name: cloud
       services:
         app:
           interfaces:
@@ -29,19 +28,19 @@ describe('graph depends_on', () => {
       '/stack/architect.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml'
+      'cloud': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud:latest')
+      await manager.loadComponentSpec('cloud:latest'),
     ]);
 
-    const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
+    const app_ref = resourceRefToNodeRef('cloud.services.app');
     const app = graph.getNodeByRef(app_ref) as ServiceNode;
 
-    const api_ref = resourceRefToNodeRef('architect/cloud.services.api');
+    const api_ref = resourceRefToNodeRef('cloud.services.api');
     const api = graph.getNodeByRef(api_ref) as ServiceNode;
 
-    const db_ref = resourceRefToNodeRef('architect/cloud.services.db');
+    const db_ref = resourceRefToNodeRef('cloud.services.db');
     const db = graph.getNodeByRef(db_ref) as ServiceNode;
 
     const app_depends_on = graph.getDependsOn(app);
@@ -58,7 +57,7 @@ describe('graph depends_on', () => {
 
   it('multiple depends_on', async () => {
     const component_config = `
-      name: architect/cloud
+      name: cloud
       services:
         app:
           interfaces:
@@ -80,19 +79,19 @@ describe('graph depends_on', () => {
       '/stack/architect.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml'
+      'cloud': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud:latest')
+      await manager.loadComponentSpec('cloud:latest'),
     ]);
 
-    const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
+    const app_ref = resourceRefToNodeRef('cloud.services.app');
     const app = graph.getNodeByRef(app_ref) as ServiceNode;
 
-    const api_ref = resourceRefToNodeRef('architect/cloud.services.api');
+    const api_ref = resourceRefToNodeRef('cloud.services.api');
     const api = graph.getNodeByRef(api_ref) as ServiceNode;
 
-    const db_ref = resourceRefToNodeRef('architect/cloud.services.db');
+    const db_ref = resourceRefToNodeRef('cloud.services.db');
     const db = graph.getNodeByRef(db_ref) as ServiceNode;
 
     const app_depends_on = graph.getDependsOn(app);
@@ -110,7 +109,7 @@ describe('graph depends_on', () => {
 
   it('no depends_on', async () => {
     const component_config = `
-      name: architect/cloud
+      name: cloud
       services:
         app:
           interfaces:
@@ -127,19 +126,19 @@ describe('graph depends_on', () => {
       '/stack/architect.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml'
+      'cloud': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud:latest')
+      await manager.loadComponentSpec('cloud:latest'),
     ]);
 
-    const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
+    const app_ref = resourceRefToNodeRef('cloud.services.app');
     const app = graph.getNodeByRef(app_ref) as ServiceNode;
 
-    const api_ref = resourceRefToNodeRef('architect/cloud.services.api');
+    const api_ref = resourceRefToNodeRef('cloud.services.api');
     const api = graph.getNodeByRef(api_ref) as ServiceNode;
 
-    const db_ref = resourceRefToNodeRef('architect/cloud.services.db');
+    const db_ref = resourceRefToNodeRef('cloud.services.db');
     const db = graph.getNodeByRef(db_ref) as ServiceNode;
 
     const app_depends_on = graph.getDependsOn(app);
@@ -154,7 +153,7 @@ describe('graph depends_on', () => {
 
   it('external depends_on', async () => {
     const component_config = `
-      name: architect/cloud
+      name: cloud
       services:
         app:
           interfaces:
@@ -177,19 +176,19 @@ describe('graph depends_on', () => {
       '/stack/architect.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml'
+      'cloud': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud:latest')
+      await manager.loadComponentSpec('cloud:latest'),
     ]);
 
-    const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
+    const app_ref = resourceRefToNodeRef('cloud.services.app');
     const app = graph.getNodeByRef(app_ref) as ServiceNode;
 
-    const api_ref = resourceRefToNodeRef('architect/cloud.services.api');
+    const api_ref = resourceRefToNodeRef('cloud.services.api');
     const api = graph.getNodeByRef(api_ref) as ServiceNode;
 
-    const db_ref = resourceRefToNodeRef('architect/cloud.services.db');
+    const db_ref = resourceRefToNodeRef('cloud.services.db');
     const db = graph.getNodeByRef(db_ref) as ServiceNode;
 
     const app_depends_on = graph.getDependsOn(app);
@@ -205,19 +204,19 @@ describe('graph depends_on', () => {
 
   it('cross component depends_on', async () => {
     const component_config = `
-      name: architect/cloud
+      name: cloud
       dependencies:
-        architect/dependency: latest
+        dependency: latest
       services:
         app:
           interfaces:
             main: 8080
           environment:
-            API_URL: \${{ dependencies.architect/dependency.interfaces.api.url }}
+            API_URL: \${{ dependencies.dependency.interfaces.api.url }}
     `;
 
     const dependency_config = `
-      name: architect/dependency
+      name: dependency
       services:
         api:
           interfaces:
@@ -235,21 +234,21 @@ describe('graph depends_on', () => {
       '/stack/dependency.yml': dependency_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml',
-      'architect/dependency': '/stack/dependency.yml'
+      'cloud': '/stack/architect.yml',
+      'dependency': '/stack/dependency.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud:latest'),
-      await manager.loadComponentSpec('architect/dependency:latest')
+      await manager.loadComponentSpec('cloud:latest'),
+      await manager.loadComponentSpec('dependency:latest'),
     ]);
 
-    const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
+    const app_ref = resourceRefToNodeRef('cloud.services.app');
     const app = graph.getNodeByRef(app_ref) as ServiceNode;
 
-    const api_ref = resourceRefToNodeRef('architect/dependency.services.api');
+    const api_ref = resourceRefToNodeRef('dependency.services.api');
     const api = graph.getNodeByRef(api_ref) as ServiceNode;
 
-    const db_ref = resourceRefToNodeRef('architect/dependency.services.db');
+    const db_ref = resourceRefToNodeRef('dependency.services.db');
     const db = graph.getNodeByRef(db_ref) as ServiceNode;
 
     const app_depends_on = graph.getDependsOn(app);
@@ -266,20 +265,20 @@ describe('graph depends_on', () => {
 
   it('cross component multiple depends_on', async () => {
     const component_config = `
-      name: architect/cloud
+      name: cloud
       dependencies:
-        architect/dependency: latest
+        dependency: latest
       services:
         app:
           interfaces:
             main: 8080
           environment:
-            API_URL: \${{ dependencies.architect/dependency.interfaces.api.url }}
-            DB_URL: \${{ dependencies.architect/dependency.interfaces.db.url }}
+            API_URL: \${{ dependencies.dependency.interfaces.api.url }}
+            DB_URL: \${{ dependencies.dependency.interfaces.db.url }}
     `;
 
     const dependency_config = `
-      name: architect/dependency
+      name: dependency
       services:
         api:
           interfaces:
@@ -297,21 +296,21 @@ describe('graph depends_on', () => {
       '/stack/dependency.yml': dependency_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml',
-      'architect/dependency': '/stack/dependency.yml'
+      'cloud': '/stack/architect.yml',
+      'dependency': '/stack/dependency.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud:latest'),
-      await manager.loadComponentSpec('architect/dependency:latest')
+      await manager.loadComponentSpec('cloud:latest'),
+      await manager.loadComponentSpec('dependency:latest'),
     ]);
 
-    const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
+    const app_ref = resourceRefToNodeRef('cloud.services.app');
     const app = graph.getNodeByRef(app_ref) as ServiceNode;
 
-    const api_ref = resourceRefToNodeRef('architect/dependency.services.api');
+    const api_ref = resourceRefToNodeRef('dependency.services.api');
     const api = graph.getNodeByRef(api_ref) as ServiceNode;
 
-    const db_ref = resourceRefToNodeRef('architect/dependency.services.db');
+    const db_ref = resourceRefToNodeRef('dependency.services.db');
     const db = graph.getNodeByRef(db_ref) as ServiceNode;
 
     const app_depends_on = graph.getDependsOn(app);
@@ -328,20 +327,20 @@ describe('graph depends_on', () => {
 
   it('cross component multiple interfaces to same service depends_on', async () => {
     const component_config = `
-      name: architect/cloud
+      name: cloud
       dependencies:
-        architect/dependency: latest
+        dependency: latest
       services:
         app:
           interfaces:
             main: 8080
           environment:
-            API_URL: \${{ dependencies.architect/dependency.interfaces.api.url }}
-            API_2_URL: \${{ dependencies.architect/dependency.interfaces.api-2.url }}
+            API_URL: \${{ dependencies.dependency.interfaces.api.url }}
+            API_2_URL: \${{ dependencies.dependency.interfaces.api-2.url }}
     `;
 
     const dependency_config = `
-      name: architect/dependency
+      name: dependency
       services:
         api:
           interfaces:
@@ -357,18 +356,18 @@ describe('graph depends_on', () => {
       '/stack/dependency.yml': dependency_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml',
-      'architect/dependency': '/stack/dependency.yml'
+      'cloud': '/stack/architect.yml',
+      'dependency': '/stack/dependency.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud:latest'),
-      await manager.loadComponentSpec('architect/dependency:latest')
+      await manager.loadComponentSpec('cloud:latest'),
+      await manager.loadComponentSpec('dependency:latest'),
     ]);
 
-    const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
+    const app_ref = resourceRefToNodeRef('cloud.services.app');
     const app = graph.getNodeByRef(app_ref) as ServiceNode;
 
-    const api_ref = resourceRefToNodeRef('architect/dependency.services.api');
+    const api_ref = resourceRefToNodeRef('dependency.services.api');
     const api = graph.getNodeByRef(api_ref) as ServiceNode;
 
     const app_depends_on = graph.getDependsOn(app);
@@ -381,19 +380,19 @@ describe('graph depends_on', () => {
 
   it('cross component chained depends_on', async () => {
     const component_config = `
-      name: architect/cloud
+      name: cloud
       dependencies:
-        architect/dependency: latest
+        dependency: latest
       services:
         app:
           interfaces:
             main: 8080
           environment:
-            API_URL: \${{ dependencies.architect/dependency.interfaces.api.url }}
+            API_URL: \${{ dependencies.dependency.interfaces.api.url }}
     `;
 
     const dependency_config = `
-      name: architect/dependency
+      name: dependency
       services:
         api:
           interfaces:
@@ -413,21 +412,21 @@ describe('graph depends_on', () => {
       '/stack/dependency.yml': dependency_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml',
-      'architect/dependency': '/stack/dependency.yml'
+      'cloud': '/stack/architect.yml',
+      'dependency': '/stack/dependency.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud:latest'),
-      await manager.loadComponentSpec('architect/dependency:latest')
+      await manager.loadComponentSpec('cloud:latest'),
+      await manager.loadComponentSpec('dependency:latest'),
     ]);
 
-    const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
+    const app_ref = resourceRefToNodeRef('cloud.services.app');
     const app = graph.getNodeByRef(app_ref) as ServiceNode;
 
-    const api_ref = resourceRefToNodeRef('architect/dependency.services.api');
+    const api_ref = resourceRefToNodeRef('dependency.services.api');
     const api = graph.getNodeByRef(api_ref) as ServiceNode;
 
-    const db_ref = resourceRefToNodeRef('architect/dependency.services.db');
+    const db_ref = resourceRefToNodeRef('dependency.services.db');
     const db = graph.getNodeByRef(db_ref) as ServiceNode;
 
     const app_depends_on = graph.getDependsOn(app);
@@ -445,20 +444,20 @@ describe('graph depends_on', () => {
 
   it('cross component multiple and chained depends_on', async () => {
     const component_config = `
-      name: architect/cloud
+      name: cloud
       dependencies:
-        architect/dependency: latest
+        dependency: latest
       services:
         app:
           interfaces:
             main: 8080
           environment:
-            API_URL: \${{ dependencies.architect/dependency.interfaces.api.url }}
-            DB_URL: \${{ dependencies.architect/dependency.interfaces.db.url }}
+            API_URL: \${{ dependencies.dependency.interfaces.api.url }}
+            DB_URL: \${{ dependencies.dependency.interfaces.db.url }}
     `;
 
     const dependency_config = `
-      name: architect/dependency
+      name: dependency
       services:
         api:
           interfaces:
@@ -478,21 +477,21 @@ describe('graph depends_on', () => {
       '/stack/dependency.yml': dependency_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml',
-      'architect/dependency': '/stack/dependency.yml'
+      'cloud': '/stack/architect.yml',
+      'dependency': '/stack/dependency.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud:latest'),
-      await manager.loadComponentSpec('architect/dependency:latest')
+      await manager.loadComponentSpec('cloud:latest'),
+      await manager.loadComponentSpec('dependency:latest'),
     ]);
 
-    const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
+    const app_ref = resourceRefToNodeRef('cloud.services.app');
     const app = graph.getNodeByRef(app_ref) as ServiceNode;
 
-    const api_ref = resourceRefToNodeRef('architect/dependency.services.api');
+    const api_ref = resourceRefToNodeRef('dependency.services.api');
     const api = graph.getNodeByRef(api_ref) as ServiceNode;
 
-    const db_ref = resourceRefToNodeRef('architect/dependency.services.db');
+    const db_ref = resourceRefToNodeRef('dependency.services.db');
     const db = graph.getNodeByRef(db_ref) as ServiceNode;
 
     const app_depends_on = graph.getDependsOn(app);

--- a/test/dependency-manager/external.test.ts
+++ b/test/dependency-manager/external.test.ts
@@ -12,7 +12,7 @@ describe('external spec v1', () => {
 
   it('simple external', async () => {
     const component_config = {
-      name: 'architect/cloud',
+      name: 'cloud',
       services: {
         app: {
           interfaces: {
@@ -35,13 +35,13 @@ describe('external spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml'
+      'cloud': '/stack/architect.yml'
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud:latest')
+      await manager.loadComponentSpec('cloud:latest')
     ]);
 
-    const app_ref = resourceRefToNodeRef('architect/cloud.services.app')
+    const app_ref = resourceRefToNodeRef('cloud.services.app')
     expect(graph.nodes.map((n) => n.ref)).has.members([
       app_ref,
     ])
@@ -63,7 +63,7 @@ describe('external spec v1', () => {
 
   it('simple no override', async () => {
     const component_config = {
-      name: 'architect/cloud',
+      name: 'cloud',
       secrets: {
         optional_host: { required: false },
         optional_port: { default: 8080 }
@@ -90,13 +90,13 @@ describe('external spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml'
+      'cloud': '/stack/architect.yml'
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud:latest')
+      await manager.loadComponentSpec('cloud:latest')
     ]);
 
-    const app_ref = resourceRefToNodeRef('architect/cloud.services.app')
+    const app_ref = resourceRefToNodeRef('cloud.services.app')
     expect(graph.nodes.map((n) => n.ref)).has.members([
       app_ref,
     ])
@@ -111,7 +111,7 @@ describe('external spec v1', () => {
 
   it('simple external override', async () => {
     const component_config = {
-      name: 'architect/cloud',
+      name: 'cloud',
       secrets: {
         optional_host: {},
         optional_port: { default: 8080 }
@@ -138,14 +138,14 @@ describe('external spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml'
+      'cloud': '/stack/architect.yml'
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud:latest')
+      await manager.loadComponentSpec('cloud:latest')
       // @ts-ignore
     ], { '*': { optional_host: 'cloud.architect.io', optional_port: 8081 } });
 
-    const app_ref = resourceRefToNodeRef('architect/cloud.services.app')
+    const app_ref = resourceRefToNodeRef('cloud.services.app')
     expect(graph.nodes.map((n) => n.ref)).has.members([
       app_ref,
     ])
@@ -167,7 +167,7 @@ describe('external spec v1', () => {
 
   it('service connecting to external', async () => {
     const component_config = {
-      name: 'architect/cloud',
+      name: 'cloud',
       services: {
         app: {
           interfaces: {
@@ -196,13 +196,13 @@ describe('external spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml'
+      'cloud': '/stack/architect.yml'
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud:latest')
+      await manager.loadComponentSpec('cloud:latest')
     ]);
-    const app_ref = resourceRefToNodeRef('architect/cloud.services.app')
-    const api_ref = resourceRefToNodeRef('architect/cloud.services.api')
+    const app_ref = resourceRefToNodeRef('cloud.services.app')
+    const api_ref = resourceRefToNodeRef('cloud.services.api')
 
     expect(graph.nodes.map((n) => n.ref)).has.members([
       app_ref,
@@ -231,7 +231,7 @@ describe('external spec v1', () => {
             context: path.resolve('/stack')
           },
           image: app_ref,
-          labels: ['architect.ref=architect/cloud.services.app']
+          labels: ['architect.ref=cloud.services.app']
         }
       },
       'version': '3',
@@ -242,21 +242,21 @@ describe('external spec v1', () => {
 
   it('dependency refs external host', async () => {
     const component_config = `
-      name: architect/component
+      name: component
       dependencies:
-        architect/dependency: latest
+        dependency: latest
       services:
         app:
           image: hashicorp/http-echo
           environment:
-            DEP_ADDR: \${{ dependencies.architect/dependency.interfaces.api.url }}
-            CI_ADDR: \${{ dependencies.architect/dependency.interfaces.ci.url }}
-            DEP_EXTERNAL_ADDR: \${{ dependencies.architect/dependency.ingresses.api.url }}
-            CI_EXTERNAL_ADDR: \${{ dependencies.architect/dependency.ingresses.ci.url }}
+            DEP_ADDR: \${{ dependencies.dependency.interfaces.api.url }}
+            CI_ADDR: \${{ dependencies.dependency.interfaces.ci.url }}
+            DEP_EXTERNAL_ADDR: \${{ dependencies.dependency.ingresses.api.url }}
+            CI_EXTERNAL_ADDR: \${{ dependencies.dependency.ingresses.ci.url }}
     `;
 
     const dependency_config = `
-      name: architect/dependency
+      name: dependency
       secrets:
         optional_host: ci.architect.io
       services:
@@ -287,15 +287,15 @@ describe('external spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/component': '/stack/component/architect.yml',
-      'architect/dependency': '/stack/dependency/architect.yml'
+      'component': '/stack/component/architect.yml',
+      'dependency': '/stack/dependency/architect.yml'
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/component:latest'),
-      await manager.loadComponentSpec('architect/dependency:latest')
+      await manager.loadComponentSpec('component:latest'),
+      await manager.loadComponentSpec('dependency:latest')
     ]);
 
-    const app_ref = resourceRefToNodeRef('architect/component.services.app')
+    const app_ref = resourceRefToNodeRef('component.services.app')
     const test_node = graph.getNodeByRef(app_ref) as ServiceNode;
     expect(test_node.config.environment).to.deep.eq({
       DEP_ADDR: `https://external.localhost`,
@@ -304,7 +304,7 @@ describe('external spec v1', () => {
       CI_EXTERNAL_ADDR: `https://ci.architect.io:8501`
     });
 
-    const dep_ref = resourceRefToNodeRef('architect/dependency.services.app')
+    const dep_ref = resourceRefToNodeRef('dependency.services.app')
     const dep_node = graph.getNodeByRef(dep_ref) as ServiceNode;
     expect(dep_node.config.environment).to.deep.eq({
       DEP_EXTERNAL_ADDR: `https://external.localhost`,
@@ -316,7 +316,7 @@ describe('external spec v1', () => {
 
   it('should strip default ports from environment ingress references', async () => {
     const component_config = `
-      name: architect/component
+      name: component
       services:
         app:
           image: hashicorp/http-echo
@@ -324,7 +324,7 @@ describe('external spec v1', () => {
             api: 8080
           environment:
             SELF_ADDR: \${{ ingresses.app.url }}
-            SELF_ADDR2: \${{ environment.ingresses['architect/component'].app.url }}
+            SELF_ADDR2: \${{ environment.ingresses['component'].app.url }}
       interfaces:
         app: \${{ services.app.interfaces.api.url }}
     `;
@@ -334,13 +334,13 @@ describe('external spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/component': '/stack/component/architect.yml'
+      'component': '/stack/component/architect.yml'
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/component:latest')
+      await manager.loadComponentSpec('component:latest')
     ]);
 
-    const app_ref = resourceRefToNodeRef('architect/component.services.app')
+    const app_ref = resourceRefToNodeRef('component.services.app')
     const test_node = graph.getNodeByRef(app_ref) as ServiceNode;
     expect(test_node.config.environment).to.deep.eq({
       SELF_ADDR: `http://app.arc.localhost`,
@@ -350,7 +350,7 @@ describe('external spec v1', () => {
 
   it('host override db via secret', async () => {
     const component_config = `
-      name: architect/component
+      name: component
 
       secrets:
         MYSQL_HOST:
@@ -379,15 +379,15 @@ describe('external spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/component': '/stack/component/architect.yml'
+      'component': '/stack/component/architect.yml'
     });
 
-    const core_ref = resourceRefToNodeRef('architect/component.services.core')
-    const db_ref = resourceRefToNodeRef('architect/component.services.db')
+    const core_ref = resourceRefToNodeRef('component.services.core')
+    const db_ref = resourceRefToNodeRef('component.services.db')
 
     // No host override
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/component:latest')
+      await manager.loadComponentSpec('component:latest')
     ], { '*': { MYSQL_DATABASE: 'test' } });
     const test_node = graph.getNodeByRef(core_ref) as ServiceNode;
     expect(test_node.config.environment).to.deep.eq({
@@ -397,7 +397,7 @@ describe('external spec v1', () => {
 
     // Host override
     const graph2 = await manager.getGraph([
-      await manager.loadComponentSpec('architect/component:latest')
+      await manager.loadComponentSpec('component:latest')
     ], { '*': { MYSQL_HOST: 'external', MYSQL_DATABASE: 'test' } });
     const test_node2 = graph2.getNodeByRef(core_ref) as ServiceNode;
     expect(test_node2.config.environment).to.deep.eq({
@@ -408,7 +408,7 @@ describe('external spec v1', () => {
 
   it('host override via templating', async () => {
     const component_config = `
-      name: architect/component
+      name: component
 
       services:
         db:
@@ -432,13 +432,13 @@ describe('external spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/component': '/stack/component/architect.yml'
+      'component': '/stack/component/architect.yml'
     });
 
-    const core_ref = resourceRefToNodeRef('architect/component.services.core')
+    const core_ref = resourceRefToNodeRef('component.services.core')
 
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/component:latest')
+      await manager.loadComponentSpec('component:latest')
     ]);
 
     const test_node = graph.getNodeByRef(core_ref) as ServiceNode;

--- a/test/dependency-manager/external.test.ts
+++ b/test/dependency-manager/external.test.ts
@@ -34,7 +34,7 @@ describe('external spec v1', () => {
       '/stack/architect.yml': yaml.dump(component_config),
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml'
     });
     const graph = await manager.getGraph([
@@ -89,7 +89,7 @@ describe('external spec v1', () => {
       '/stack/architect.yml': yaml.dump(component_config),
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml'
     });
     const graph = await manager.getGraph([
@@ -137,7 +137,7 @@ describe('external spec v1', () => {
       '/stack/architect.yml': yaml.dump(component_config),
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml'
     });
     const graph = await manager.getGraph([
@@ -195,7 +195,7 @@ describe('external spec v1', () => {
       '/stack/architect.yml': yaml.dump(component_config),
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml'
     });
     const graph = await manager.getGraph([
@@ -286,7 +286,7 @@ describe('external spec v1', () => {
       '/stack/dependency/architect.yml': dependency_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/stack/component/architect.yml',
       'dependency': '/stack/dependency/architect.yml'
     });
@@ -333,7 +333,7 @@ describe('external spec v1', () => {
       '/stack/component/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/stack/component/architect.yml'
     });
     const graph = await manager.getGraph([
@@ -378,7 +378,7 @@ describe('external spec v1', () => {
       '/stack/component/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/stack/component/architect.yml'
     });
 
@@ -431,7 +431,7 @@ describe('external spec v1', () => {
       '/stack/component/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/stack/component/architect.yml'
     });
 

--- a/test/dependency-manager/graph.test.ts
+++ b/test/dependency-manager/graph.test.ts
@@ -8,11 +8,11 @@ describe('graph', () => {
 
   it('graph without interpolation', async () => {
     const component_config = `
-      name: architect/component
+      name: component
 
       dependencies:
-        architect/dependency: latest
-        architect/missing-dependency: latest
+        dependency: latest
+        missing-dependency: latest
 
       secrets:
         MYSQL_DATABASE:
@@ -33,14 +33,14 @@ describe('graph', () => {
         core:
           environment:
             ADDR: \${{ ingresses.db.url }}
-            DEP_ADDR: \${{ dependencies.architect/dependency.interfaces.db.url }}
-            DEP_INGRESS_ADDR: \${{ dependencies.architect/dependency.ingresses.db.url }}
-            DEP_MISSING_ADDR: \${{ dependencies.architect/missing-dependency.interfaces.db.url }}
-            DEP_MISSING_INGRESS_ADDR: \${{ dependencies.architect/missing-dependency.ingresses.db.url }}
+            DEP_ADDR: \${{ dependencies.dependency.interfaces.db.url }}
+            DEP_INGRESS_ADDR: \${{ dependencies.dependency.ingresses.db.url }}
+            DEP_MISSING_ADDR: \${{ dependencies.missing-dependency.interfaces.db.url }}
+            DEP_MISSING_INGRESS_ADDR: \${{ dependencies.missing-dependency.ingresses.db.url }}
     `;
 
     const dependency_config = `
-      name: architect/dependency
+      name: dependency
 
       secrets:
         MYSQL_DATABASE:
@@ -64,16 +64,17 @@ describe('graph', () => {
     `;
 
     nock('http://localhost').get('/accounts/architect/components/component/versions/latest')
-      .reply(200, { tag: 'latest', config: yaml.load(component_config), service: { url: 'architect/component:latest' } });
+      .reply(200, { tag: 'latest', config: yaml.load(component_config), service: { url: 'component:latest' } });
 
     nock('http://localhost').get('/accounts/architect/components/dependency/versions/latest')
-      .reply(200, { tag: 'latest', config: yaml.load(dependency_config), service: { url: 'architect/dependency:latest' } });
+      .reply(200, { tag: 'latest', config: yaml.load(dependency_config), service: { url: 'dependency:latest' } });
 
     const manager = new LocalDependencyManager(axios.create());
+    manager.account = 'architect';
 
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/component:latest'),
-      await manager.loadComponentSpec('architect/dependency:latest', { interfaces: { db2: 'db' } })
+      await manager.loadComponentSpec('component:latest'),
+      await manager.loadComponentSpec('dependency:latest', { interfaces: { db2: 'db' } })
     ], {}, { interpolate: false });
 
     expect(graph.nodes).to.have.length(7);
@@ -82,10 +83,10 @@ describe('graph', () => {
 
   it('graph without validation', async () => {
     const component_config = `
-      name: architect/component
+      name: component
 
       dependencies:
-        architect/dependency: latest
+        dependency: latest
 
       secrets:
         external_host:
@@ -97,11 +98,11 @@ describe('graph', () => {
               port: 5432
               host: \${{ secrets.external_host }}
           environment:
-            OTHER_DB_ADDR: \${{ dependencies.architect/dependency.interfaces.db.url }}
+            OTHER_DB_ADDR: \${{ dependencies.dependency.interfaces.db.url }}
     `;
 
     const dependency_config = `
-      name: architect/dependency
+      name: dependency
 
       secrets:
         external_host:
@@ -119,16 +120,17 @@ describe('graph', () => {
     `;
 
     nock('http://localhost').get('/accounts/architect/components/component/versions/latest')
-      .reply(200, { tag: 'latest', config: yaml.load(component_config), service: { url: 'architect/component:latest' } });
+      .reply(200, { tag: 'latest', config: yaml.load(component_config), service: { url: 'component:latest' } });
 
     nock('http://localhost').get('/accounts/architect/components/dependency/versions/latest')
-      .reply(200, { tag: 'latest', config: yaml.load(dependency_config), service: { url: 'architect/dependency:latest' } });
+      .reply(200, { tag: 'latest', config: yaml.load(dependency_config), service: { url: 'dependency:latest' } });
 
     const manager = new LocalDependencyManager(axios.create());
+    manager.account = 'architect';
 
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/component:latest'),
-      await manager.loadComponentSpec('architect/dependency:latest')
+      await manager.loadComponentSpec('component:latest'),
+      await manager.loadComponentSpec('dependency:latest')
     ], {}, { interpolate: true, validate: false });
 
     expect(graph.nodes).to.have.length(3);

--- a/test/dependency-manager/graph.test.ts
+++ b/test/dependency-manager/graph.test.ts
@@ -69,8 +69,7 @@ describe('graph', () => {
     nock('http://localhost').get('/accounts/architect/components/dependency/versions/latest')
       .reply(200, { tag: 'latest', config: yaml.load(dependency_config), service: { url: 'dependency:latest' } });
 
-    const manager = new LocalDependencyManager(axios.create());
-    manager.account = 'architect';
+    const manager = new LocalDependencyManager(axios.create(), 'architect');
 
     const graph = await manager.getGraph([
       await manager.loadComponentSpec('component:latest'),
@@ -125,8 +124,7 @@ describe('graph', () => {
     nock('http://localhost').get('/accounts/architect/components/dependency/versions/latest')
       .reply(200, { tag: 'latest', config: yaml.load(dependency_config), service: { url: 'dependency:latest' } });
 
-    const manager = new LocalDependencyManager(axios.create());
-    manager.account = 'architect';
+    const manager = new LocalDependencyManager(axios.create(), 'architect');
 
     const graph = await manager.getGraph([
       await manager.loadComponentSpec('component:latest'),

--- a/test/dependency-manager/interfaces.test.ts
+++ b/test/dependency-manager/interfaces.test.ts
@@ -76,7 +76,7 @@ describe('interfaces spec v1', () => {
         '/stack/leaf/architect.yml': yaml.dump(leaf_component),
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'leaf': '/stack/leaf/architect.yml',
       });
       const graph = await manager.getGraph([
@@ -111,7 +111,7 @@ describe('interfaces spec v1', () => {
         '/stack/branch/architect.yml': yaml.dump(branch_component),
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'leaf': '/stack/leaf/architect.yml',
         'branch': '/stack/branch/architect.yml',
       });
@@ -186,7 +186,7 @@ describe('interfaces spec v1', () => {
         '/stack/other-leaf/architect.yml': yaml.dump(other_leaf_component),
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'leaf': '/stack/leaf/architect.yml',
         'branch': '/stack/branch/architect.yml',
         'other-leaf': '/stack/other-leaf/architect.yml',
@@ -364,7 +364,7 @@ describe('interfaces spec v1', () => {
       '/stack/architect.yml': yaml.dump(component_config),
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
@@ -450,7 +450,7 @@ describe('interfaces spec v1', () => {
       '/stack/architect.yml': yaml.dump(component_config),
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'cloud': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
@@ -554,7 +554,7 @@ describe('interfaces spec v1', () => {
       '/stack/admin-ui/architect.yml': admin_ui_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'admin-ui': '/stack/admin-ui/architect.yml',
       'product-catalog': '/stack/product-catalog/architect.yml',
     });
@@ -608,7 +608,7 @@ describe('interfaces spec v1', () => {
       '/stack/smtp/architect.yml': smtp_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'smtp': '/stack/smtp/architect.yml',
     });
     const graph = await manager.getGraph([
@@ -654,7 +654,7 @@ describe('interfaces spec v1', () => {
       '/stack/smtp/architect.yml': smtp_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'smtp': '/stack/smtp/architect.yml',
     });
     const graph = await manager.getGraph([
@@ -706,7 +706,7 @@ describe('interfaces spec v1', () => {
       '/stack/upstream/architect.yml': upstream_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'smtp': '/stack/smtp/architect.yml',
       'upstream': '/stack/upstream/architect.yml',
     });
@@ -748,7 +748,7 @@ describe('interfaces spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(
@@ -797,7 +797,7 @@ describe('interfaces spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(
@@ -839,7 +839,7 @@ describe('interfaces spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     let err;
@@ -871,7 +871,7 @@ describe('interfaces spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'dependency': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(
@@ -908,7 +908,7 @@ describe('interfaces spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     let err;
@@ -942,7 +942,7 @@ describe('interfaces spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(

--- a/test/dependency-manager/interfaces.test.ts
+++ b/test/dependency-manager/interfaces.test.ts
@@ -16,7 +16,7 @@ describe('interfaces spec v1', () => {
 
     beforeEach(async () => {
       leaf_component = {
-        name: 'test/leaf',
+        name: 'leaf',
         services: {
           db: {
             image: 'postgres:11',
@@ -45,19 +45,19 @@ describe('interfaces spec v1', () => {
       };
 
       branch_component = {
-        name: 'test/branch',
+        name: 'branch',
         dependencies: {
-          'test/leaf': 'latest',
+          'leaf': 'latest',
         },
         services: {
           api: {
             image: 'branch:latest',
             interfaces: {},
             environment: {
-              LEAF_PROTOCOL: '${{ dependencies.test/leaf.interfaces.api.protocol }}',
-              LEAF_HOST: '${{ dependencies.test/leaf.interfaces.api.host }}',
-              LEAF_PORT: '${{ dependencies.test/leaf.interfaces.api.port }}',
-              LEAF_URL: '${{ dependencies.test/leaf.interfaces.api.url }}',
+              LEAF_PROTOCOL: '${{ dependencies.leaf.interfaces.api.protocol }}',
+              LEAF_HOST: '${{ dependencies.leaf.interfaces.api.host }}',
+              LEAF_PORT: '${{ dependencies.leaf.interfaces.api.port }}',
+              LEAF_URL: '${{ dependencies.leaf.interfaces.api.url }}',
             },
           },
         },
@@ -65,10 +65,10 @@ describe('interfaces spec v1', () => {
       };
     });
 
-    const branch_ref = resourceRefToNodeRef('test/branch.services.api');
-    const leaf_interfaces_ref = resourceRefToNodeRef('test/leaf');
-    const leaf_db_ref = resourceRefToNodeRef('test/leaf.services.db');
-    const leaf_api_resource_ref = 'test/leaf.services.api';
+    const branch_ref = resourceRefToNodeRef('branch.services.api');
+    const leaf_interfaces_ref = resourceRefToNodeRef('leaf');
+    const leaf_db_ref = resourceRefToNodeRef('leaf.services.db');
+    const leaf_api_resource_ref = 'leaf.services.api';
     const leaf_api_ref = resourceRefToNodeRef(leaf_api_resource_ref);
 
     it('should connect two services together', async () => {
@@ -77,10 +77,10 @@ describe('interfaces spec v1', () => {
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/leaf': '/stack/leaf/architect.yml',
+        'leaf': '/stack/leaf/architect.yml',
       });
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('test/leaf'),
+        await manager.loadComponentSpec('leaf'),
       ]);
 
       expect(graph.nodes.map((n) => n.ref)).has.members([
@@ -112,12 +112,12 @@ describe('interfaces spec v1', () => {
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/leaf': '/stack/leaf/architect.yml',
-        'test/branch': '/stack/branch/architect.yml',
+        'leaf': '/stack/leaf/architect.yml',
+        'branch': '/stack/branch/architect.yml',
       });
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('test/leaf'),
-        await manager.loadComponentSpec('test/branch'),
+        await manager.loadComponentSpec('leaf'),
+        await manager.loadComponentSpec('branch'),
       ]);
 
       expect(graph.nodes.map((n) => n.ref)).has.members([
@@ -146,11 +146,11 @@ describe('interfaces spec v1', () => {
       leaf_component.interfaces = {
         api: '${{ services.api.interfaces.main.url }}',
       };
-      branch_component.services.api.environment.EXTERNAL_INTERFACE = "${{ dependencies['test/leaf'].ingresses['api'].url }}";
-      branch_component.services.api.environment.EXTERNAL_INTERFACE2 = "${{ environment.ingresses['test/leaf']['api'].url }}";
+      branch_component.services.api.environment.EXTERNAL_INTERFACE = "${{ dependencies['leaf'].ingresses['api'].url }}";
+      branch_component.services.api.environment.EXTERNAL_INTERFACE2 = "${{ environment.ingresses['leaf']['api'].url }}";
 
       const other_leaf_component = {
-        name: 'test/other-leaf',
+        name: 'other-leaf',
         services: {
           db: {
             image: 'postgres:11',
@@ -187,19 +187,19 @@ describe('interfaces spec v1', () => {
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/leaf': '/stack/leaf/architect.yml',
-        'test/branch': '/stack/branch/architect.yml',
-        'test/other-leaf': '/stack/other-leaf/architect.yml',
+        'leaf': '/stack/leaf/architect.yml',
+        'branch': '/stack/branch/architect.yml',
+        'other-leaf': '/stack/other-leaf/architect.yml',
       });
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('test/leaf', { interfaces: { public: 'api' } }),
-        await manager.loadComponentSpec('test/branch'),
-        await manager.loadComponentSpec('test/other-leaf', { interfaces: { publicv1: 'api' } }),
+        await manager.loadComponentSpec('leaf', { interfaces: { public: 'api' } }),
+        await manager.loadComponentSpec('branch'),
+        await manager.loadComponentSpec('other-leaf', { interfaces: { publicv1: 'api' } }),
       ]);
 
-      const other_leaf_interfaces_ref = resourceRefToNodeRef('test/other-leaf');
-      const other_leaf_api_ref = resourceRefToNodeRef('test/other-leaf.services.api');
-      const other_leaf_db_ref = resourceRefToNodeRef('test/other-leaf.services.db');
+      const other_leaf_interfaces_ref = resourceRefToNodeRef('other-leaf');
+      const other_leaf_api_ref = resourceRefToNodeRef('other-leaf.services.api');
+      const other_leaf_db_ref = resourceRefToNodeRef('other-leaf.services.db');
 
       expect(graph.nodes.map((n) => n.ref)).has.members([
         'gateway',
@@ -261,7 +261,7 @@ describe('interfaces spec v1', () => {
           'gateway:public.arc.localhost',
           'gateway:publicv1.arc.localhost',
         ],
-        labels: ['architect.ref=test/branch.services.api'],
+        labels: ['architect.ref=branch.services.api'],
       };
       expect(template.services[branch_ref]).to.be.deep.equal(expected_leaf_compose);
 
@@ -273,7 +273,7 @@ describe('interfaces spec v1', () => {
           'gateway:public.arc.localhost',
           'gateway:publicv1.arc.localhost',
         ],
-        labels: ['architect.ref=test/leaf.services.db'],
+        labels: ['architect.ref=leaf.services.db'],
       };
       expect(template.services[leaf_db_ref]).to.be.deep.equal(expected_leaf_db_compose);
 
@@ -311,7 +311,7 @@ describe('interfaces spec v1', () => {
           'gateway:public.arc.localhost',
           'gateway:publicv1.arc.localhost',
         ],
-        labels: ['architect.ref=test/other-leaf.services.db'],
+        labels: ['architect.ref=other-leaf.services.db'],
       };
       expect(template.services[other_leaf_db_ref]).to.be.deep.equal(expected_other_leaf_db_compose);
 
@@ -324,7 +324,7 @@ describe('interfaces spec v1', () => {
           DB_URL: `postgres://${other_leaf_db_ref}:5432`,
         },
         "labels": [
-          `architect.ref=test/other-leaf.services.api`,
+          `architect.ref=other-leaf.services.api`,
           "traefik.enable=true",
           "traefik.port=80",
           `traefik.http.routers.${other_leaf_api_ref}-api.rule=Host(\`publicv1.arc.localhost\`)`,
@@ -345,7 +345,7 @@ describe('interfaces spec v1', () => {
 
   it('service with multiple public interfaces', async () => {
     const component_config = {
-      name: 'architect/cloud',
+      name: 'cloud',
       services: {
         api: {
           interfaces: {
@@ -365,14 +365,14 @@ describe('interfaces spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml',
+      'cloud': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud', { interfaces: { app: 'app', admin: 'admin' } }),
+      await manager.loadComponentSpec('cloud', { interfaces: { app: 'app', admin: 'admin' } }),
     ]);
 
-    const cloud_interfaces_ref = resourceRefToNodeRef('architect/cloud');
-    const api_resource_ref = 'architect/cloud.services.api';
+    const cloud_interfaces_ref = resourceRefToNodeRef('cloud');
+    const api_resource_ref = 'cloud.services.api';
     const api_ref = resourceRefToNodeRef(api_resource_ref);
 
     expect(graph.nodes.map((n) => n.ref)).has.members([
@@ -419,7 +419,7 @@ describe('interfaces spec v1', () => {
 
   it('automatically maps interfaces when map_all_interfaces = true', async () => {
     const component_config = {
-      name: 'architect/cloud',
+      name: 'cloud',
       services: {
         api: {
           interfaces: {
@@ -451,14 +451,14 @@ describe('interfaces spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/cloud': '/stack/architect.yml',
+      'cloud': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/cloud', { map_all_interfaces: true, interfaces: { 'staff2': 'admin2', 'staff3': 'admin3' } }),
+      await manager.loadComponentSpec('cloud', { map_all_interfaces: true, interfaces: { 'staff2': 'admin2', 'staff3': 'admin3' } }),
     ]);
 
-    const cloud_interfaces_ref = resourceRefToNodeRef('architect/cloud');
-    const api_resource_ref = 'architect/cloud.services.api';
+    const cloud_interfaces_ref = resourceRefToNodeRef('cloud');
+    const api_resource_ref = 'cloud.services.api';
     const api_ref = resourceRefToNodeRef(api_resource_ref);
 
     expect(graph.nodes.map((n) => n.ref)).has.members([
@@ -515,23 +515,23 @@ describe('interfaces spec v1', () => {
 
   it('using multiple ports from a dependency', async () => {
     const admin_ui_config = `
-      name: voic/admin-ui
+      name: admin-ui
       dependencies:
-        voic/product-catalog: latest
+        product-catalog: latest
       services:
         dashboard:
           interfaces:
             main: 3000
           environment:
-            API_ADDR: \${{ dependencies['voic/product-catalog'].interfaces.public.url }}
-            ADMIN_ADDR: \${{ dependencies['voic/product-catalog'].interfaces.admin.url }}
-            PRIVATE_ADDR: \${{ dependencies['voic/product-catalog'].interfaces.private.url }}
-            EXTERNAL_API_ADDR: \${{ dependencies['voic/product-catalog'].ingresses['public'].url }}
-            EXTERNAL_API_ADDR2: \${{ environment.ingresses['voic/product-catalog']['public'].url }}
+            API_ADDR: \${{ dependencies['product-catalog'].interfaces.public.url }}
+            ADMIN_ADDR: \${{ dependencies['product-catalog'].interfaces.admin.url }}
+            PRIVATE_ADDR: \${{ dependencies['product-catalog'].interfaces.private.url }}
+            EXTERNAL_API_ADDR: \${{ dependencies['product-catalog'].ingresses['public'].url }}
+            EXTERNAL_API_ADDR2: \${{ environment.ingresses['product-catalog']['public'].url }}
       `;
 
     const product_catalog_config = `
-      name: voic/product-catalog
+      name: product-catalog
       services:
         db:
           interfaces:
@@ -555,17 +555,17 @@ describe('interfaces spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'voic/admin-ui': '/stack/admin-ui/architect.yml',
-      'voic/product-catalog': '/stack/product-catalog/architect.yml',
+      'admin-ui': '/stack/admin-ui/architect.yml',
+      'product-catalog': '/stack/product-catalog/architect.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('voic/admin-ui'),
-      await manager.loadComponentSpec('voic/product-catalog', { interfaces: { public2: 'public', admin2: 'admin' } }),
+      await manager.loadComponentSpec('admin-ui'),
+      await manager.loadComponentSpec('product-catalog', { interfaces: { public2: 'public', admin2: 'admin' } }),
     ]);
 
-    const admin_ref = resourceRefToNodeRef('voic/admin-ui.services.dashboard');
-    const catalog_interfaces_ref = resourceRefToNodeRef('voic/product-catalog');
-    const api_ref = resourceRefToNodeRef('voic/product-catalog.services.api');
+    const admin_ref = resourceRefToNodeRef('admin-ui.services.dashboard');
+    const catalog_interfaces_ref = resourceRefToNodeRef('product-catalog');
+    const api_ref = resourceRefToNodeRef('product-catalog.services.api');
 
     expect(graph.edges.map(e => e.toString())).members([
       `${catalog_interfaces_ref} [public, admin, private] -> ${api_ref} [public, admin, private]`,
@@ -585,7 +585,7 @@ describe('interfaces spec v1', () => {
 
   it('should support HTTP basic auth', async () => {
     const smtp_config = `
-      name: architect/smtp
+      name: smtp
       services:
         maildev:
           image: maildev/maildev
@@ -609,14 +609,14 @@ describe('interfaces spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/smtp': '/stack/smtp/architect.yml',
+      'smtp': '/stack/smtp/architect.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/smtp'),
+      await manager.loadComponentSpec('smtp'),
     ]);
 
-    const mail_ref = resourceRefToNodeRef('architect/smtp.services.maildev');
-    const app_ref = resourceRefToNodeRef('architect/smtp.services.test-app');
+    const mail_ref = resourceRefToNodeRef('smtp.services.maildev');
+    const app_ref = resourceRefToNodeRef('smtp.services.test-app');
 
     const test_node = graph.getNodeByRef(app_ref) as ServiceNode;
     expect(test_node.config.environment).to.deep.eq({
@@ -628,7 +628,7 @@ describe('interfaces spec v1', () => {
 
   it('should allow HTTP basic auth values to be secrets', async () => {
     const smtp_config = `
-      name: architect/smtp
+      name: smtp
       secrets:
         SMTP_USER: param-user
         SMTP_PASS: param-pass
@@ -655,14 +655,14 @@ describe('interfaces spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/smtp': '/stack/smtp/architect.yml',
+      'smtp': '/stack/smtp/architect.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/smtp'),
+      await manager.loadComponentSpec('smtp'),
     ]);
 
-    const mail_ref = resourceRefToNodeRef('architect/smtp.services.maildev');
-    const app_ref = resourceRefToNodeRef('architect/smtp.services.test-app');
+    const mail_ref = resourceRefToNodeRef('smtp.services.maildev');
+    const app_ref = resourceRefToNodeRef('smtp.services.test-app');
 
     const test_node = graph.getNodeByRef(app_ref) as ServiceNode;
     expect(test_node.config.environment).to.deep.eq({
@@ -674,7 +674,7 @@ describe('interfaces spec v1', () => {
 
   it('should support HTTP basic auth for dependency interfaces', async () => {
     const smtp_config = `
-      name: architect/smtp
+      name: smtp
       services:
         maildev:
           image: maildev/maildev
@@ -689,16 +689,16 @@ describe('interfaces spec v1', () => {
     `;
 
     const upstream_config = `
-      name: architect/upstream
+      name: upstream
       dependencies:
-        architect/smtp: latest
+        smtp: latest
       services:
         test-app:
           image: hashicorp/http-echo
           environment:
-            SMTP_ADDR: \${{ dependencies['architect/smtp'].interfaces.smtp.url }}
-            SMTP_USER: \${{ dependencies['architect/smtp'].interfaces.smtp.username }}
-            SMTP_PASS: \${{ dependencies['architect/smtp'].interfaces.smtp.password }}
+            SMTP_ADDR: \${{ dependencies['smtp'].interfaces.smtp.url }}
+            SMTP_USER: \${{ dependencies['smtp'].interfaces.smtp.username }}
+            SMTP_PASS: \${{ dependencies['smtp'].interfaces.smtp.password }}
     `;
 
     mock_fs({
@@ -707,16 +707,16 @@ describe('interfaces spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/smtp': '/stack/smtp/architect.yml',
-      'architect/upstream': '/stack/upstream/architect.yml',
+      'smtp': '/stack/smtp/architect.yml',
+      'upstream': '/stack/upstream/architect.yml',
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('architect/smtp'),
-      await manager.loadComponentSpec('architect/upstream'),
+      await manager.loadComponentSpec('smtp'),
+      await manager.loadComponentSpec('upstream'),
     ]);
 
-    const mail_ref = resourceRefToNodeRef('architect/smtp.services.maildev');
-    const app_ref = resourceRefToNodeRef('architect/upstream.services.test-app');
+    const mail_ref = resourceRefToNodeRef('smtp.services.maildev');
+    const app_ref = resourceRefToNodeRef('upstream.services.test-app');
 
     const test_node = graph.getNodeByRef(app_ref) as ServiceNode;
     expect(test_node.config.environment).to.deep.eq({
@@ -728,7 +728,7 @@ describe('interfaces spec v1', () => {
 
   it('service interface with path', async () => {
     const component_config = `
-    name: examples/hello-world
+    name: hello-world
     services:
       app:
         environment:
@@ -749,19 +749,19 @@ describe('interfaces spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'examples/hello-world': '/stack/architect.yml',
+      'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(
-      await manager.loadComponentSpecs('examples/hello-world'));
+      await manager.loadComponentSpecs('hello-world'));
     const template = await DockerComposeUtils.generate(graph);
 
-    const api_ref = resourceRefToNodeRef('examples/hello-world.services.api');
+    const api_ref = resourceRefToNodeRef('hello-world.services.api');
     expect(template.services[api_ref].environment).to.deep.eq({
       MY_PATH: '/api',
       MY_ADDR: `http://${api_ref}:8080/api`,
     });
 
-    const app_ref = resourceRefToNodeRef('examples/hello-world.services.app');
+    const app_ref = resourceRefToNodeRef('hello-world.services.app');
     expect(template.services[app_ref].environment).to.deep.eq({
       API_PATH: '/api',
       API_ADDR: `http://${api_ref}:8080/api`,
@@ -770,7 +770,7 @@ describe('interfaces spec v1', () => {
 
   it('interfaces with same subdomain and different paths', async () => {
     const component_config = `
-    name: examples/hello-world
+    name: hello-world
     interfaces:
       api:
         url: \${{ services.api.interfaces.main.url }}
@@ -798,11 +798,11 @@ describe('interfaces spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'examples/hello-world': '/stack/architect.yml',
+      'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(
-      await manager.loadComponentSpecs('examples/hello-world'));
-    const api_ref = resourceRefToNodeRef('examples/hello-world.services.api');
+      await manager.loadComponentSpecs('hello-world'));
+    const api_ref = resourceRefToNodeRef('hello-world.services.api');
 
     const template = await DockerComposeUtils.generate(graph);
     expect(template.services[api_ref].environment).to.deep.eq({
@@ -815,7 +815,7 @@ describe('interfaces spec v1', () => {
 
   it('error on interfaces with same subdomain and same path', async () => {
     const component_config = `
-    name: examples/hello-world
+    name: hello-world
     interfaces:
       api:
         url: \${{ services.api.interfaces.main.url }}
@@ -840,11 +840,11 @@ describe('interfaces spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'examples/hello-world': '/stack/architect.yml',
+      'hello-world': '/stack/architect.yml',
     });
     let err;
     try {
-      await manager.getGraph(await manager.loadComponentSpecs('examples/hello-world'));
+      await manager.getGraph(await manager.loadComponentSpecs('hello-world'));
     } catch (e: any) {
       err = e;
     }
@@ -853,7 +853,7 @@ describe('interfaces spec v1', () => {
 
   it('followEdge returns proper results when called with ServiceEdge', async () => {
     const component_config = `
-    name: architect/dependency
+    name: dependency
 
     services:
       db:
@@ -872,10 +872,10 @@ describe('interfaces spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'architect/dependency': '/stack/architect.yml',
+      'dependency': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(
-      await manager.loadComponentSpecs('architect/dependency'));
+      await manager.loadComponentSpecs('dependency'));
 
     expect(graph.edges.length).eq(1);
 
@@ -888,7 +888,7 @@ describe('interfaces spec v1', () => {
 
   it('validation error on interfaces for invalid subdomain passed through secrets', async () => {
     const component_config = `
-    name: examples/hello-world
+    name: hello-world
     secrets:
       subdomain: not_ok
     interfaces:
@@ -909,11 +909,11 @@ describe('interfaces spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'examples/hello-world': '/stack/architect.yml',
+      'hello-world': '/stack/architect.yml',
     });
     let err;
     try {
-      await manager.getGraph(await manager.loadComponentSpecs('examples/hello-world'));
+      await manager.getGraph(await manager.loadComponentSpecs('hello-world'));
     } catch (e: any) {
       err = e;
     }
@@ -922,7 +922,7 @@ describe('interfaces spec v1', () => {
 
   it('maps ok on interfaces for valid subdomain passed through secrets', async () => {
     const component_config = `
-    name: examples/hello-world
+    name: hello-world
     secrets:
       subdomain: is-ok
     interfaces:
@@ -943,11 +943,11 @@ describe('interfaces spec v1', () => {
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'examples/hello-world': '/stack/architect.yml',
+      'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(
-      await manager.loadComponentSpecs('examples/hello-world'));
-    const api_ref = resourceRefToNodeRef('examples/hello-world.services.api');
+      await manager.loadComponentSpecs('hello-world'));
+    const api_ref = resourceRefToNodeRef('hello-world.services.api');
 
     const template = await DockerComposeUtils.generate(graph);
     expect(template.services[api_ref].environment).to.deep.eq({

--- a/test/dependency-manager/interpolation.test.ts
+++ b/test/dependency-manager/interpolation.test.ts
@@ -58,7 +58,7 @@ describe('interpolation spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
@@ -87,7 +87,7 @@ describe('interpolation spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
@@ -134,7 +134,7 @@ describe('interpolation spec v1', () => {
       '/stack/worker.yml': yaml.dump(worker_component_config),
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'web': '/stack/web.yml',
       'worker': '/stack/worker.yml'
     });
@@ -202,7 +202,7 @@ describe('interpolation spec v1', () => {
     };
     expect(template).to.be.deep.equal(expected_compose);
 
-    const public_manager = new LocalDependencyManager(axios.create(), {
+    const public_manager = new LocalDependencyManager(axios.create(), 'architect', {
       'web': '/stack/web.yml',
       'worker': '/stack/worker.yml'
     });
@@ -295,7 +295,7 @@ describe('interpolation spec v1', () => {
       '/frontend/architect.yml': frontend_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'backend': '/backend/architect.yml',
       'frontend': '/frontend/architect.yml'
     });
@@ -348,7 +348,7 @@ describe('interpolation spec v1', () => {
       '/frontend/architect.yml': frontend_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'frontend': '/frontend/architect.yml'
     });
     const graph = await manager.getGraph([
@@ -443,7 +443,7 @@ describe('interpolation spec v1', () => {
       '/frontend3/architect.yml': frontend_config3,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'backend': '/backend/architect.yml',
       'frontend': '/frontend/architect.yml',
       'frontend2': '/frontend2/architect.yml',
@@ -511,7 +511,7 @@ describe('interpolation spec v1', () => {
       '/frontend/architect.yml': frontend_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'backend': '/backend/architect.yml',
       'frontend': '/frontend/architect.yml'
     });
@@ -571,7 +571,7 @@ describe('interpolation spec v1', () => {
   //     '/stack/web/web.json': JSON.stringify(component_config),
   //   });
 
-  //   const manager = new LocalDependencyManager(axios.create(), {
+  //   const manager = new LocalDependencyManager(axios.create(), 'architect', {
   //     'component': '/stack/web/web.json',
   //   });
   //   const graph = await manager.getGraph([
@@ -610,7 +610,7 @@ describe('interpolation spec v1', () => {
   //     '/stack/web/web.json': JSON.stringify(component_config),
   //   });
 
-  //   const manager = new LocalDependencyManager(axios.create(), {
+  //   const manager = new LocalDependencyManager(axios.create(), 'architect', {
   //     'component': '/stack/web/web.json',
   //   });
   //   const graph = await manager.getGraph([
@@ -645,7 +645,7 @@ describe('interpolation spec v1', () => {
   //     '/stack/architect.yml': component_config,
   //   });
 
-  //   const manager = new LocalDependencyManager(axios.create(), {
+  //   const manager = new LocalDependencyManager(axios.create(), 'architect', {
   //     'hello-world': '/stack/architect.yml',
   //   });
   //   const graph = await manager.getGraph([
@@ -680,7 +680,7 @@ describe('interpolation spec v1', () => {
   //     '/stack/architect.yml': component_config,
   //   });
 
-  //   const manager = new LocalDependencyManager(axios.create(), {
+  //   const manager = new LocalDependencyManager(axios.create(), 'architect', {
   //     'hello-world': '/stack/architect.yml',
   //   });
   //   const graph = await manager.getGraph([
@@ -715,7 +715,7 @@ describe('interpolation spec v1', () => {
   //     '/stack/architect.yml': component_config,
   //   });
 
-  //   const manager = new LocalDependencyManager(axios.create(), {
+  //   const manager = new LocalDependencyManager(axios.create(), 'architect', {
   //     'hello-world': '/stack/architect.yml',
   //   });
   //   const graph = await manager.getGraph([
@@ -752,7 +752,7 @@ describe('interpolation spec v1', () => {
   //     '/stack/architect.yml': component_config,
   //   });
 
-  //   const manager = new LocalDependencyManager(axios.create(), {
+  //   const manager = new LocalDependencyManager(axios.create(), 'architect', {
   //     'hello-world': '/stack/architect.yml',
   //   });
   //   const graph = await manager.getGraph([
@@ -788,7 +788,7 @@ describe('interpolation spec v1', () => {
   //     '/stack/architect.yml': component_config,
   //   });
 
-  //   const manager = new LocalDependencyManager(axios.create(), {
+  //   const manager = new LocalDependencyManager(axios.create(), 'architect', {
   //     'hello-world': '/stack/architect.yml',
   //   });
   //   const graph = await manager.getGraph([
@@ -824,7 +824,7 @@ describe('interpolation spec v1', () => {
   //     '/stack/web.json': JSON.stringify(component_config),
   //   });
 
-  //   const manager = new LocalDependencyManager(axios.create(), {
+  //   const manager = new LocalDependencyManager(axios.create(), 'architect', {
   //     'component': '/stack/web.json',
   //   });
   //   const graph = await manager.getGraph([
@@ -859,7 +859,7 @@ describe('interpolation spec v1', () => {
   //     '/stack/arc/architect.yml': component_config,
   //   });
 
-  //   const manager = new LocalDependencyManager(axios.create(), {
+  //   const manager = new LocalDependencyManager(axios.create(), 'architect', {
   //     'hello-world': '/stack/arc/architect.yml',
   //   });
   //   const graph = await manager.getGraph([
@@ -896,7 +896,7 @@ describe('interpolation spec v1', () => {
   //     '/stack/architect.yml': component_config,
   //   });
 
-  //   const manager = new LocalDependencyManager(axios.create(), {
+  //   const manager = new LocalDependencyManager(axios.create(), 'architect', {
   //     'hello-world': '/stack/architect.yml',
   //   });
   //   const graph = await manager.getGraph([
@@ -926,7 +926,7 @@ describe('interpolation spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
@@ -960,7 +960,7 @@ describe('interpolation spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
@@ -995,7 +995,7 @@ describe('interpolation spec v1', () => {
   //     '/stack/architect.yml': component_config,
   //   });
 
-  //   const manager = new LocalDependencyManager(axios.create(), {
+  //   const manager = new LocalDependencyManager(axios.create(), 'architect', {
   //     'hello-world': '/stack/architect.yml',
   //   });
   //   const graph = await manager.getGraph([
@@ -1035,7 +1035,7 @@ describe('interpolation spec v1', () => {
   //     '/stack/architect.yml': component_config,
   //   });
 
-  //   const manager = new LocalDependencyManager(axios.create(), {
+  //   const manager = new LocalDependencyManager(axios.create(), 'architect', {
   //     'hello-world': '/stack/architect.yml',
   //   });
   //   const graph = await manager.getGraph([
@@ -1076,7 +1076,7 @@ describe('interpolation spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph([
@@ -1135,7 +1135,7 @@ describe('interpolation spec v1', () => {
       '/stack2/architect.yml': component_config2,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
       'dependency': '/stack2/architect.yml',
     });
@@ -1170,7 +1170,7 @@ describe('interpolation spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(
@@ -1201,7 +1201,7 @@ describe('interpolation spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(
@@ -1227,7 +1227,7 @@ describe('interpolation spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(
@@ -1263,7 +1263,7 @@ describe('interpolation spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(
@@ -1306,7 +1306,7 @@ describe('interpolation spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(await manager.loadComponentSpecs('hello-world'));
@@ -1352,7 +1352,7 @@ describe('interpolation spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(
@@ -1412,7 +1412,7 @@ describe('interpolation spec v1', () => {
       '/stack/architect.yml': component_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'hello-world': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(
@@ -1475,7 +1475,7 @@ describe('interpolation spec v1', () => {
       '/stack/consumer/architect.yml': consumer_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'publisher': '/stack/publisher/architect.yml',
       'consumer': '/stack/consumer/architect.yml',
     });
@@ -1524,7 +1524,7 @@ describe('interpolation spec v1', () => {
       '/stack/consumer/architect.yml': consumer_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'publisher': '/stack/publisher/architect.yml',
       'consumer': '/stack/consumer/architect.yml',
     });
@@ -1566,7 +1566,7 @@ describe('interpolation spec v1', () => {
       '/stack/consumer/architect.yml': consumer_config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'publisher': '/stack/publisher/architect.yml',
       'consumer': '/stack/consumer/architect.yml',
     });
@@ -1614,7 +1614,7 @@ describe('interpolation spec v1', () => {
       '/stack/architect.yml': config,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'test': '/stack/architect.yml',
     });
     const graph = await manager.getGraph(

--- a/test/dependency-manager/reserved-names.test.ts
+++ b/test/dependency-manager/reserved-names.test.ts
@@ -31,7 +31,7 @@ describe('components with reserved_name field set', function () {
         '/stack/architect.yml': component_config_yml,
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'cloud': '/stack'
       });
 
@@ -97,7 +97,7 @@ describe('components with reserved_name field set', function () {
         '/stack/architect.yml': component_config_yml,
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'cloud': '/stack'
       });
 
@@ -138,8 +138,7 @@ describe('components with reserved_name field set', function () {
       nock('http://localhost').get(`/accounts/architect/components/cloud/versions/v1`)
         .reply(200, { tag: 'v1', config: component_config_json, service: { url: 'cloud:v1' } });
 
-      const manager = new LocalDependencyManager(axios.create());
-      manager.account = 'architect';
+      const manager = new LocalDependencyManager(axios.create(), 'architect');
 
       const graph = await manager.getGraph([
         await manager.loadComponentSpec('cloud:v1')
@@ -177,8 +176,7 @@ describe('components with reserved_name field set', function () {
       nock('http://localhost').get(`/accounts/architect/components/cloud/versions/v1`)
         .reply(200, { tag: 'v1', config: component_config, service: { url: 'cloud:v1' } });
 
-      const manager = new LocalDependencyManager(axios.create());
-      manager.account = 'architect';
+      const manager = new LocalDependencyManager(axios.create(), 'architect');
 
       const graph = await manager.getGraph([
         await manager.loadComponentSpec('cloud:v1')
@@ -231,7 +229,7 @@ describe('components with reserved_name field set', function () {
         return true;
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'cloud': '/stack/architect.yml'
       });
       const graph = await manager.getGraph([
@@ -359,7 +357,7 @@ describe('components with reserved_name field set', function () {
         '/stack/concourse/architect.yml': yaml.dump(concourse_component_config),
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'cloud': '/stack/cloud/architect.yml',
         'ci': '/stack/concourse/architect.yml'
       });
@@ -423,7 +421,7 @@ describe('components with reserved_name field set', function () {
         '/stack/cloud/architect.yml': yaml.dump(cloud_component_config),
       });
 
-      const manager = new LocalDependencyManager(axios.create(), { 'cloud': '/stack/cloud/architect.yml' });
+      const manager = new LocalDependencyManager(axios.create(), 'architect', { 'cloud': '/stack/cloud/architect.yml' });
       const graph = await manager.getGraph([
         await manager.loadComponentSpec('cloud:latest', { interfaces: { api: 'api-interface' } })
       ]);
@@ -470,7 +468,7 @@ describe('components with reserved_name field set', function () {
         '/c/architect.yaml': component_c,
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component-a': '/a/architect.yaml',
         'component-b': '/b/architect.yaml',
         'component-c': '/c/architect.yaml'
@@ -534,7 +532,7 @@ describe('components with reserved_name field set', function () {
         '/c/architect.yaml': component_c,
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component-a': '/a/architect.yaml',
         'component-b': '/b/architect.yaml',
         'component-c': '/c/architect.yaml'
@@ -582,7 +580,7 @@ describe('components with reserved_name field set', function () {
         '/stack/architect.yml': component_config_yml,
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'cloud': '/stack/architect.yml'
       });
 

--- a/test/dependency-manager/reserved-names.test.ts
+++ b/test/dependency-manager/reserved-names.test.ts
@@ -16,7 +16,7 @@ describe('components with reserved_name field set', function () {
     it('simple local component with reserved name', async () => {
       const reserved_name = 'test-name';
       const component_config_yml = `
-        name: architect/cloud
+        name: cloud
         services:
           app:
             interfaces:
@@ -32,14 +32,14 @@ describe('components with reserved_name field set', function () {
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'architect/cloud': '/stack'
+        'cloud': '/stack'
       });
 
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('architect/cloud:latest')
+        await manager.loadComponentSpec('cloud:latest')
       ]);
 
-      const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
+      const app_ref = resourceRefToNodeRef('cloud.services.app');
       const api_ref = reserved_name;
 
       expect(graph.nodes.map((n) => n.ref)).has.members([
@@ -60,7 +60,7 @@ describe('components with reserved_name field set', function () {
               "context": path.resolve("/stack")
             },
             image: app_ref,
-            labels: ['architect.ref=architect/cloud.services.app']
+            labels: ['architect.ref=cloud.services.app']
           },
           [api_ref]: {
             "environment": {},
@@ -71,7 +71,7 @@ describe('components with reserved_name field set', function () {
               "context": path.resolve("/stack")
             },
             image: reserved_name,
-            labels: [`architect.ref=architect/cloud.services.api`]
+            labels: [`architect.ref=cloud.services.api`]
           },
         },
         "version": "3",
@@ -82,7 +82,7 @@ describe('components with reserved_name field set', function () {
 
     it('simple local component with interpolated reserved name', async () => {
       const component_config_yml = `
-        name: architect/cloud
+        name: cloud
         secrets:
           name_override:
             default: test-name
@@ -98,11 +98,11 @@ describe('components with reserved_name field set', function () {
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'architect/cloud': '/stack'
+        'cloud': '/stack'
       });
 
       try {
-        await manager.loadComponentSpec('architect/cloud:latest');
+        await manager.loadComponentSpec('cloud:latest');
       } catch (err: any) {
         expect(err).instanceOf(ValidationErrors);
         const errors = JSON.parse(err.message) as ValidationError[];
@@ -119,7 +119,7 @@ describe('components with reserved_name field set', function () {
     it('simple remote component', async () => {
       const reserved_name = 'test-name';
       const component_config_json = {
-        name: 'architect/cloud',
+        name: 'cloud',
         services: {
           app: {
             interfaces: {
@@ -136,14 +136,16 @@ describe('components with reserved_name field set', function () {
       };
 
       nock('http://localhost').get(`/accounts/architect/components/cloud/versions/v1`)
-        .reply(200, { tag: 'v1', config: component_config_json, service: { url: 'architect/cloud:v1' } });
+        .reply(200, { tag: 'v1', config: component_config_json, service: { url: 'cloud:v1' } });
 
       const manager = new LocalDependencyManager(axios.create());
+      manager.account = 'architect';
+
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('architect/cloud:v1')
+        await manager.loadComponentSpec('cloud:v1')
       ]);
       const app_ref = reserved_name;
-      const api_ref = resourceRefToNodeRef('architect/cloud.services.api');
+      const api_ref = resourceRefToNodeRef('cloud.services.api');
 
       expect(graph.nodes.map((n) => n.ref)).has.members([
         app_ref,
@@ -155,7 +157,7 @@ describe('components with reserved_name field set', function () {
     it('simple remote component with override', async () => {
       const reserved_name = 'test-name';
       const component_config = {
-        name: 'architect/cloud',
+        name: 'cloud',
         secrets: {
           log_level: 'info'
         },
@@ -173,11 +175,13 @@ describe('components with reserved_name field set', function () {
       };
 
       nock('http://localhost').get(`/accounts/architect/components/cloud/versions/v1`)
-        .reply(200, { tag: 'v1', config: component_config, service: { url: 'architect/cloud:v1' } });
+        .reply(200, { tag: 'v1', config: component_config, service: { url: 'cloud:v1' } });
 
       const manager = new LocalDependencyManager(axios.create());
+      manager.account = 'architect';
+
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('architect/cloud:v1')
+        await manager.loadComponentSpec('cloud:v1')
       ], { '*': { log_level: 'debug' } });
       const app_ref = reserved_name;
       expect(graph.nodes.map((n) => n.ref)).has.members([app_ref]);
@@ -189,7 +193,7 @@ describe('components with reserved_name field set', function () {
     it('local component with edges and reserved name', async () => {
       const reserved_name = 'test-name';
       const component_config = {
-        name: 'architect/cloud',
+        name: 'cloud',
         services: {
           app: {
             interfaces: {
@@ -228,14 +232,14 @@ describe('components with reserved_name field set', function () {
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'architect/cloud': '/stack/architect.yml'
+        'cloud': '/stack/architect.yml'
       });
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('architect/cloud:latest')
+        await manager.loadComponentSpec('cloud:latest')
       ]);
-      const app_ref = resourceRefToNodeRef('architect/cloud.services.app');
+      const app_ref = resourceRefToNodeRef('cloud.services.app');
       const api_ref = reserved_name;
-      const db_ref = resourceRefToNodeRef('architect/cloud.services.db');
+      const db_ref = resourceRefToNodeRef('cloud.services.db');
       expect(graph.nodes.map((n) => n.ref)).has.members([
         app_ref,
         api_ref,
@@ -269,7 +273,7 @@ describe('components with reserved_name field set', function () {
               "50001:8080",
             ],
             image: reserved_name,
-            labels: [`architect.ref=architect/cloud.services.api`]
+            labels: [`architect.ref=cloud.services.api`]
           },
           [app_ref]: {
             "depends_on": [
@@ -290,7 +294,7 @@ describe('components with reserved_name field set', function () {
               ],
             },
             image: app_ref,
-            labels: ['architect.ref=architect/cloud.services.app']
+            labels: ['architect.ref=cloud.services.app']
           },
           [db_ref]: {
             "environment": {},
@@ -298,7 +302,7 @@ describe('components with reserved_name field set', function () {
               "50002:5432"
             ],
             image: db_ref,
-            labels: ['architect.ref=architect/cloud.services.db']
+            labels: ['architect.ref=cloud.services.db']
           }
         },
         "version": "3",
@@ -397,7 +401,7 @@ describe('components with reserved_name field set', function () {
     it('environment ingress context produces the correct values for a simple external interface', async () => {
       const reserved_name = 'test-name';
       const cloud_component_config = {
-        name: 'architect/cloud',
+        name: 'cloud',
         services: {
           api: {
             interfaces: {
@@ -405,7 +409,7 @@ describe('components with reserved_name field set', function () {
             },
             environment: {
               EXTERNAL_APP_URL: "${{ ingresses['api-interface'].url }}",
-              EXTERNAL_APP_URL2: "${{ environment.ingresses['architect/cloud']['api-interface'].url }}",
+              EXTERNAL_APP_URL2: "${{ environment.ingresses['cloud']['api-interface'].url }}",
             },
             reserved_name,
           }
@@ -419,9 +423,9 @@ describe('components with reserved_name field set', function () {
         '/stack/cloud/architect.yml': yaml.dump(cloud_component_config),
       });
 
-      const manager = new LocalDependencyManager(axios.create(), { 'architect/cloud': '/stack/cloud/architect.yml' });
+      const manager = new LocalDependencyManager(axios.create(), { 'cloud': '/stack/cloud/architect.yml' });
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('architect/cloud:latest', { interfaces: { api: 'api-interface' } })
+        await manager.loadComponentSpec('cloud:latest', { interfaces: { api: 'api-interface' } })
       ]);
 
       expect(graph.edges.filter(e => e instanceof IngressEdge).length).eq(1);
@@ -435,18 +439,18 @@ describe('components with reserved_name field set', function () {
     it('component with deep dependencies', async () => {
       const reserved_name = 'test-name';
       const component_a = `
-      name: examples/component-a
+      name: component-a
       dependencies:
-        examples/component-b: latest
+        component-b: latest
       services:
         app:
           image: test:v1
       `;
 
       const component_b = `
-      name: examples/component-b
+      name: component-b
       dependencies:
-        examples/component-c: latest
+        component-c: latest
       services:
         api:
           image: test:v1
@@ -454,7 +458,7 @@ describe('components with reserved_name field set', function () {
       `;
 
       const component_c = `
-      name: examples/component-c
+      name: component-c
       services:
         api:
           image: test:v1
@@ -467,17 +471,17 @@ describe('components with reserved_name field set', function () {
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'examples/component-a': '/a/architect.yaml',
-        'examples/component-b': '/b/architect.yaml',
-        'examples/component-c': '/c/architect.yaml'
+        'component-a': '/a/architect.yaml',
+        'component-b': '/b/architect.yaml',
+        'component-c': '/c/architect.yaml'
       });
       const graph = await manager.getGraph([
-        ...await manager.loadComponentSpecs('examples/component-a'),
+        ...await manager.loadComponentSpecs('component-a'),
       ]);
 
-      const a_ref = resourceRefToNodeRef('examples/component-a.services.app');
+      const a_ref = resourceRefToNodeRef('component-a.services.app');
       const b_ref = reserved_name;
-      const c_ref = resourceRefToNodeRef('examples/component-c.services.api');
+      const c_ref = resourceRefToNodeRef('component-c.services.api');
 
       expect(graph.nodes.map((n) => n.ref)).has.members([
         a_ref,
@@ -489,31 +493,31 @@ describe('components with reserved_name field set', function () {
     it('components with a shared dependency', async () => {
       const reserved_name = 'test-name';
       const component_a = `
-      name: examples/component-a
+      name: component-a
       dependencies:
-        examples/component-c: latest
+        component-c: latest
       services:
         app:
           image: test:v1
           environment:
-            C_ADDR: \${{ dependencies.examples/component-c.interfaces.api.url }}
-            C_EXT_ADDR: \${{ dependencies.examples/component-c.ingresses.api.url }}
+            C_ADDR: \${{ dependencies.component-c.interfaces.api.url }}
+            C_EXT_ADDR: \${{ dependencies.component-c.ingresses.api.url }}
       `;
 
       const component_b = `
-      name: examples/component-b
+      name: component-b
       dependencies:
-        examples/component-c: latest
+        component-c: latest
       services:
         api:
           image: test:v1
           environment:
-            C_ADDR: \${{ dependencies.examples/component-c.interfaces.api.url }}
-            C_EXT_ADDR: \${{ dependencies.examples/component-c.ingresses.api.url }}
+            C_ADDR: \${{ dependencies.component-c.interfaces.api.url }}
+            C_EXT_ADDR: \${{ dependencies.component-c.ingresses.api.url }}
       `;
 
       const component_c = `
-      name: examples/component-c
+      name: component-c
       services:
         api:
           image: test:v1
@@ -531,17 +535,17 @@ describe('components with reserved_name field set', function () {
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'examples/component-a': '/a/architect.yaml',
-        'examples/component-b': '/b/architect.yaml',
-        'examples/component-c': '/c/architect.yaml'
+        'component-a': '/a/architect.yaml',
+        'component-b': '/b/architect.yaml',
+        'component-c': '/c/architect.yaml'
       });
       const graph = await manager.getGraph([
-        ...await manager.loadComponentSpecs('examples/component-a'),
-        ...await manager.loadComponentSpecs('examples/component-b'),
+        ...await manager.loadComponentSpecs('component-a'),
+        ...await manager.loadComponentSpecs('component-b'),
       ]);
 
-      const a_ref = resourceRefToNodeRef('examples/component-a.services.app');
-      const b_ref = resourceRefToNodeRef('examples/component-b.services.api');
+      const a_ref = resourceRefToNodeRef('component-a.services.app');
+      const b_ref = resourceRefToNodeRef('component-b.services.api');
       const c_ref = reserved_name;
 
       const a_node = graph.getNodeByRef(a_ref) as ServiceNode;
@@ -559,7 +563,7 @@ describe('components with reserved_name field set', function () {
 
     it(`the same reserved name can't be used for more than one service`, async () => {
       const component_config_yml = `
-        name: architect/cloud
+        name: cloud
         secrets:
           name_override:
             default: test-name
@@ -579,12 +583,12 @@ describe('components with reserved_name field set', function () {
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'architect/cloud': '/stack/architect.yml'
+        'cloud': '/stack/architect.yml'
       });
 
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('architect/cloud:latest')
+          await manager.loadComponentSpec('cloud:latest')
         ]);
       } catch (err: any) {
         expect(err.message).eq(`A service named uncreative-name is declared in multiple places. The same name can't be used for multiple services.`);

--- a/test/dependency-manager/spec/component-spec.unit.test.ts
+++ b/test/dependency-manager/spec/component-spec.unit.test.ts
@@ -18,7 +18,7 @@ describe('component spec unit test', () => {
 
   it('component spec overrides', () => {
     const yml = `
-    name: test/component
+    name: component
     secrets:
       test1: test1
       test2:
@@ -76,7 +76,7 @@ describe('component spec unit test', () => {
     const override_spec = plainToClass(ComponentSpec, yaml.load(override_yml));
     const merged_spec = overrideSpec(component_spec, override_spec);
     expect(classToPlain(merged_spec)).to.deep.equal(yaml.load(`
-    name: test/component
+    name: component
     secrets:
       test1:
         required: false

--- a/test/dependency-manager/template.test.ts
+++ b/test/dependency-manager/template.test.ts
@@ -159,7 +159,7 @@ describe('template', () => {
         '/stack/architect.yml': component_config,
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'hello-world': '/stack/architect.yml',
       });
       const graph = await manager.getGraph([
@@ -211,7 +211,7 @@ describe('template', () => {
         '/stack/architect.yml': component_config,
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'hello-world': '/stack/architect.yml',
       });
       const graph = await manager.getGraph([
@@ -249,7 +249,7 @@ describe('template', () => {
         '/stack/architect.yml': component_config,
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'hello-world': '/stack/architect.yml',
       });
       const graph = await manager.getGraph([

--- a/test/dependency-manager/template.test.ts
+++ b/test/dependency-manager/template.test.ts
@@ -125,7 +125,7 @@ describe('template', () => {
   describe('statements', () => {
     it('nested if statements', async () => {
       const component_config = `
-    name: examples/hello-world
+    name: hello-world
     secrets:
       environment: local
 
@@ -160,12 +160,12 @@ describe('template', () => {
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'examples/hello-world': '/stack/architect.yml',
+        'hello-world': '/stack/architect.yml',
       });
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('examples/hello-world', { map_all_interfaces: true }),
+        await manager.loadComponentSpec('hello-world', { map_all_interfaces: true }),
       ]);
-      const api_ref = resourceRefToNodeRef('examples/hello-world.services.api');
+      const api_ref = resourceRefToNodeRef('hello-world.services.api');
       const node = graph.getNodeByRef(api_ref) as ServiceNode;
       expect(node.config.environment).to.deep.eq({
         LOCAL: '1',
@@ -174,7 +174,7 @@ describe('template', () => {
       });
 
       const graph2 = await manager.getGraph([
-        await manager.loadComponentSpec('examples/hello-world'),
+        await manager.loadComponentSpec('hello-world'),
       ], { '*': { environment: 'prod' } });
       const node2 = graph2.getNodeByRef(api_ref) as ServiceNode;
       expect(node2.config.environment).to.deep.eq({
@@ -186,7 +186,7 @@ describe('template', () => {
 
     it('if statements for host overrides', async () => {
       const component_config = `
-    name: examples/hello-world
+    name: hello-world
     secrets:
       environment: prod
 
@@ -212,12 +212,12 @@ describe('template', () => {
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'examples/hello-world': '/stack/architect.yml',
+        'hello-world': '/stack/architect.yml',
       });
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('examples/hello-world'),
+        await manager.loadComponentSpec('hello-world'),
       ]);
-      const api_ref = resourceRefToNodeRef('examples/hello-world.services.api');
+      const api_ref = resourceRefToNodeRef('hello-world.services.api');
       const api_node = graph.getNodeByRef(api_ref) as ServiceNode;
       expect(api_node.config.environment).to.deep.eq({
         DB_HOST: 'db.aws.com',
@@ -227,7 +227,7 @@ describe('template', () => {
 
     it('if statements without interpolation', async () => {
       const component_config = `
-    name: examples/hello-world
+    name: hello-world
 
     interfaces:
       \${{ if architect.environment == 'local' }}:
@@ -250,10 +250,10 @@ describe('template', () => {
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'examples/hello-world': '/stack/architect.yml',
+        'hello-world': '/stack/architect.yml',
       });
       const graph = await manager.getGraph([
-        await manager.loadComponentSpec('examples/hello-world'),
+        await manager.loadComponentSpec('hello-world'),
       ], undefined, { interpolate: false });
       expect(graph.nodes).lengthOf(0);
       expect(graph.edges).lengthOf(0);

--- a/test/dependency-manager/validation.test.ts
+++ b/test/dependency-manager/validation.test.ts
@@ -4,14 +4,13 @@ import { expect } from 'chai';
 import yaml from 'js-yaml';
 import mock_fs from 'mock-fs';
 import nock from 'nock';
-import TSON from "typescript-json";
+import TSON from 'typescript-json';
 import { buildSpecFromPath, buildSpecFromYml, resourceRefToNodeRef, ServiceNode, Slugs, ValidationError, ValidationErrors } from '../../src';
 import LocalDependencyManager from '../../src/common/dependency-manager/local-manager';
 import { DeepPartial } from '../../src/common/utils/types';
 import { SecretsConfig } from '../../src/dependency-manager/secrets/secrets';
 
 describe('validate spec', () => {
-
   describe('component config validation', () => {
     it('valid service ref brackets', async () => {
       const component_config = `
@@ -29,7 +28,7 @@ describe('validate spec', () => {
 
     it('invalid nested debug', async () => {
       const component_config = `
-name: test/component
+name: component
 services:
   stateless-app:
     environment:
@@ -62,19 +61,19 @@ services:
 
     it('invalid replicas value', async () => {
       const component_config = `
-      name: test/component
+      name: component
       services:
         stateless-app:
           replicas: '1'
       `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/architect.yml',
+        'component': '/architect.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -94,7 +93,7 @@ services:
 
     it('invalid service ref', async () => {
       const component_config = `
-      name: test/component
+      name: component
       services:
         stateless-app:
           interfaces:
@@ -104,12 +103,12 @@ services:
       `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/architect.yml',
+        'component': '/architect.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -152,7 +151,7 @@ services:
 
     it('valid service depends_on', async () => {
       const component_config = `
-      name: test/component
+      name: component
       services:
         stateful-app:
           depends_on:
@@ -171,7 +170,7 @@ services:
 
     it('invalid task schedule', async () => {
       const component_config = `
-      name: test/component
+      name: component
       tasks:
         some-task:
           schedule: "*/5 * * * ? * * * * *"
@@ -179,12 +178,12 @@ services:
       `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/architect.yml',
+        'component': '/architect.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -198,7 +197,7 @@ services:
 
     it('valid task depends_on', async () => {
       const component_config = `
-      name: test/component
+      name: component
       tasks:
         some-task:
           depends_on:
@@ -221,7 +220,7 @@ services:
 
     it('invalid task depends_on', async () => {
       const component_config = `
-      name: test/component
+      name: component
       tasks:
         some-task:
           schedule: "*/5 * * * ?"
@@ -237,12 +236,12 @@ services:
       `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/architect.yml',
+        'component': '/architect.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -256,7 +255,7 @@ services:
 
     it('invalid service self reference', async () => {
       const component_config = `
-      name: test/component
+      name: component
       services:
         stateless-app:
           depends_on:
@@ -268,12 +267,12 @@ services:
       `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/architect.yml',
+        'component': '/architect.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -287,7 +286,7 @@ services:
 
     it('invalid service depends_on reference', async () => {
       const component_config = `
-      name: test/component
+      name: component
       services:
         stateless-app:
           depends_on:
@@ -299,12 +298,12 @@ services:
       `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/architect.yml',
+        'component': '/architect.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -318,7 +317,7 @@ services:
 
     it('invalid circular service reference', async () => {
       const component_config = `
-      name: test/component
+      name: component
       services:
         stateful-app:
           depends_on:
@@ -336,12 +335,12 @@ services:
       mock_fs({ '/architect.yml': component_config });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/architect.yml',
+        'component': '/architect.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -358,7 +357,7 @@ services:
 
     it('invalid deep circular service reference', async () => {
       const component_config = `
-      name: test/component
+      name: component
       services:
         stateful-app:
           depends_on:
@@ -380,12 +379,12 @@ services:
       `;
       mock_fs({ '/architect.yml': component_config });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/architect.yml',
+        'component': '/architect.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -412,12 +411,12 @@ services:
         '/component.yml': component_config,
       });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/component.yml',
+        'component': '/component.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -429,7 +428,7 @@ services:
       expect(errors.map(e => e.path)).members([
         'name',
       ]);
-      expect(errors[0].message).includes('architect/component-name');
+      expect(errors[0].message).includes('must contain only lower alphanumeric and single hyphens or underscores in the middle;');
       expect(errors[0].component).eq('test_component');
       expect(errors[0].start?.row).eq(2);
       expect(errors[0].start?.column).eq(12);
@@ -440,7 +439,7 @@ services:
 
     it('invalid key value', async () => {
       const component_config = `
-      name: test/component
+      name: component
       secrets:
         environment: missing if
       services:
@@ -454,12 +453,12 @@ services:
         '/component.yml': component_config,
       });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/component.yml',
+        'component': '/component.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -481,7 +480,7 @@ services:
 
     it('invalid component secret keys', async () => {
       const component_config = `
-      name: test/component
+      name: component
       secrets:
         test:
         test2: test
@@ -495,12 +494,12 @@ services:
         '/component.yml': component_config,
       });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/component.yml',
+        'component': '/component.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -519,7 +518,7 @@ services:
 
     it('invalid secret ref', async () => {
       const component_config = `
-      name: test/component
+      name: component
       secrets:
         test: test2
       services:
@@ -532,12 +531,12 @@ services:
         '/component.yml': component_config,
       });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/component.yml',
+        'component': '/component.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -551,7 +550,7 @@ services:
         'services.api.environment.TEST',
       ]);
       expect(errors[0].message).includes('secrets.test');
-      expect(errors[0].component).eq('test/component');
+      expect(errors[0].component).eq('component');
       expect(errors[0].start?.row).eq(8);
       expect(errors[0].start?.column).eq(23);
       expect(errors[0].end?.row).eq(8);
@@ -561,17 +560,17 @@ services:
 
     it('invalid component interfaces ref', async () => {
       const component_config = `
-      name: test/component
+      name: component
       services:
         api:
           environment:
-            OTHER_ADDR: \${{ dependencies.test/other.interfaces.fake.url }}
-            EXT_OTHER_ADDR: \${{ dependencies.test/other.ingresses.fake.url }}
+            OTHER_ADDR: \${{ dependencies.other.interfaces.fake.url }}
+            EXT_OTHER_ADDR: \${{ dependencies.other.ingresses.fake.url }}
       dependencies:
-        test/other: latest
+        other: latest
       `;
       const other_component_config = `
-      name: test/other
+      name: other
       interfaces:
         not-fake: \${{ services.api.interfaces.main.url }}
       services:
@@ -585,14 +584,14 @@ services:
         '/other-component.yml': other_component_config,
       });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/component.yml',
-        'test/other': '/other-component.yml',
+        'component': '/component.yml',
+        'other': '/other-component.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
-          await manager.loadComponentSpec('test/other'),
+          await manager.loadComponentSpec('component'),
+          await manager.loadComponentSpec('other'),
         ]);
       } catch (e: any) {
         err = e;
@@ -610,7 +609,7 @@ services:
 
     it('invalid services interfaces ref', async () => {
       const component_config = `
-      name: test/component
+      name: component
       interfaces:
         other-api: \${{ services.other-api.interfaces.not-fake.url }}
       services:
@@ -628,12 +627,12 @@ services:
         '/component.yml': component_config,
       });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/component.yml',
+        'component': '/component.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -651,7 +650,7 @@ services:
 
     it('invalid services ref', async () => {
       const component_config = `
-      name: test/component
+      name: component
       interfaces:
         api: \${{ services.app.interfaces.main.url }}
         api2: \${{ service.api.interfaces.main.url }}
@@ -665,12 +664,12 @@ services:
         '/component.yml': component_config,
       });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/component.yml',
+        'component': '/component.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component', { interfaces: { api: 'api', api2: 'api2' } }),
+          await manager.loadComponentSpec('component', { interfaces: { api: 'api', api2: 'api2' } }),
         ]);
       } catch (e: any) {
         err = e;
@@ -689,7 +688,7 @@ services:
 
     it('deploy time validation', async () => {
       const component_config = `
-      name: test/component
+      name: component
       secrets:
         app_liveness_path: /health
       services:
@@ -706,12 +705,12 @@ services:
         '/component.yml': component_config,
       });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/component.yml',
+        'component': '/component.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -720,15 +719,14 @@ services:
       const errors = JSON.parse(err.message) as ValidationError[];
       expect(errors).lengthOf(1);
       expect(errors.map(e => e.path)).members([
-        "services.api.liveness_probe.path",
+        'services.api.liveness_probe.path',
       ]);
       expect(process.exitCode).eq(1);
     });
 
-
     it('valid labels', async () => {
       const component_config = `
-      name: test/component
+      name: component
       secrets:
         environment: dev
       services:
@@ -741,12 +739,12 @@ services:
         '/component.yml': component_config,
       });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/component.yml',
+        'component': '/component.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -757,7 +755,7 @@ services:
 
     it('invalid labels', async () => {
       const component_config = `
-      name: test/component
+      name: component
       secrets:
         environment: dev$%^%^%$T
       services:
@@ -771,13 +769,13 @@ services:
         '/component.yml': component_config,
       });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/component.yml',
+        'component': '/component.yml',
       });
 
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -792,7 +790,7 @@ services:
 
     it('invalid labels length', async () => {
       const component_config = `
-      name: test/component
+      name: component
       secrets:
         environment: dev$%^%^%$&T
       services:
@@ -804,12 +802,12 @@ services:
         '/component.yml': component_config,
       });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/component.yml',
+        'component': '/component.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -825,18 +823,18 @@ services:
   describe('component builder validation', () => {
     it('file reference does not misalign validation error line numbers', async () => {
       const component_config = `
-      name: test/component
+      name: component
       services:
         api:
           environment:
             TEST_FILE_TEXT: file:./test-file.txt
-            OTHER_ADDR: \${{ dependencies.test/other.interfaces.fake.url }}
+            OTHER_ADDR: \${{ dependencies.other.interfaces.fake.url }}
       dependencies:
-        test/other: latest
+        other: latest
       `;
 
       const other_component_config = `
-      name: test/other
+      name: other
       services:
         api:
           image: test
@@ -848,14 +846,14 @@ services:
       });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/component.yml',
-        'test/other': '/other-component.yml',
+        'component': '/component.yml',
+        'other': '/other-component.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
-          await manager.loadComponentSpec('test/other'),
+          await manager.loadComponentSpec('component'),
+          await manager.loadComponentSpec('other'),
         ]);
       } catch (e: any) {
         err = e;
@@ -872,7 +870,7 @@ services:
       });
       expect(errors[0].end).to.deep.equal({
         row: 7,
-        column: 71,
+        column: 66,
       });
       expect(process.exitCode).eq(1);
     });
@@ -881,7 +879,7 @@ services:
   describe('required secret validation', () => {
     it('required component secrets', async () => {
       const component_config = `
-      name: test/component
+      name: component
       secrets:
         required:
         required-explicit:
@@ -905,12 +903,12 @@ services:
         '/component.yml': component_config,
       });
       const manager = new LocalDependencyManager(axios.create(), {
-        'test/component': '/component.yml',
+        'component': '/component.yml',
       });
       let err;
       try {
         await manager.getGraph([
-          await manager.loadComponentSpec('test/component'),
+          await manager.loadComponentSpec('component'),
         ]);
       } catch (e: any) {
         err = e;
@@ -924,17 +922,17 @@ services:
         'secrets.required-explicit',
       ]);
       expect([...new Set(errors.map(e => e.component))]).members([
-        'test/component',
+        'component',
       ]);
       expect(process.exitCode).eq(1);
     });
 
     it('required dependency secret', async () => {
       const component_config = `
-      name: examples/hello-world
+      name: hello-world
 
       dependencies:
-        examples/hello-world2: latest
+        hello-world2: latest
 
       services:
         api:
@@ -948,7 +946,7 @@ services:
       `;
 
       const component_config2 = `
-      name: examples/hello-world2
+      name: hello-world2
 
       secrets:
         aws_secret:
@@ -971,15 +969,17 @@ services:
       });
 
       nock('http://localhost').get('/accounts/examples/components/hello-world2/versions/latest')
-        .reply(200, { tag: 'latest', config: yaml.load(component_config2), service: { url: 'examples/hello-world2:latest' } });
+        .reply(200, { tag: 'latest', config: yaml.load(component_config2), service: { url: 'hello-world2:latest' } });
 
       const manager = new LocalDependencyManager(axios.create(), {
-        'examples/hello-world': '/architect.yml',
+        'hello-world': '/architect.yml',
       });
+      manager.account = 'examples';
+
       let err;
       try {
         await manager.getGraph([
-          ...await manager.loadComponentSpecs('examples/hello-world'),
+          ...await manager.loadComponentSpecs('hello-world'),
         ]);
       } catch (e: any) {
         err = e;
@@ -991,7 +991,7 @@ services:
         'secrets.aws_secret',
       ]);
       expect([...new Set(errors.map(e => e.component))]).members([
-        'examples/hello-world2',
+        'hello-world2',
       ]);
       expect(process.exitCode).eq(1);
     });
@@ -999,11 +999,11 @@ services:
 
   it('valid component keys in values files pass validation', () => {
     const values_dict = {
-      "*": {
-        "POSTGRES_HOST": "172.17.0.1",
+      '*': {
+        'POSTGRES_HOST': '172.17.0.1',
       },
-      "architect/cloud": {
-        "TEST": "string",
+      'architect/cloud': {
+        'TEST': 'string',
       },
 
     };
@@ -1018,8 +1018,8 @@ services:
 
   it('invalid component keys in values files fail validation', () => {
     const values_dict = {
-      "architect_cloud:latest": {
-        "TEST": "string",
+      'architect_cloud:latest': {
+        'TEST': 'string',
       },
     };
 
@@ -1038,8 +1038,8 @@ services:
 
   it('invalid value keys in values files fail validation', () => {
     const values_dict = {
-      "architect/cloud": {
-        "TE@ST": "string",
+      'architect/cloud': {
+        'TE@ST': 'string',
       },
     };
 
@@ -1058,8 +1058,8 @@ services:
 
   it('component values are defined in an object', () => {
     const values_dict = {
-      "architect/cloud": [],
-      "architect/cloud@v2": 'string',
+      'architect/cloud': [],
+      'architect/cloud@v2': 'string',
     };
 
     let err;
@@ -1078,13 +1078,13 @@ services:
 
   it('component values are strings only', () => {
     const values_dict = {
-      "architect/cloud": {
+      'architect/cloud': {
         'test': 'test value',
       },
-      "architect/cloud@v2": {
+      'architect/cloud@v2': {
         'ANOTHER_test': 'another value',
       },
-      "architect/*": {
+      'architect/*': {
         'ANOTHER_test': 'another value',
       },
     };
@@ -1100,7 +1100,7 @@ services:
 
   it('AtLeastOne and scaling validation', async () => {
     const component_config = `
-      name: test/component
+      name: component
       services:
         api:
           interfaces:
@@ -1114,12 +1114,12 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1135,7 +1135,7 @@ services:
 
   it('valid interface number', async () => {
     const component_config = `
-      name: test/component
+      name: component
       services:
         app:
           interfaces:
@@ -1145,12 +1145,12 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1161,7 +1161,7 @@ services:
 
   it('invalid interface string', async () => {
     const component_config = `
-      name: test/component
+      name: component
       services:
         app:
           interfaces:
@@ -1171,13 +1171,13 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
 
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1194,7 +1194,7 @@ services:
 
   it('valid interface interpolation reference', async () => {
     const component_config = `
-      name: test/component
+      name: component
       secrets:
         app_port: 3000
       services:
@@ -1206,13 +1206,13 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
 
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1223,7 +1223,7 @@ services:
 
   it('invalid interface string', async () => {
     const component_config = `
-      name: test/component
+      name: component
       services:
         app:
           interfaces:
@@ -1233,13 +1233,13 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
 
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1256,7 +1256,7 @@ services:
 
   it('valid component interface string', async () => {
     const component_config = `
-      name: test/component
+      name: component
       interfaces:
         main: \${{ services.app.interfaces.main.url }}
       services:
@@ -1268,13 +1268,13 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
 
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1285,7 +1285,7 @@ services:
   /*
   it('invalid tcp component protocol', async () => {
     const component_config = `
-      name: test/component
+      name: component
       interfaces:
         main: \${{ services.app.interfaces.main.url }}
       services:
@@ -1299,13 +1299,13 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
 
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1318,7 +1318,7 @@ services:
 
   it('valid component with protocol of undefined', async () => {
     const component_config = `
-      name: test/component
+      name: component
       interfaces:
         main: \${{ services.app.interfaces.mysql.url }}
       services:
@@ -1334,13 +1334,13 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
 
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ], {}, { interpolate: false });
     } catch (e: any) {
       err = e;
@@ -1351,7 +1351,7 @@ services:
 
   it('invalid component interface number', async () => {
     const component_config = `
-      name: test/component
+      name: component
       interfaces:
         main: 3000
       services:
@@ -1363,13 +1363,13 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
 
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1385,7 +1385,7 @@ services:
 
   it('invalid component interface number', async () => {
     const component_config = `
-      name: test/component
+      name: component
       interfaces: main
       services:
         app:
@@ -1396,13 +1396,13 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
 
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1417,7 +1417,7 @@ services:
 
   it('valid command', async () => {
     const component_config = `
-      name: test/component
+      name: component
       secrets:
         SPRING_PROFILE: test
       services:
@@ -1428,11 +1428,11 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
 
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('test/component'),
+      await manager.loadComponentSpec('component'),
     ]);
     const service_node = graph.nodes.find((node) => node instanceof ServiceNode) as ServiceNode;
     expect(service_node.config.command).to.deep.equal(['catalina.sh', 'run', '-Pprofile=test', '--test-string', 'two words', '--test-env', '$API_KEY']);
@@ -1440,7 +1440,7 @@ services:
 
   it('liveness_probe rejects command with path', async () => {
     const component_config = `
-      name: test/component
+      name: component
       services:
         api:
           interfaces:
@@ -1455,12 +1455,12 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1476,7 +1476,7 @@ services:
 
   it('liveness_probe rejects command with port', async () => {
     const component_config = `
-      name: test/component
+      name: component
       services:
         api:
           interfaces:
@@ -1491,12 +1491,12 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1512,7 +1512,7 @@ services:
 
   it('liveness_probe accepts command', async () => {
     const component_config = `
-      name: test/component
+      name: component
       services:
         api:
           interfaces:
@@ -1526,12 +1526,12 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1542,7 +1542,7 @@ services:
 
   it('liveness_probe accepts port and path', async () => {
     const component_config = `
-      name: test/component
+      name: component
       services:
         api:
           interfaces:
@@ -1555,12 +1555,12 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1571,7 +1571,7 @@ services:
 
   it('liveness_probe rejects port without path', async () => {
     const component_config = `
-      name: test/component
+      name: component
       services:
         api:
           interfaces:
@@ -1583,12 +1583,12 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1608,7 +1608,7 @@ services:
 
   it('liveness_probe rejects path without port', async () => {
     const component_config = `
-      name: test/component
+      name: component
       services:
         api:
           interfaces:
@@ -1620,12 +1620,12 @@ services:
       '/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component.yml',
+      'component': '/component.yml',
     });
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component'),
+        await manager.loadComponentSpec('component'),
       ]);
     } catch (e: any) {
       err = e;
@@ -1645,7 +1645,7 @@ services:
 
   it('throw error for trying to expose incorrect interface', async () => {
     const yml = `
-    name: test/component
+    name: component
     services:
       app:
         interfaces:
@@ -1659,13 +1659,13 @@ services:
     });
 
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/stack/architect.yml',
+      'component': '/stack/architect.yml',
     });
 
     let err;
     try {
       await manager.getGraph([
-        await manager.loadComponentSpec('test/component', { interfaces: { 'cloud': 'appppp' } }),
+        await manager.loadComponentSpec('component', { interfaces: { 'cloud': 'appppp' } }),
       ]);
     } catch (e: any) {
       err = e;
@@ -1684,7 +1684,7 @@ services:
   describe('validate if statements', () => {
     it('cannot use if statement at top level of component', async () => {
       const yml = `
-      name: test/component
+      name: component
       \${{ if true }}:
         secrets:
           test: test
@@ -1708,7 +1708,7 @@ services:
 
     it('cannot use if statement in secrets block', async () => {
       const yml = `
-      name: test/component
+      name: component
       secrets:
         \${{ if true }}:
           test: test
@@ -1732,7 +1732,7 @@ services:
 
     it('cannot use if statement in secret value block', async () => {
       const yml = `
-      name: test/component
+      name: component
       secrets:
         test:
           \${{ if true }}:
@@ -1757,10 +1757,10 @@ services:
 
     it('cannot use if statement in dependencies block', async () => {
       const yml = `
-      name: test/component
+      name: component
       dependencies:
         \${{ if true }}:
-          test/dependency: latest
+          dependency: latest
       `;
 
       let err;
@@ -1781,7 +1781,7 @@ services:
 
     it('can use if statement in service block', async () => {
       const yml = `
-      name: test/component
+      name: component
       services:
         app:
           environment:
@@ -1802,11 +1802,11 @@ services:
           template: {
             spec: {
               containers: [{
-                invalid_key: 'wrong'
-              }]
-            }
-          }
-        }
+                invalid_key: 'wrong',
+              }],
+            },
+          },
+        },
       };
 
       const res = TSON.validateEquals<DeepPartial<V1Deployment>>(deployment);
@@ -1814,7 +1814,7 @@ services:
       expect(res.errors.map(error => error.path)).to.have.members([
         '$input.metadata',
         '$input.metadata2',
-        '$input.spec.template.spec.containers[0].invalid_key'
+        '$input.spec.template.spec.containers[0].invalid_key',
       ]);
 
       expect(res.success).to.be.false;
@@ -1822,7 +1822,7 @@ services:
 
     it('invalid deploy overrides for kubernetes', async () => {
       const yml = `
-      name: test/component
+      name: component
       services:
         app:
           deploy:
@@ -1837,12 +1837,14 @@ services:
                         iam.gke.io/gke-metadata-server-enabled: "true"
       `;
 
-      expect(() => { buildSpecFromYml(yml); }).to.throw(ValidationErrors);
+      expect(() => {
+ buildSpecFromYml(yml);
+}).to.throw(ValidationErrors);
     });
 
     it('valid deploy overrides for kubernetes', async () => {
       const yml = `
-      name: test/component
+      name: component
       services:
         app:
           deploy:

--- a/test/dependency-manager/validation.test.ts
+++ b/test/dependency-manager/validation.test.ts
@@ -67,7 +67,7 @@ services:
           replicas: '1'
       `;
       mock_fs({ '/architect.yml': component_config });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/architect.yml',
       });
       let err;
@@ -102,7 +102,7 @@ services:
         frontend: \${{ services.fake.interfaces.main.url }}
       `;
       mock_fs({ '/architect.yml': component_config });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/architect.yml',
       });
       let err;
@@ -135,7 +135,7 @@ services:
             TEST: 1
       `;
       mock_fs({ '/architect.yml': component_config });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/architect.yml',
       });
 
@@ -177,7 +177,7 @@ services:
           image: ellerbrock/alpine-bash-curl-ssl
       `;
       mock_fs({ '/architect.yml': component_config });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/architect.yml',
       });
       let err;
@@ -235,7 +235,7 @@ services:
         frontend: \${{ services['stateless-app'].interfaces.main.url }}
       `;
       mock_fs({ '/architect.yml': component_config });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/architect.yml',
       });
       let err;
@@ -266,7 +266,7 @@ services:
         frontend: \${{ services['stateless-app'].interfaces.main.url }}
       `;
       mock_fs({ '/architect.yml': component_config });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/architect.yml',
       });
       let err;
@@ -297,7 +297,7 @@ services:
         frontend: \${{ services['stateless-app'].interfaces.main.url }}
       `;
       mock_fs({ '/architect.yml': component_config });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/architect.yml',
       });
       let err;
@@ -334,7 +334,7 @@ services:
       `;
       mock_fs({ '/architect.yml': component_config });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/architect.yml',
       });
       let err;
@@ -378,7 +378,7 @@ services:
         frontend: \${{ services['stateful-app'].interfaces.main.url }}
       `;
       mock_fs({ '/architect.yml': component_config });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/architect.yml',
       });
       let err;
@@ -410,7 +410,7 @@ services:
       mock_fs({
         '/component.yml': component_config,
       });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/component.yml',
       });
       let err;
@@ -452,7 +452,7 @@ services:
       mock_fs({
         '/component.yml': component_config,
       });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/component.yml',
       });
       let err;
@@ -493,7 +493,7 @@ services:
       mock_fs({
         '/component.yml': component_config,
       });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/component.yml',
       });
       let err;
@@ -530,7 +530,7 @@ services:
       mock_fs({
         '/component.yml': component_config,
       });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/component.yml',
       });
       let err;
@@ -583,7 +583,7 @@ services:
         '/component.yml': component_config,
         '/other-component.yml': other_component_config,
       });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/component.yml',
         'other': '/other-component.yml',
       });
@@ -626,7 +626,7 @@ services:
       mock_fs({
         '/component.yml': component_config,
       });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/component.yml',
       });
       let err;
@@ -663,7 +663,7 @@ services:
       mock_fs({
         '/component.yml': component_config,
       });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/component.yml',
       });
       let err;
@@ -704,7 +704,7 @@ services:
       mock_fs({
         '/component.yml': component_config,
       });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/component.yml',
       });
       let err;
@@ -738,7 +738,7 @@ services:
       mock_fs({
         '/component.yml': component_config,
       });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/component.yml',
       });
       let err;
@@ -768,7 +768,7 @@ services:
       mock_fs({
         '/component.yml': component_config,
       });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/component.yml',
       });
 
@@ -801,7 +801,7 @@ services:
       mock_fs({
         '/component.yml': component_config,
       });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/component.yml',
       });
       let err;
@@ -845,7 +845,7 @@ services:
         '/other-component.yml': other_component_config,
       });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/component.yml',
         'other': '/other-component.yml',
       });
@@ -902,7 +902,7 @@ services:
       mock_fs({
         '/component.yml': component_config,
       });
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'architect', {
         'component': '/component.yml',
       });
       let err;
@@ -971,10 +971,9 @@ services:
       nock('http://localhost').get('/accounts/examples/components/hello-world2/versions/latest')
         .reply(200, { tag: 'latest', config: yaml.load(component_config2), service: { url: 'hello-world2:latest' } });
 
-      const manager = new LocalDependencyManager(axios.create(), {
+      const manager = new LocalDependencyManager(axios.create(), 'examples', {
         'hello-world': '/architect.yml',
       });
-      manager.account = 'examples';
 
       let err;
       try {
@@ -1113,7 +1112,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
     let err;
@@ -1144,7 +1143,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
     let err;
@@ -1170,7 +1169,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
 
@@ -1205,7 +1204,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
 
@@ -1232,7 +1231,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
 
@@ -1267,7 +1266,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
 
@@ -1298,7 +1297,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
 
@@ -1333,7 +1332,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
 
@@ -1362,7 +1361,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
 
@@ -1395,7 +1394,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
 
@@ -1427,7 +1426,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
 
@@ -1454,7 +1453,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
     let err;
@@ -1490,7 +1489,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
     let err;
@@ -1525,7 +1524,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
     let err;
@@ -1554,7 +1553,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
     let err;
@@ -1582,7 +1581,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
     let err;
@@ -1619,7 +1618,7 @@ services:
     mock_fs({
       '/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component.yml',
     });
     let err;
@@ -1658,7 +1657,7 @@ services:
       '/stack/architect.yml': yml,
     });
 
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/stack/architect.yml',
     });
 

--- a/test/dependency-manager/volumes.test.ts
+++ b/test/dependency-manager/volumes.test.ts
@@ -8,12 +8,12 @@ import { DockerComposeUtils } from '../../src/common/docker-compose';
 
 describe('volumes spec v1', () => {
 
-  const test_component_api_safe_ref = resourceRefToNodeRef('test/component.services.api');
-  const test_component_app_safe_ref = resourceRefToNodeRef('test/component.services.app');
+  const test_component_api_safe_ref = resourceRefToNodeRef('component.services.api');
+  const test_component_app_safe_ref = resourceRefToNodeRef('component.services.app');
 
   it('simple volume', async () => {
     const component_config = `
-      name: test/component
+      name: component
       services:
         api:
           volumes:
@@ -24,10 +24,10 @@ describe('volumes spec v1', () => {
       '/component/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component/component.yml'
+      'component': '/component/component.yml'
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('test/component')
+      await manager.loadComponentSpec('component')
     ])
     const template = await DockerComposeUtils.generate(graph);
     expect(template.services[test_component_api_safe_ref].volumes).has.members(['api-data:/data'])
@@ -35,7 +35,7 @@ describe('volumes spec v1', () => {
 
   it('simple debug volume', async () => {
     const component_config = `
-      name: test/component
+      name: component
       services:
         api:
           debug:
@@ -48,10 +48,10 @@ describe('volumes spec v1', () => {
       '/component/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component/component.yml'
+      'component': '/component/component.yml'
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('test/component', {}, true)
+      await manager.loadComponentSpec('component', {}, true)
     ]);
     const template = await DockerComposeUtils.generate(graph);
     expect(template.services[test_component_api_safe_ref].volumes).has.members([`${path.resolve('/component/data')}:/data`])
@@ -59,7 +59,7 @@ describe('volumes spec v1', () => {
 
   it('simple external volume', async () => {
     const component_config = `
-      name: test/component
+      name: component
       services:
         api:
           volumes:
@@ -71,10 +71,10 @@ describe('volumes spec v1', () => {
       '/component/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component/component.yml'
+      'component': '/component/component.yml'
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('test/component')
+      await manager.loadComponentSpec('component')
     ])
     const template = await DockerComposeUtils.generate(graph);
     expect(template.services[test_component_api_safe_ref].volumes).has.members([`/user/app/data:/data`])
@@ -82,7 +82,7 @@ describe('volumes spec v1', () => {
 
   it('multiple volumes and services', async () => {
     const component_config = `
-      name: test/component
+      name: component
       services:
         api:
           volumes:
@@ -111,10 +111,10 @@ describe('volumes spec v1', () => {
       '/component/component.yml': component_config,
     });
     const manager = new LocalDependencyManager(axios.create(), {
-      'test/component': '/component/component.yml'
+      'component': '/component/component.yml'
     });
     const graph = await manager.getGraph([
-      await manager.loadComponentSpec('test/component', {}, true)
+      await manager.loadComponentSpec('component', {}, true)
     ])
     const template = await DockerComposeUtils.generate(graph);
     expect(template.services[test_component_api_safe_ref].volumes).has.members(['api-data:/data', 'api-data2:/data2', `${path.resolve('/component/data3')}:/data3`])

--- a/test/dependency-manager/volumes.test.ts
+++ b/test/dependency-manager/volumes.test.ts
@@ -23,7 +23,7 @@ describe('volumes spec v1', () => {
     mock_fs({
       '/component/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component/component.yml'
     });
     const graph = await manager.getGraph([
@@ -47,7 +47,7 @@ describe('volumes spec v1', () => {
     mock_fs({
       '/component/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component/component.yml'
     });
     const graph = await manager.getGraph([
@@ -70,7 +70,7 @@ describe('volumes spec v1', () => {
     mock_fs({
       '/component/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component/component.yml'
     });
     const graph = await manager.getGraph([
@@ -110,7 +110,7 @@ describe('volumes spec v1', () => {
     mock_fs({
       '/component/component.yml': component_config,
     });
-    const manager = new LocalDependencyManager(axios.create(), {
+    const manager = new LocalDependencyManager(axios.create(), 'architect', {
       'component': '/component/component.yml'
     });
     const graph = await manager.getGraph([

--- a/test/mocks/validationerrors/architect.yml
+++ b/test/mocks/validationerrors/architect.yml
@@ -1,4 +1,4 @@
-name: tests/validation_errors
+name: validation_errors
 
 services:
   validation_errors:


### PR DESCRIPTION
## Overview

The primary code change was updating `LocalDependencyManager` to take in `account` as a parameter in its constructor. This is because now, `this.account` always needs to be available. In practice, we always set `manager.account = {account name}` anyways, this update just prevents us from making future mistakes.

Otherwise, there were a few small tweaks to places that used `component_account_name || this.account` to always ignore `component_account_name` if it exists whenever we are using `ComponentVersionSlugUtils.parse` with user inputted values.

In the backend, we always handle components with `account-name/component-name` format so there's no ambiguity. We should in the long term stop using `ComponentSlugUtils` to build / parse the `account-name/component-name` component slugs used elsewhere. `ComponentSlugUtils` can drop the `component_account_name` completely if it's fully deprecated and `architect.yml`'s aren't accepted with an account name anymore, and we can perhaps build an `AccountComponentSlug` class to handle creating/parsing strings we expect to _always_ contain account_name separate from user component names that don't have account_name.

The rest of the changes are simply updating tests to remove the account name in most places, with the exception being the account scoping test that actually verifies various permutations of names with / without the account name work together as we'd expect and still want for now.

A combination of this PR and https://github.com/architect-team/architect-documentation/pull/24/files will remove the suggestions of adding `account-name/component-name` from our docs/spec - it's already barely mentioned but there's a lot of various examples that still use it.