### PR TITLE
Add CI error message in prompts

### DIFF
--- a/src/commands/clusters/create.ts
+++ b/src/commands/clusters/create.ts
@@ -14,6 +14,7 @@ import PipelineUtils from '../../architect/pipeline/pipeline.utils';
 import BaseCommand from '../../base-command';
 import { AgentClusterUtils } from '../../common/utils/agent-cluster.utils';
 import { booleanString } from '../../common/utils/oclif';
+import PromptUtils from '../../common/utils/prompt-utils';
 
 export default class ClusterCreate extends BaseCommand {
   static aliases = ['clusters:register', 'cluster:create', 'clusters:create'];
@@ -111,7 +112,7 @@ export default class ClusterCreate extends BaseCommand {
         type: 'input',
         name: 'cluster',
         message: 'What would you like to name your new cluster?',
-        when: !args.cluster,
+        when: PromptUtils.allowWhen('Cluster name is required in ci pipelines', args.cluster),
         filter: value => value.toLowerCase(),
         validate: value => {
           if (Slugs.ArchitectSlugValidator.test(value)) return true;
@@ -217,6 +218,7 @@ export default class ClusterCreate extends BaseCommand {
             // Set the context value to the matching object from the kubeconfig
             return kubeconfig.contexts.find((ctx: any) => ctx.name === value);
           },
+          when: PromptUtils.allowWhen('kube context is required in ci pipelines'),
         },
       ]);
       kube_context = new_cluster_answers.context;

--- a/src/commands/clusters/destroy.ts
+++ b/src/commands/clusters/destroy.ts
@@ -5,6 +5,7 @@ import AccountUtils from '../../architect/account/account.utils';
 import ClusterUtils from '../../architect/cluster/cluster.utils';
 import BaseCommand from '../../base-command';
 import { booleanString } from '../../common/utils/oclif';
+import PromptUtils from '../../common/utils/prompt-utils';
 
 export default class ClusterDestroy extends BaseCommand {
   static aliases = ['clusters:deregister', 'cluster:destroy', 'clusters:destroy'];
@@ -71,7 +72,7 @@ export default class ClusterDestroy extends BaseCommand {
         }
         return `Name must match: ${chalk.blue(cluster.name)}`;
       },
-      when: !flags['auto-approve'],
+      when: PromptUtils.allowWhen('--auto-approve is required in ci pipelines', flags['auto-approve']),
     }]);
 
     answers = { ...args, ...flags, ...answers };

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -13,6 +13,7 @@ import { buildSpecFromPath } from '../dependency-manager/spec/utils/component-bu
 import { ComponentVersionSlugUtils } from '../dependency-manager/spec/utils/slugs';
 import Dev from './dev';
 import ComponentRegister from './register';
+import PromptUtils from '../common/utils/prompt-utils';
 
 export abstract class DeployCommand extends BaseCommand {
   static flags = {
@@ -58,6 +59,7 @@ export abstract class DeployCommand extends BaseCommand {
         type: 'confirm',
         name: 'deploy',
         message: 'Would you like to apply?',
+        when: PromptUtils.allowWhen('--auto-approve is required in ci pipelines'),
       });
       if (!confirmation.deploy) {
         this.warn(`Canceled pipeline`);

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -76,13 +76,13 @@ export default class Login extends BaseCommand {
         type: 'input',
         name: 'email',
         default: flags.email,
-        when: !flags.email,
+        when: PromptUtils.allowWhen('email is required in ci pipelines', flags.email),
       },
       {
         type: 'password',
         name: 'password',
         default: flags.password,
-        when: !flags.password,
+        when: PromptUtils.allowWhen('password is required in ci pipelines', flags.password),
       },
     ]);
 

--- a/src/common/utils/prompt-utils.ts
+++ b/src/common/utils/prompt-utils.ts
@@ -24,31 +24,14 @@ export default class PromptUtils {
     return !(isCi || !process.stdout.isTTY);
   }
 
-  /**
-   * There is an open issue in inquirer to handle this behavior, eventually we can replace this when it's properly released:
-   * https://github.com/SBoudrias/Inquirer.js/pull/891
-   */
-  public static disable_prompts(): void {
-    // eslint-disable-next-line unicorn/prefer-module
-    const inquirer = require('inquirer');
-    process.stdout.isTTY = false;
+  public static allowWhen(error_msg: string, value?: any | undefined): boolean {
+    if (value) {
+      return false;
+    }
 
-    inquirer.prompt = async function (prompts: any) {
-      if (!Array.isArray(prompts)) {
-        prompts = [prompts];
-      }
-      for (const prompt of prompts) {
-        if ((prompt.when && prompt.default === undefined) || prompt.when === undefined) {
-          throw new Error(`${prompt.name} is required`);
-        }
-      }
-      // eslint-disable-next-line unicorn/no-array-reduce,unicorn/prefer-object-from-entries
-      return prompts.reduce((d: any, p: any) => {
-        d[p.name] = p.default;
-        return d;
-      }, {});
-    };
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    inquirer.prompt.registerPrompt = function () { };
+    if (!this.prompts_available()) {
+      throw new Error(error_msg);
+    }
+    return true;
   }
 }

--- a/src/hooks/init/tty.ts
+++ b/src/hooks/init/tty.ts
@@ -1,15 +1,11 @@
 import { Hook } from '@oclif/core';
 import readline from 'readline';
-import PromptUtils from '../../common/utils/prompt-utils';
 
 const hook: Hook<'init'> = async function (_) {
   // https://github.com/SBoudrias/Inquirer.js#know-issues
   if (/^win/i.test(process.platform)) {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     readline.Interface.prototype.close = () => { };
-  }
-  if (!PromptUtils.prompts_available()) {
-    PromptUtils.disable_prompts();
   }
 };
 

--- a/test/commands/clusters/create.test.ts
+++ b/test/commands/clusters/create.test.ts
@@ -6,6 +6,7 @@ import AppService from '../../../src/app-config/service';
 import PipelineUtils from '../../../src/architect/pipeline/pipeline.utils';
 import ClusterCreate from '../../../src/commands/clusters/create';
 import { AgentClusterUtils } from '../../../src/common/utils/agent-cluster.utils';
+import PromptUtils from '../../../src/common/utils/prompt-utils';
 
 describe('cluster:create', function () {
   const account = {
@@ -127,6 +128,9 @@ describe('cluster:create', function () {
         cluster_type: 'agent (BETA)',
         application_install: true,
       }
+    })
+    .stub(PromptUtils, 'allowWhen', () => {
+      return true;
     })
     .stub(AgentClusterUtils, 'installAgent', sinon.stub().returns(Promise.resolve()))
     .stub(AgentClusterUtils, 'configureAgentCluster', sinon.stub().returns(Promise.resolve()))

--- a/test/commands/clusters/destroy.test.ts
+++ b/test/commands/clusters/destroy.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import PipelineUtils from '../../../src/architect/pipeline/pipeline.utils';
 import { mockArchitectAuth, MOCK_API_HOST } from '../../utils/mocks';
 
-describe('environment:destroy', () => {
+describe('clusters:destroy', () => {
 
   // set to true while working on tests for easier debugging; otherwise oclif/test eats the stdout/stderr
   const print = false;

--- a/test/commands/platforms/create.test.ts
+++ b/test/commands/platforms/create.test.ts
@@ -7,6 +7,7 @@ import PipelineUtils from '../../../src/architect/pipeline/pipeline.utils';
 import ClusterCreate from '../../../src/commands/clusters/create';
 import PlatformCreate from '../../../src/commands/platforms/create';
 import { AgentClusterUtils } from '../../../src/common/utils/agent-cluster.utils';
+import PromptUtils from '../../../src/common/utils/prompt-utils';
 
 describe('platform:create', function () {
   const account = {
@@ -128,6 +129,9 @@ describe('platform:create', function () {
         cluster_type: 'agent (BETA)',
         application_install: true,
       }
+    })
+    .stub(PromptUtils, 'allowWhen', () => {
+      return true;
     })
     .stub(AgentClusterUtils, 'installAgent', sinon.stub().returns(Promise.resolve()))
     .stub(AgentClusterUtils, 'configureAgentCluster', sinon.stub().returns(Promise.resolve()))

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -5,9 +5,6 @@ import 'reflect-metadata';
 import sinon from 'sinon';
 import CredentialManager from '../src/app-config/credentials';
 import PortUtil from '../src/common/utils/port';
-import PromptUtils from '../src/common/utils/prompt-utils';
-
-PromptUtils.disable_prompts();
 
 for (const env_key of Object.keys(process.env)) {
   if (env_key.startsWith('ARC_')) {


### PR DESCRIPTION
## Overview
Closes https://gitlab.com/architect-io/architect-cli/-/issues/530.  
Show a more descriptive error message to the user when a deploy prompt fails in CI.


## Changes
Add a check for the deploy prompt and throw an error message.


## Tests
- Create a Github repo of any project
- Set Github secrets for `ARCHITECT_EMAIL` and `ARCHITECT_PASSWORD`
- Add a workflow file (Ex: .github/workflows/workflow.yml)
- Push some changes to trigger the CI job
