### PR TITLE
[WIP] ensure that we can run exec for detached local environments

### DIFF
--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -53,7 +53,7 @@ export function socketPath(path: string): string {
  * Gracefully stops running containers when the process is interrupted, and
  * stops containers when the underlying process returns with an error.
  */
-class UpProcessManager {
+export class UpProcessManager {
   compose_file: string;
   server?: net.Server;
   socket: string;
@@ -125,14 +125,14 @@ class UpProcessManager {
   }
 
   /** Sends the SIGINT signal to the running `docker compose up` process. */
-  interrupt() {
+  interrupt(): void {
     if (!this.compose_process) {
       throw new Error('Must call run() first');
     }
     process.kill(-this.compose_process.pid, 'SIGINT');
   }
 
-  configureInterrupts() {
+  configureInterrupts(): void {
     process.on('SIGINT', () => {
       this.handleInterrupt();
     });
@@ -144,7 +144,7 @@ class UpProcessManager {
     });
   }
 
-  async handleInterrupt() {
+  async handleInterrupt(): Promise<void> {
     // If a user SIGINT's between when docker compose outputs "Attaching to ..." and starts printing logs,
     // the containers will not be stopped and `docker compose stop` won't yet work.
     // We stop SIGINT from doing anything until we know for sure we can stop gracefully.
@@ -166,7 +166,7 @@ class UpProcessManager {
    * Handles printing logs from the attached docker images.
    * Stops printing logs once `handleInterrupt` is called and containers are being stopped.
    */
-  configureLogs() {
+  configureLogs(): void {
     if (!this.compose_process) {
       throw new Error('Must call run() first');
     }
@@ -198,7 +198,7 @@ class UpProcessManager {
     });
   }
 
-  async run() {
+  async run(): Promise<void> {
     this.compose_process = this.start();
 
     this.configureInterrupts();
@@ -514,7 +514,9 @@ export default class Dev extends BaseCommand {
     }
 
     await new UpProcessManager(compose_file, socket, project_name, flags.detached).run();
-    fs.removeSync(compose_file);
+    if (!flags.detached) {
+      fs.removeSync(compose_file);
+    }
     // eslint-disable-next-line no-process-exit
     process.exit();
   }

--- a/src/commands/dev/stop.ts
+++ b/src/commands/dev/stop.ts
@@ -52,7 +52,7 @@ export default class DevStop extends BaseCommand {
   async runComposeStop(project: string): Promise<void> {
     const compose_file = DockerComposeUtils.buildComposeFilepath(this.app.config.getConfigDir(), project);
     await DockerComposeUtils.dockerCompose(['-p', project, '-f', compose_file, 'stop']);
-    fs.removeSync(compose_file);
+    fs.removeSync(compose_file); // remove compose file if dev was started in detached mode
   }
 
   @RequiresDocker({ compose: true })

--- a/test/commands/dev/index.test.ts
+++ b/test/commands/dev/index.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@oclif/test';
+import fs from 'fs-extra';
 import yaml from 'js-yaml';
 import path from 'path';
 import sinon from 'sinon';
 import { buildSpecFromYml, ComponentConfig, resourceRefToNodeRef } from '../../../src';
 import AppService from '../../../src/app-config/service';
-import Dev from '../../../src/commands/dev';
+import Dev, { UpProcessManager } from '../../../src/commands/dev';
 import { DockerComposeUtils } from '../../../src/common/docker-compose';
 import DockerComposeTemplate from '../../../src/common/docker-compose/template';
 import DeployUtils from '../../../src/common/utils/deploy.utils';
@@ -612,7 +613,29 @@ describe('local dev environment', function () {
       const runCompose = Dev.prototype.runCompose as sinon.SinonStub;
       expect(runCompose.calledOnce).to.be.true
       expect(runCompose.firstCall.args[0]).to.deep.equal(component_expected_compose)
+    });
+
+  test
+    .timeout(20000)
+    .stub(ComponentBuilder, 'loadFile', () => {
+      return getHelloComponentConfig();
     })
+    .stub(Dev.prototype, 'failIfEnvironmentExists', sinon.stub().returns(undefined))
+    .stub(Dev.prototype, 'buildImage', sinon.stub().returns(['project_name', 'compose_file']))
+    .stub(Dev.prototype, 'setupTraefikServiceMap', sinon.stub().returns({}))
+    .stub(Dev.prototype, 'downloadSSLCerts', sinon.stub().returns(undefined))
+    .stub(UpProcessManager.prototype, 'run', sinon.stub().returns(undefined))
+    .stub(fs, 'removeSync', sinon.stub().returns(null))
+    .stub(process, 'exit', sinon.stub().returns(undefined))
+    .stdout({ print })
+    .stderr({ print })
+    .command(['dev', './examples/hello-world/architect.yml', '-d', '--ssl=false'])
+    .it(`Run a component locally in detached mode and check that the compose file doesn't get deleted`, ctx => {
+      expect(ctx.stdout).to.contain('Starting containers...');
+
+      const remove_sync = fs.removeSync as sinon.SinonStub;
+      expect(remove_sync.calledOnce).false;
+    });
 
   test
     .timeout(20000)

--- a/test/commands/dev/stop.test.ts
+++ b/test/commands/dev/stop.test.ts
@@ -50,6 +50,22 @@ describe('dev:stop', () => {
     });
 
   mockArchitectAuth()
+    .stub(DockerComposeUtils, 'getLocalEnvironments', sinon.stub().returns(env_names))
+    .stub(DevStop.prototype, 'waitForEnviromentToStop', sinon.stub().returns(true))
+    .stub(DevStop.prototype, 'log', sinon.fake.returns(null))
+    .stub(fs, 'existsSync', sinon.stub().returns(false))
+    .stub(net, 'createConnection', sinon.stub().returns(mocked_connection))
+    .stub(fs, 'removeSync', sinon.stub().returns(null))
+    .command(['dev:stop', 'test_env'])
+    .it('stop a detached local deployment and remove left over compose file from when it started', ctx => {
+      const log_spy = DevStop.prototype.log as SinonSpy;
+      expect(log_spy.firstCall.args[0]).to.contain("Successfully stopped local deployment");
+
+      const remove_sync = fs.removeSync as sinon.SinonStub;
+      expect(remove_sync.calledOnce).true;
+    });
+
+  mockArchitectAuth()
     .stub(DockerComposeUtils, 'getLocalEnvironments', sinon.stub().returns([]))
     .stub(DevStop.prototype, 'waitForEnviromentToStop', sinon.stub().returns(true))
     .stub(DevStop.prototype, 'log', sinon.fake.returns(null))


### PR DESCRIPTION
## Overview
Closes https://gitlab.com/architect-io/architect-cli/-/issues/560 and enables users to run `exec` against a container that was started with `architect dev -d ....`

## Changes
* Fixed some linting issues
* Avoided removing the compose file when the compose process was started in detached mode
* Added line to remove the file (or do nothing) when the process is stopped with `architect stop ....`

## Tests
* Added tests
* Ran local deployments in both normal and detached states, ran exec against them, then stopped them