### PR TITLE
566 local dev secrets

### DIFF
--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -282,7 +282,8 @@ export default class Dev extends BaseCommand {
       sensitive: false,
     }),
     'secrets-env': Flags.string({
-      description: 'Environment to load secrets from',
+      description: 'Environment to load secrets from [beta]',
+      hidden: true,
     }),
     'secret-file': Flags.string({
       description: 'Path of secrets file',

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -283,7 +283,6 @@ export default class Dev extends BaseCommand {
     }),
     'secrets-from': Flags.string({
       description: 'Environment to load secrets from',
-      hidden: true,
     }),
     'secret-file': Flags.string({
       description: 'Path of secrets file',

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -249,7 +249,7 @@ export default class Dev extends BaseCommand {
 
   static examples = [
     'architect dev ./mycomponent/architect.yml',
-    'architect dev ./mycomponent/architect.yml -a myaccount --secrets-from=myenvironment',
+    'architect dev ./mycomponent/architect.yml -a myaccount --secrets-env=myenvironment',
     'architect dev --port=81 --browser=false --debug=true --secret-file=./mycomponent/mysecrets.yml ./mycomponent/architect.yml',
   ];
 
@@ -281,7 +281,7 @@ export default class Dev extends BaseCommand {
       default: [],
       sensitive: false,
     }),
-    'secrets-from': Flags.string({
+    'secrets-env': Flags.string({
       description: 'Environment to load secrets from',
     }),
     'secret-file': Flags.string({
@@ -649,9 +649,9 @@ $ architect dev -e new_env_name_here .`));
     const interfaces_map = DeployUtils.getInterfacesMap(flags.interface);
 
     let env_secrets: SecretsDict = {};
-    if (flags['secrets-from']) {
+    if (flags['secrets-env']) {
       const account = await AccountUtils.getAccount(this.app, flags.account, { ask_local_account: false });
-      env_secrets = await this.getEnvironmentSecrets(account, flags['secrets-from']);
+      env_secrets = await this.getEnvironmentSecrets(account, flags['secrets-env']);
       flags.account = account.name;
     }
 

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -653,7 +653,6 @@ $ architect dev -e new_env_name_here .`));
     if (flags['secrets-env']) {
       const account = await AccountUtils.getAccount(this.app, flags.account, { ask_local_account: false });
       env_secrets = await this.getEnvironmentSecrets(account, flags['secrets-env']);
-      flags.account = account.name;
     }
 
     const all_secret_file_values = [...(flags['secret-file'] || []), ...(flags.secrets || [])]; // TODO: 404: remove

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -10,6 +10,7 @@ import net from 'net';
 import opener from 'opener';
 import path from 'path';
 import { ArchitectError, buildSpecFromPath, ComponentSlugUtils, ComponentSpec, ComponentVersionSlugUtils, Dictionary } from '../../';
+import Account from '../../architect/account/account.entity';
 import AccountUtils from '../../architect/account/account.utils';
 import { EnvironmentUtils } from '../../architect/environment/environment.utils';
 import SecretUtils from '../../architect/secret/secret.utils';
@@ -617,8 +618,7 @@ $ architect dev -e new_env_name_here .`));
     }
   }
 
-  private async getEnvironmentSecrets(account_name: string, environment_name: string, cluster_name?: string): Promise<SecretsDict> {
-    const account = await AccountUtils.getAccount(this.app, account_name);
+  private async getEnvironmentSecrets(account: Account, environment_name: string, cluster_name?: string): Promise<SecretsDict> {
     const secrets = await SecretUtils.getSecrets(this.app, account, { cluster_name, environment_name }, true);
 
     const env_secrets: SecretsDict = {};
@@ -649,11 +649,9 @@ $ architect dev -e new_env_name_here .`));
 
     let env_secrets: SecretsDict = {};
     if (flags['secrets-from']) {
-      if (!flags.account) {
-        const account = await AccountUtils.getAccount(this.app, flags.account, { ask_local_account: false });
-        flags.account = account.name;
-      }
-      env_secrets = await this.getEnvironmentSecrets(flags.account, flags['secrets-from']);
+      const account = await AccountUtils.getAccount(this.app, flags.account, { ask_local_account: false });
+      env_secrets = await this.getEnvironmentSecrets(account, flags['secrets-from']);
+      flags.account = account.name;
     }
 
     const all_secret_file_values = [...(flags['secret-file'] || []), ...(flags.secrets || [])]; // TODO: 404: remove

--- a/src/common/utils/deploy.utils.ts
+++ b/src/common/utils/deploy.utils.ts
@@ -62,8 +62,9 @@ export default class DeployUtils {
   }
 
   static getComponentSecrets(individual_secrets: string[], secrets_file: string[], env_secrets?: SecretsDict): SecretsDict {
-    // Check to see if there are multiple secret files; else, just read the single secret file
     let component_secrets: SecretsDict = env_secrets ? env_secrets : {};
+
+    // Check to see if there are multiple secret files; else, just read the single secret file
     for (const secret_file of secrets_file) {
       const output_catch = DeployUtils.readSecretsFile(secret_file);
       // Deep merge to ensure all values from files are captured

--- a/src/common/utils/deploy.utils.ts
+++ b/src/common/utils/deploy.utils.ts
@@ -3,6 +3,7 @@ import deepmerge from 'deepmerge';
 import fs from 'fs-extra';
 import yaml from 'js-yaml';
 import { ArchitectError, Dictionary } from '../../';
+import { SecretsDict, SecretType } from '../../dependency-manager/secrets/type';
 
 export default class DeployUtils {
   private static getExtraSecrets(secrets: string[] = []): Dictionary<string | number | undefined> {
@@ -60,9 +61,9 @@ export default class DeployUtils {
     return flags;
   }
 
-  static getComponentSecrets(individual_secrets: string[], secrets_file: string[]): Dictionary<Dictionary<string | number | null>> {
+  static getComponentSecrets(individual_secrets: string[], secrets_file: string[], env_secrets?: SecretsDict): SecretsDict {
     // Check to see if there are multiple secret files; else, just read the single secret file
-    let component_secrets: any = {};
+    let component_secrets: SecretsDict = env_secrets ? env_secrets : {};
     for (const secret_file of secrets_file) {
       const output_catch = DeployUtils.readSecretsFile(secret_file);
       // Deep merge to ensure all values from files are captured
@@ -76,7 +77,7 @@ export default class DeployUtils {
         component_secrets['*'] = {};
       }
       // Shallow merge to ensure CLI arguments replace anything from the secrets file
-      component_secrets['*'] = { ...component_secrets['*'], ...extra_secrets };
+      component_secrets['*'] = { ...component_secrets['*'], ...extra_secrets } as Dictionary<SecretType>;
     }
     return component_secrets;
   }

--- a/src/common/utils/deploy.utils.ts
+++ b/src/common/utils/deploy.utils.ts
@@ -72,13 +72,13 @@ export default class DeployUtils {
       component_secrets = deepmerge(component_secrets, output_catch);
     }
 
-    const extra_secrets = DeployUtils.getExtraSecrets(individual_secrets);
+    const extra_secrets = DeployUtils.getExtraSecrets(individual_secrets) as Dictionary<SecretType>;
     if (extra_secrets && Object.keys(extra_secrets).length > 0) {
       if (!component_secrets['*']) {
         component_secrets['*'] = {};
       }
       // Shallow merge to ensure CLI arguments replace anything from the secrets file
-      component_secrets['*'] = { ...component_secrets['*'], ...extra_secrets } as Dictionary<SecretType>;
+      component_secrets['*'] = { ...component_secrets['*'], ...extra_secrets };
     }
     return component_secrets;
   }

--- a/test/commands/dev/index.test.ts
+++ b/test/commands/dev/index.test.ts
@@ -994,7 +994,7 @@ describe('local dev environment', function () {
     .stub(Dev.prototype, 'downloadSSLCerts', sinon.stub().returns(undefined))
     .stdout({ print })
     .stderr({ print })
-    .command(['dev', './examples/hello-world/architect.yml', '-i', 'test:hello', '--secrets-from=env', '-a', 'examples', '--ssl=false'])
+    .command(['dev', './examples/hello-world/architect.yml', '-i', 'test:hello', '--secrets-env=env', '-a', 'examples', '--ssl=false'])
     .it('Create a local dev with a basic component and an environment secret', ctx => {
       const runCompose = Dev.prototype.runCompose as sinon.SinonStub;
       expect(runCompose.calledOnce).to.be.true;
@@ -1022,7 +1022,7 @@ describe('local dev environment', function () {
     .stub(Dev.prototype, 'downloadSSLCerts', sinon.stub().returns(undefined))
     .stdout({ print })
     .stderr({ print })
-    .command(['dev', './examples/hello-world/architect.yml', '-i', 'test:hello', '--secret-file', './examples/hello-world/secrets.yml', '--secrets-from=env', '-a', 'examples', '--ssl=false'])
+    .command(['dev', './examples/hello-world/architect.yml', '-i', 'test:hello', '--secret-file', './examples/hello-world/secrets.yml', '--secrets-env=env', '-a', 'examples', '--ssl=false'])
     .it('Create a local dev with a basic component, a secret file, and an overwritten environment secret', ctx => {
       const runCompose = Dev.prototype.runCompose as sinon.SinonStub;
       expect(runCompose.calledOnce).to.be.true;


### PR DESCRIPTION
## Overview
Closes https://gitlab.com/architect-io/architect-cli/-/issues/566.  
Allow `architect dev` command to pull in secrets from an environment to be used for local dev.


## Changes
Get secrets from a production environment and merge to other component secrets.


## Tests
- Create a secret in a production environment
- Use that secret in your application `architect.yml`
- Run `$ architect dev . --secrets-env=my-environment -a my-account`
