### PR TITLE
561 log errors when liveness probe fails

### DIFF
--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -486,7 +486,7 @@ export class DockerComposeUtils {
   public static async getContainerInfo(container_id: string): Promise<DockerInspect | undefined> {
     if (!container_id) return;
     const inspect_cmd = await docker(['inspect', '--format=\'{{json .}}\'', container_id], { stdout: false });
-    return JSON.parse(inspect_cmd.stdout.substring(1, inspect_cmd.stdout.length - 1)) as DockerInspect;
+    return await JSON.parse(inspect_cmd.stdout.substring(1, inspect_cmd.stdout.length - 1)) as DockerInspect;
   }
 
   /**

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -705,7 +705,7 @@ export class DockerComposeUtils {
             if (container_docker_inspect && container_docker_inspect.State.Health.Log?.length > 0) {
               const log_size = container_docker_inspect.State.Health.Log.length;
               console.log(chalk.red(`\nThe liveness probe has detected an error starting the service '${full_service_name}'.`));
-              console.log(chalk.red(`The service may try to restart and/or never reach a running state`));
+              console.log(chalk.red(`The service may try to restart and/or never reach a stable state`));
               console.log(chalk.red(`ERROR: ${container_docker_inspect.State.Health.Log[log_size - 1].Output}\n`));
             }
           }

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -704,7 +704,7 @@ export class DockerComposeUtils {
             const container_docker_inspect: DockerInspect | undefined = await this.getContainerInfo(container_state.ID);
             if (container_docker_inspect && container_docker_inspect.State.Health.Log?.length > 0) {
               const log_size = container_docker_inspect.State.Health.Log.length;
-              console.log(chalk.red(`\nThe liveness probe has detected an error starting the service '${full_service_name}'.`));
+              console.log(chalk.red(`\nThe liveness probe has encountered an error trying to start the service '${full_service_name}'.`));
               console.log(chalk.red(`The service may try to restart and/or never reach a stable state`));
               console.log(chalk.red(`ERROR: ${container_docker_inspect.State.Health.Log[log_size - 1].Output}\n`));
             }

--- a/src/common/docker-compose/template.ts
+++ b/src/common/docker-compose/template.ts
@@ -78,10 +78,8 @@ export interface DockerInspectHealth {
 }
 
 export interface DockerInspect {
-  Service: string,
   Id: string,
   State: {
-    Running: boolean,
     Status: string,
     Health: DockerInspectHealth,
     ExitCode: number

--- a/src/common/docker-compose/template.ts
+++ b/src/common/docker-compose/template.ts
@@ -78,7 +78,10 @@ export interface DockerInspectHealth {
 }
 
 export interface DockerInspect {
+  Service: string,
+  ID: string,
   State: {
+    Running: boolean,
     Status: string,
     Health: DockerInspectHealth
   },

--- a/src/common/docker-compose/template.ts
+++ b/src/common/docker-compose/template.ts
@@ -79,11 +79,12 @@ export interface DockerInspectHealth {
 
 export interface DockerInspect {
   Service: string,
-  ID: string,
+  Id: string,
   State: {
     Running: boolean,
     Status: string,
-    Health: DockerInspectHealth
+    Health: DockerInspectHealth,
+    ExitCode: number
   },
   Name: string,
   Config: {

--- a/src/common/docker-compose/template.ts
+++ b/src/common/docker-compose/template.ts
@@ -66,12 +66,25 @@ export default interface DockerComposeTemplate {
   volumes: { [key: string]: { external?: boolean } };
 }
 
+export interface DockerInspectHealth {
+  Status: string;
+  FailingStreak: number;
+  Log: {
+    Start: string,
+    End: string,
+    ExitCode: number,
+    Output: string
+  }[]
+}
+
 export interface DockerInspect {
   State: {
-    Status: string
+    Status: string,
+    Health: DockerInspectHealth
   },
   Name: string,
   Config: {
     Labels: { [key: string]: string }
   }
 }
+


### PR DESCRIPTION
## Overview
Please see https://gitlab.com/architect-io/architect-cli/-/issues/561

If your liveness probe fails before it hits your service (e.g. you don't have curl installed on the container and it's trying to curl a URL), it silently fails and will just restart your container without any indication as to why. We can possibly use docker status or similar to get the reason the probe failed and can more clearly surface the issue to the user so that they know what is going wrong.

## Changes
Add  Health property to DockerInspect  interface.  Check for failing liveprobe, and conditionally fetch logs from docker inspect. print to screen.

## Docs
N/A

## Pictures
![image](https://user-images.githubusercontent.com/99742088/202246522-f1f7fa47-4ba6-475a-8ead-64d429f01eeb.png)
