### PR TITLE
validator for looser validation on account names

### DIFF
--- a/src/dependency-manager/spec/utils/slugs.ts
+++ b/src/dependency-manager/spec/utils/slugs.ts
@@ -17,6 +17,10 @@ export class Slugs {
   public static ArchitectSlugRegexBase = `(?!-)(?!.{0,${Slugs.SLUG_CHAR_LIMIT}}--)[a-z0-9-]{1,${Slugs.SLUG_CHAR_LIMIT}}(?<!-)`;
   public static ArchitectSlugValidator = new RegExp(`^${Slugs.ArchitectSlugRegexBase}$`);
 
+  public static ArchitectSlugDescriptionCaseInsensitive = `must contain only alphanumeric and single hyphens or underscores in the middle; max length ${Slugs.SLUG_CHAR_LIMIT}`;
+  public static ArchitectSlugRegexBaseCaseInsensitive = `(?!-)(?!.{0,${Slugs.SLUG_CHAR_LIMIT}}--)[A-Za-z0-9-]{1,${Slugs.SLUG_CHAR_LIMIT}}(?<!-)`;
+  public static ArchitectSlugValidatorCaseInsensitive = new RegExp(`^${Slugs.ArchitectSlugRegexBaseCaseInsensitive}$`);
+
   public static LabelMax = 63;
   public static LabelSlugDescription = `max length ${Slugs.LabelMax} characters, must begin and end with an alphanumeric character ([a-z0-9A-Z]), could contain dashes (-), underscores (_), dots (.), and alphanumerics between.`;
   public static LabelValueSlugRegexNoMaxLength = '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?';

--- a/test/dependency-manager/utils/slug-validators.test.ts
+++ b/test/dependency-manager/utils/slug-validators.test.ts
@@ -18,6 +18,13 @@ describe('slugs validators', () => {
     '2',
   ];
 
+  const case_insensitive_valid_slugs = [
+    ...valid_slugs,
+    'MyUsername',
+    'anOtherUs3rn4me',
+    'Dashed-Username'
+  ];
+
   const valid_tags = [
     valid_tag,
     '1-0-0',
@@ -54,13 +61,20 @@ describe('slugs validators', () => {
     'other;punctuation',
   ];
 
-  const invalid_slugs = [
+  const case_insensitive_invalid_slugs = [
     invalid_slug,
     '-leading-dashes',
     'trailingdashes-',
     'something-33-characters-loooooong',
     'other.punctuation',
-    ...globally_invalid_punctuation
+    ...globally_invalid_punctuation,
+  ];
+
+  const invalid_slugs = [
+    'MyUsername',
+    'anOtherUs3rn4me',
+    'Dashed-Username',
+    ...case_insensitive_invalid_slugs,
   ];
 
   const invalid_tags = [
@@ -77,6 +91,18 @@ describe('slugs validators', () => {
   it(`invalid slugs are NOT acceptable to ArchitectSlugValidator`, async () => {
     for (const slug of invalid_slugs) {
       expect(Slugs.ArchitectSlugValidator.test(slug)).to.be.false
+    }
+  });
+
+  it(`valid slugs are acceptable to ArchitectSlugValidatorCaseInsensitive`, async () => {
+    for (const slug of case_insensitive_valid_slugs) {
+      expect(Slugs.ArchitectSlugValidatorCaseInsensitive.test(slug)).to.be.true
+    }
+  });
+
+  it(`invalid slugs are NOT acceptable to ArchitectSlugValidatorCaseInsensitive`, async () => {
+    for (const slug of case_insensitive_invalid_slugs) {
+      expect(Slugs.ArchitectSlugValidatorCaseInsensitive.test(slug)).to.be.false
     }
   });
 


### PR DESCRIPTION
## Overview
Adds a validator for account names, part of https://gitlab.com/architect-io/architect-hub/-/issues/579

## Changes
* Added a validator for case-insensitive slugs to be used as a looser validator for account names or others

## Tests
* Added tests
