### PR TITLE
567-add-additional-data-as-tags

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -175,7 +175,7 @@ export default class SentryService {
         await this.setScopeExtra('args', filtered_sentry_args);
         await this.setScopeExtra('flags', filtered_sentry_flags);
         // set both filtered flags as tags for sentry
-        const filtered_sentry_flags_tags = this.flattenNestedJson(filtered_sentry_flags, 'flags');
+        const filtered_sentry_flags_tags = this.flattenNestedJson(filtered_sentry_flags, 'flag');
         await this.setTags(filtered_sentry_flags_tags);
       } catch (err) {
         this.command.debug('Unable to add extra sentry metadata');

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -96,7 +96,7 @@ export default class SentryService {
 
       const used_flags: { [key: string]: string | undefined } = {};
       for (const flag of non_default_flags) {
-        used_flags[flag] = command_class.flags[flag].sensitive ? 'Filtered' : flags[flag];
+        used_flags[`flag.${flag}`] = command_class.flags[flag].sensitive ? 'Filtered' : flags[flag];
       }
 
       const sentry_tags: { [key: string]: string | undefined } = {

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -169,13 +169,12 @@ export default class SentryService {
       ]);
 
       try {
-        // set both filtered args and flags as tags for sentry
         const filtered_sentry_args = await this.filterNonSensitiveSentryMetadata(non_sensitive, args);
         const filtered_sentry_flags = await this.filterNonSensitiveSentryMetadata(non_sensitive, flags);
 
         await this.setScopeExtra('command_args', filtered_sentry_args);
         await this.setScopeExtra('command_flags', filtered_sentry_flags);
-
+        // set both filtered flags as tags for sentry
         const filtered_sentry_flags_tags = this.flattenNestedJson(filtered_sentry_flags, 'command_flags');
         await this.setTags(filtered_sentry_flags_tags);
       } catch (err) {

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -172,10 +172,10 @@ export default class SentryService {
         const filtered_sentry_args = await this.filterNonSensitiveSentryMetadata(non_sensitive, args);
         const filtered_sentry_flags = await this.filterNonSensitiveSentryMetadata(non_sensitive, flags);
 
-        await this.setScopeExtra('command_args', filtered_sentry_args);
-        await this.setScopeExtra('command_flags', filtered_sentry_flags);
+        await this.setScopeExtra('args', filtered_sentry_args);
+        await this.setScopeExtra('flags', filtered_sentry_flags);
         // set both filtered flags as tags for sentry
-        const filtered_sentry_flags_tags = this.flattenNestedJson(filtered_sentry_flags, 'command_flags');
+        const filtered_sentry_flags_tags = this.flattenNestedJson(filtered_sentry_flags, 'flags');
         await this.setTags(filtered_sentry_flags_tags);
       } catch (err) {
         this.command.debug('Unable to add extra sentry metadata');


### PR DESCRIPTION
Please see https://gitlab.com/architect-io/architect-cli/-/issues/567

## Overview
Sentry transactions for the CLI project assigns command flags under Additional Data. Additional Data is not indexed for search, so there is no way to filter search results for a particular flag value used. Eg., wanting to see architect dev/deploy commands that have used the -i flag.


## Changes
Update sentry startTransaction to add command flags passed by argument to CLI as tags to sentry.
Move logic for setting additional data into start sentry transaction.


## Tests
- `npm run test`
-  `architect environments`
-  `architect environments -a architect`


## Docs
N/A

