### PR TITLE
Remove type kubernetes from cluster registration

### DIFF
--- a/src/commands/clusters/create.ts
+++ b/src/commands/clusters/create.ts
@@ -20,7 +20,7 @@ export default class ClusterCreate extends BaseCommand {
   static description = 'Register a new cluster with Architect Cloud';
   static examples = [
     'architect clusters:create --account=myaccount',
-    'architect clusters:register --account=myaccount --type=kubernetes --kubeconfig=~/.kube/config --auto-approve',
+    'architect clusters:register --account=myaccount --kubeconfig=~/.kube/config --auto-approve',
   ];
   static args = [{
     sensitive: false,


### PR DESCRIPTION
## Overview
Remove type `kubernetes` from cluster registration example since it is no longer used.
