### PR TITLE
529 default register path

### DIFF
--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -93,7 +93,7 @@ export default class ComponentRegister extends BaseCommand {
     const parsed = await super.parse(options, argv) as Interfaces.ParserOutput<F, A>;
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    parsed.args.component = [...new Set(parsed.argv)];
+    parsed.args.component = parsed.argv;
 
     return parsed;
   }
@@ -106,14 +106,13 @@ export default class ComponentRegister extends BaseCommand {
       args.component = ['./architect.yml'];
     }
 
-    for (const component of args.component) {
-      const config_path = path.resolve(untildify(component));
-
+    const resolved_components: string[] = args.component.map((provided: string) => path.resolve(untildify(provided)));
+    for (const component of new Set(resolved_components)) {
       if (!Slugs.ComponentTagValidator.test(flags.tag)) {
         throw new ArchitectError(Slugs.ComponentTagDescription);
       }
 
-      await this.registerComponent(config_path, ComponentRegister.getTagFromFlags(flags));
+      await this.registerComponent(component, ComponentRegister.getTagFromFlags(flags));
     }
   }
 

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -77,7 +77,6 @@ export default class ComponentRegister extends BaseCommand {
     sensitive: false,
     name: 'component',
     description: 'Path to the component(s) to register',
-    default: './',
   }];
 
   // overrides the oclif default parse to allow for component to be a list of components
@@ -92,10 +91,9 @@ export default class ComponentRegister extends BaseCommand {
       options.args.push({ name: 'filler' });
     }
     const parsed = await super.parse(options, argv) as Interfaces.ParserOutput<F, A>;
-    const absolute_component_path_argv = (parsed.argv || []).map(argv => path.resolve(argv));
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    parsed.args.component = new Set(absolute_component_path_argv);
+    parsed.args.component = [...new Set(parsed.argv)];
 
     return parsed;
   }
@@ -103,6 +101,11 @@ export default class ComponentRegister extends BaseCommand {
   @RequiresDocker({ buildx: true })
   async run(): Promise<void> {
     const { args, flags } = await this.parse(ComponentRegister);
+
+    if (!args.component || args.component.length === 0) {
+      args.component = ['./architect.yml'];
+    }
+
     for (const component of args.component) {
       const config_path = path.resolve(untildify(component));
 

--- a/test/commands/register.test.ts
+++ b/test/commands/register.test.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import fs from 'fs-extra';
 import yaml from 'js-yaml';
+import path from 'path';
+import untildify from 'untildify';
 import sinon, { SinonSpy, SinonStub } from 'sinon';
 import { ServiceSpec, TaskSpec, validateSpec } from '../../src';
 import AccountUtils from '../../src/architect/account/account.utils';
@@ -34,6 +36,17 @@ describe('register', function () {
     ...mock_account_response,
     name: 'architect',
   };
+
+  mockArchitectAuth()
+    .stub(fs, 'move', sinon.stub())
+    .stub(ComponentRegister, 'registerComponent', sinon.stub().returns({}))
+    .stdout({ print })
+    .stderr({ print })
+    .command(['register', '-a', 'examples'])
+    .catch(e => {
+      expect(e.message).contains(path.resolve(untildify('./architect.yml')));
+    })
+    .it('expect default project path to be ./architect.yml if not provided');
 
   mockArchitectAuth()
     .nock(MOCK_API_HOST, api => api


### PR DESCRIPTION
## Overview

please see: 
https://gitlab.com/architect-io/architect-cli/-/issues/529

>architect dev doesn't require you to specify an architect.yml and will assume you mean ./architect.yml. architect register doesn't do this - if you run architect register it will just do nothing, and you need to run architect register . instead. We should update the register command to support being run with no path similar to dev.


## Changes
Moved path resolution into run method to avoid having to resolve twice. 
Moved deduplication as last step after paths have been resolved.
Set default path as `./architect.yml` (same as architect dev command)

## Tests
```javascript
  mockArchitectAuth()
    .stub(fs, 'move', sinon.stub())
    .stub(ComponentRegister, 'registerComponent', sinon.stub().returns({}))
    .stdout({ print })
    .stderr({ print })
    .command(['register', '-a', 'examples'])
    .catch(e => {
      expect(e.message).contains(path.resolve(untildify('./architect.yml')));
    })
    .it('expect default project path to be ./architect.yml if not provided');
```

## Docs
N/A

## Pictures
N/A
