### PR TITLE
571-allow-env-destroy-to-fail

### DIFF
--- a/src/commands/environments/destroy.ts
+++ b/src/commands/environments/destroy.ts
@@ -30,6 +30,11 @@ export default class EnvironmentDestroy extends BaseCommand {
       default: false,
       sensitive: false,
     }),
+    'skip-deregistered': booleanString({
+      description: 'If set to true, does not throw error when an environment cannot be found to deregister',
+      default: false,
+      sensitive: false,
+    }),
     force: booleanString({
       description: 'Force the deletion even if the environment is not empty',
       char: 'f',
@@ -62,7 +67,12 @@ export default class EnvironmentDestroy extends BaseCommand {
     const { args, flags } = await this.parse(EnvironmentDestroy);
 
     const account = await AccountUtils.getAccount(this.app, flags.account);
-    const environment = await EnvironmentUtils.getEnvironment(this.app.api, account, args.environment);
+    const environment = await EnvironmentUtils.getEnvironment(this.app.api, account, args.environment, flags['skip-deregistered']);
+
+    if (!environment.id && flags['skip-deregistered']) {
+      this.warn(`No configured environments found matching ${args?.environment}.`);
+      return;
+    }
 
     let answers = await inquirer.prompt([{
       type: 'input',

--- a/src/commands/environments/destroy.ts
+++ b/src/commands/environments/destroy.ts
@@ -31,8 +31,8 @@ export default class EnvironmentDestroy extends BaseCommand {
       sensitive: false,
     }),
     'skip-deregistered': booleanString({
-      description: 'If set to true, does not throw error when an environment cannot be found to deregister',
-      default: false,
+      description: 'If set to false, throws an error when an environment cannot be found to deregister',
+      default: true,
       sensitive: false,
     }),
     force: booleanString({


### PR DESCRIPTION
Please see: https://gitlab.com/architect-io/architect-cli/-/issues/571

## Overview
This should allow users to avoid using `|| exit 0` or similar in CI jobs when removing environments. `environment:destroy` warns and exits by default when environment is not found to deregister.

## Changes
add new flag for environment: destroy, `--skip-deregistered`
set flag value properties: non-sensitive, default: true
add optional param to EnvironmentUtils.getEnvironment, `skip_deregistered=false`
print warning and return when environment is not found and skip_deregistered is provided.

## Tests
`destroy.test.ts`

```javascript
  mockArchitectAuth()
    .stub(PipelineUtils, 'pollPipeline', async () => null)
    .nock(MOCK_API_HOST, api => api
      .get(`/accounts/${mock_account.name}`)
      .reply(200, mock_account))
    .nock(MOCK_API_HOST, api => api
      .get(`/accounts/${mock_account.id}/environments/${failing_mock_env.name}`)
      .reply(200, failing_mock_env))
    .stdout({ print })
    .stderr({ print })
    .timeout(20000)
    .command(['environments:destroy', '-a', mock_account.name, failing_mock_env.name, '--auto-approve', '--skip-deregistered'])
    .it('should warn and exit with non-error status when skip-deregistered is provided', ctx => {
      expect(ctx.stderr).contains(`Warning: No configured environments found matching ${failing_mock_env.name}.`);
    });

  mockArchitectAuth()
    .stub(PipelineUtils, 'pollPipeline', async () => null)
    .nock(MOCK_API_HOST, api => api
      .get(`/accounts/${mock_account.name}`)
      .reply(200, mock_account))
    .nock(MOCK_API_HOST, api => api
      .get(`/accounts/${mock_account.id}/environments/${failing_mock_env.name}`)
      .reply(200, failing_mock_env))
    .stdout({ print })
    .stderr({ print })
    .timeout(20000)
    .command(['environments:destroy', '-a', mock_account.name, failing_mock_env.name, '--auto-approve', '--skip-deregistered=true'])
    .it('should warn and exit with non-error status when skip-deregistered is set explicitly to true', ctx => {
      expect(ctx.stderr).to.contain(`Warning: No configured environments found matching ${failing_mock_env.name}.`);
    });

  mockArchitectAuth()
    .stub(PipelineUtils, 'pollPipeline', async () => null)
    .nock(MOCK_API_HOST, api => api
      .get(`/accounts/${mock_account.name}`)
      .reply(200, mock_account))
    .nock(MOCK_API_HOST, api => api
      .get(`/accounts/${mock_account.id}/environments/${failing_mock_env.name}`)
      .reply(404))
    .stdout({ print })
    .stderr({ print })
    .timeout(20000)
    .command(['environments:destroy', '-a', mock_account.name, failing_mock_env.name, '--auto-approve', '--skip-deregistered=false'])
    .catch(e => {
      expect(e.message).to.contain('Request failed with status code 404');
    })
    .it('should exit with error status when skip-deregistered is set explicitly to false');
```

