### PR TITLE
Fixing register for services with reserved names

### DIFF
--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -331,8 +331,7 @@ export class DockerComposeUtils {
       if (service.build) {
         if (!service.image) {
           // eslint-disable-next-line unicorn/consistent-destructuring
-          const image = options.getImage ? options.getImage(node.config.metadata.ref) : node.ref;
-          service.image = image;
+          service.image = options.getImage ? options.getImage(node.config.metadata.architect_ref) : node.ref;
         }
 
         // Optimization to check if multiple services share the same dockerfile/build config and avoid building unnecessarily

--- a/test/commands/register.test.ts
+++ b/test/commands/register.test.ts
@@ -16,7 +16,7 @@ import { mockArchitectAuth, MOCK_API_HOST, MOCK_REGISTRY_HOST } from '../utils/m
 describe('register', function () {
 
   // set to true while working on tests for easier debugging; otherwise oclif/test eats the stdout/stderr
-  const print = true; // TODO: undo
+  const print = false;
 
   const mock_account_response = {
     created_at: "2020-06-02T15:33:27.870Z",

--- a/test/mocks/superset/architect.yml
+++ b/test/mocks/superset/architect.yml
@@ -140,7 +140,7 @@ services:
           protocol: postgresql
 
   stateful-api:
-    reserved_name: stateful-api
+    reserved_name: stateful-reserved-name
     build:
       args:
         build_arg_string: arg_value
@@ -211,7 +211,7 @@ services:
         args:
           NODE_ENV: development
       depends_on:
-        - stateful-api
+        - stateful-reserved-name
       scaling:
         min_replicas: 1
         max_replicas: 3

--- a/test/mocks/superset/architect.yml
+++ b/test/mocks/superset/architect.yml
@@ -140,6 +140,7 @@ services:
           protocol: postgresql
 
   stateful-api:
+    reserved_name: stateful-api
     build:
       args:
         build_arg_string: arg_value


### PR DESCRIPTION
## Overview
Fixes registering a component with a service that includes a reserved name (https://gitlab.com/architect-io/architect-cli/-/issues/579)

## Changes
* Passing `architect_ref` to `getImage` rather than just `ref`

## Tests
* Added test that registers the superset
