### PR TITLE
updating the remote deployment condition

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -39,7 +39,7 @@ jobs:
 
   test_remote:
     name: Superset remote deployment
-    if: github.ref_name == 'rc'
+    if: github.base_ref == 'main'
     env:
       ACCOUNT_NAME: architect-ci
       ENVIRONMENT_NAME: example-environment


### PR DESCRIPTION
## Overview
Updated when TJ found that no workflows were triggered by [this PR](https://github.com/architect-team/architect-cli/pull/780)

## Changes
* Updated the condition for the remote deployment job to use the proper `github` context property

