### PR TITLE
add nullsafe chain, and filter out potential null

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -104,7 +104,7 @@ export default class SentryService {
       };
 
       for (const flag of non_default_flags) {
-        sentry_tags[`flag.${flag}`] = command_class.flags?.[flag]?.sensitive ? 'Filtered' : flags?.[flag];
+        sentry_tags[`flag.${flag}`] = command_class.flags[flag].sensitive ? 'Filtered' : flags[flag];
       }
 
       if (sentry_user?.email) {

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -33,7 +33,7 @@ export default class SentryService {
   initSentry(): void {
     this.ignoreTryCatch(async () => {
       Sentry.init({
-        enabled: false, // process.env.TEST !== '1' && process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== ENVIRONMENT.PREVIEW,
+        enabled: process.env.TEST !== '1' && process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== ENVIRONMENT.PREVIEW,
         dsn: CLI_SENTRY_DSN,
         debug: false,
         environment: process.env?.NODE_ENV ?? 'production',


### PR DESCRIPTION
## Overview
add null-safe chain to make referencing user input via either invalid file parsing, or cli stdio directly more safe.
filter out potentially undefined values coming from stdio or file parsing directly.

please see: https://gitlab.com/architect-io/architect-cli/-/issues/595

## Tests
architect dev using an empty architect.yml configuration file

## Docs
N/A

## Pictures
N/A
