### PR TITLE
Remote deployment url fix

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -317,7 +317,7 @@ export default class Deploy extends DeployCommand {
       }
     }
 
-    if (available_urls) {
+    if (available_urls.size) {
       this.log('Deployed services are now available at the following URLs:\n');
       for (const url of available_urls) {
         this.log(`\t${url}`);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -317,7 +317,7 @@ export default class Deploy extends DeployCommand {
       }
     }
 
-    if (available_urls.size) {
+    if (available_urls.size > 0) {
       this.log('Deployed services are now available at the following URLs:\n');
       for (const url of available_urls) {
         this.log(`\t${url}`);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -302,7 +302,7 @@ export default class Deploy extends DeployCommand {
 
     // Get available URLs from CertManager data
     const { data: cert_data } = await this.app.api.get(`/environments/${environment.id}/certificates`);
-    const available_urls = [];
+    const available_urls: Set<string> = new Set<string>();
 
     for (const data of cert_data) {
       const cert_component_name = data.metadata.labels['architect.io/component'];
@@ -311,7 +311,7 @@ export default class Deploy extends DeployCommand {
       if ((new Set([...component_names].filter(n => label_set.has(n)))).size > 0) {
         for (const dns_name of data.spec.dnsNames) {
           if (!dns_name.startsWith('env--')) {
-            available_urls.push(`https://${dns_name}`);
+            available_urls.add(`https://${dns_name}`);
           }
         }
       }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -305,8 +305,9 @@ export default class Deploy extends DeployCommand {
     const available_urls = [];
 
     for (const data of cert_data) {
-      const deployed_component_name = `${data.metadata.labels['architect.io/component']}:${data.metadata.labels['architect.io/component-tag']}`;
-      if (component_names.includes(deployed_component_name)) {
+      const deployed_component_name_with_tag = `${data.metadata.labels['architect.io/component']}:${data.metadata.labels['architect.io/component-tag']}`;
+      const deployed_component_name_without_tag = `${data.metadata.labels['architect.io/component']}`;
+      if (component_names.includes(deployed_component_name_with_tag) || component_names.includes(deployed_component_name_without_tag)) {
         for (const dns_name of data.spec.dnsNames) {
           if (!dns_name.startsWith('env--')) {
             available_urls.push(`https://${dns_name}`);

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -121,6 +121,13 @@ describe('remote deploy environment', function () {
       expect(ctx.stdout).to.not.contain('app.doesnt.get.output');
     });
 
+  remoteDeploy
+    .command(['deploy', '-e', environment.name, '-a', account.name, '--auto-approve', 'echo'])
+    .it('Remote deployment outputs URLs from for the deployed component with no tag and not other components in the same environment', ctx => {
+      expect(ctx.stdout).to.contain('app.test-env.examples.arc.test');
+      expect(ctx.stdout).to.not.contain('app.doesnt.get.output');
+    });
+
   describe('instance deploys', function () {
     remoteDeploy
       .command(['deploy', '-e', environment.name, '-a', account.name, '--auto-approve', 'echo:latest@tenant-1'])


### PR DESCRIPTION
## Overview
Closes https://gitlab.com/architect-io/architect-cli/-/issues/598 by also printing the URL when the component(s) specified to be deployed don't include a tag

## Changes
* Checked the returned cert data to see if it matches either just the component name or the component and tag name

## Tests
* Added a test for the case where the component tag isn't specified
* ```sh
  ryan@ryan-ThinkPad-P53s:~/Code/architect-cli$ architect deploy -e do-k8s hello-world react-app --auto-approve
  Creating pipelines... done
  hello-world Deployed
  react-app Deployed
  Deploying... done
  Deployed services are now available at the following URLs:

          https://hello.do-k8s.architect-ryan.dev.arcitect.io
          https://app.do-k8s.architect-ryan.dev.arcitect.io
  ```

