### PR TITLE
Superset test communication enabled

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -69,10 +69,12 @@ jobs:
         run: |
           export CERT_DATA=$(openssl s_client -showcerts -connect hello.$ENVIRONMENT_NAME.$ACCOUNT_NAME.dev.arcitect.io:443 </dev/null | openssl x509 -noout -issuer)
           if [[ "$CERT_DATA" = "issuer=C = US, O = Let's Encrypt, CN = R3" || "$CERT_DATA" = "issuer=C = US, O = (STAGING) Let's Encrypt, CN = (STAGING) Artificial Apricot R3" ]]; then echo "Valid cert generated"; else exit 1; fi
-      # - name: Ensure that network policies are being enforced in the cluster
+      # - name: Ensure that network policies are being enforced in the cluster and a service can't connect to one that it shouldn't be able to
       #   run: |
       #     ./bin/dev exec -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME superset.services.stateful-api -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://hello-world--api:3000/ || true" > network_policy_test.txt 2>&1 </dev/null
       #     if [[ $(cat network_policy_test.txt) == *"Connection timeout"* ]]; then exit 0; else exit 1; fi
+      - name: Ensure that network policies are being enforced in the cluster and a service can connect to one that it shouldn be able to
+        run: ./bin/dev exec -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME superset.services.stateful-frontend -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://superset--stateful-api:8080/"
       - name: Run a remote task
         run: ./bin/dev task superset curler -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME
       - run: ./bin/dev destroy -e $ENVIRONMENT_NAME -a $ACCOUNT_NAME --auto-approve

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -74,7 +74,7 @@ jobs:
       #     ./bin/dev exec -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME superset.services.stateful-api -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://hello-world--api:3000/ || true" > network_policy_test.txt 2>&1 </dev/null
       #     if [[ $(cat network_policy_test.txt) == *"Connection timeout"* ]]; then exit 0; else exit 1; fi
       - name: Ensure that network policies are being enforced in the cluster and a service can connect to one that it should be able to
-        run: ./bin/dev exec -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME superset.services.stateful-frontend -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://superset--stateful-api:8080/"
+        run: ./bin/dev exec -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME superset.services.stateful-frontend -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://stateful-reserved-name:8080/"
       - name: Run a remote task
         run: ./bin/dev task superset curler -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME
       - run: ./bin/dev destroy -e $ENVIRONMENT_NAME -a $ACCOUNT_NAME --auto-approve

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -73,7 +73,7 @@ jobs:
       #   run: |
       #     ./bin/dev exec -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME superset.services.stateful-api -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://hello-world--api:3000/ || true" > network_policy_test.txt 2>&1 </dev/null
       #     if [[ $(cat network_policy_test.txt) == *"Connection timeout"* ]]; then exit 0; else exit 1; fi
-      - name: Ensure that network policies are being enforced in the cluster and a service can connect to one that it shouldn be able to
+      - name: Ensure that network policies are being enforced in the cluster and a service can connect to one that it should be able to
         run: ./bin/dev exec -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME superset.services.stateful-frontend -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://superset--stateful-api:8080/"
       - name: Run a remote task
         run: ./bin/dev task superset curler -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME

--- a/examples/stateful-component/frontend/Dockerfile
+++ b/examples/stateful-component/frontend/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:18-alpine
 
+# added to support CI job
+RUN apk update && apk upgrade && \
+    apk add --no-cache curl
+
 WORKDIR /usr/src/app
 
 COPY package*.json ./


### PR DESCRIPTION
Adds a test to the superset remote deployment that checks that communication is enabled between services where it should be enabled. Closes https://gitlab.com/architect-io/architect-cli/-/issues/587

Check passing on previous PR targeting `main`: https://github.com/architect-team/architect-cli/actions/runs/3808982183/jobs/6480000852