### PR TITLE
582 602 expected docker compose err

### DIFF
--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -506,9 +506,10 @@ export default class Dev extends BaseCommand {
     try {
       await DockerComposeUtils.dockerCompose(['-f', compose_file, '-p', project_name, 'build', ...build_args], { stdio: 'inherit' });
     } catch (e: any) {
-      if (e.failed && !e.signal && !e.isCancelled && !e.killed) {
-        // eslint-disable-next-line no-process-exit
-        process.exit(e.exitCode || 1);
+      const pattern = new RegExp('Command failed with exit code 17: docker compose -f [-p architect build]?', 'g');
+      const error = e?.message || '';
+      if (pattern.test(error)) {
+        throw new ArchitectError(`Docker compose has encountered an error building the image specified in ${compose_file}`, false);
       }
     }
     return [project_name, compose_file];

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -503,7 +503,14 @@ export default class Dev extends BaseCommand {
       build_args.push('--build-arg', arg);
     }
 
-    await DockerComposeUtils.dockerCompose(['-f', compose_file, '-p', project_name, 'build', ...build_args], { stdio: 'inherit' });
+    try {
+      await DockerComposeUtils.dockerCompose(['-f', compose_file, '-p', project_name, 'build', ...build_args], { stdio: 'inherit' });
+    } catch (e: any) {
+      if (e.failed && !e.signal && !e.isCancelled && !e.killed) {
+        // eslint-disable-next-line no-process-exit
+        process.exit(e.exitCode || 1);
+      }
+    }
     return [project_name, compose_file];
   }
 

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -512,8 +512,10 @@ export default class Dev extends BaseCommand {
       });
       await cmd;
     } catch (e: any) {
-      this.logToStderr(chalk.red('Docker compose has encounted an error building the specified image:'));
-      throw new ArchitectError(stderr_message, e.exitCode !== 17);
+      if (e.exitCode !== 0) {
+        this.logToStderr(chalk.red('Docker compose has encounted an error building the specified image:'));
+        throw new ArchitectError(stderr_message);
+      }
     }
     return [project_name, compose_file];
   }

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -503,18 +503,12 @@ export default class Dev extends BaseCommand {
       build_args.push('--build-arg', arg);
     }
 
-    const cmd = DockerComposeUtils.dockerCompose(['-f', compose_file, '-p', project_name, 'build', ...build_args], { stdin: 'inherit', stdout: 'inherit', stderr: 'pipe' });
-
-    let stderr_message = '';
     try {
-      cmd.stderr?.on('data', (bytes) => {
-        stderr_message = (bytes.toString() || '').trim();
-      });
-      await cmd;
+      await DockerComposeUtils.dockerCompose(['-f', compose_file, '-p', project_name, 'build', ...build_args], { stdin: 'inherit', stdout: 'inherit', stderr: 'pipe' });
     } catch (e: any) {
       if (e.exitCode !== 0) {
         this.logToStderr(chalk.red('Docker compose has encounted an error building the specified image:'));
-        throw new ArchitectError(stderr_message);
+        throw new ArchitectError(e.stderr);
       }
     }
     return [project_name, compose_file];

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -508,9 +508,7 @@ export default class Dev extends BaseCommand {
     } catch (e: any) {
       const pattern = new RegExp('Command failed with exit code 17: docker compose -f [-p architect build]?', 'g');
       const error = e?.message || '';
-      if (pattern.test(error)) {
-        throw new ArchitectError(`Docker compose has encountered an error building the image specified in ${compose_file}`, false);
-      }
+      throw new ArchitectError(`Docker compose has encountered an error building the image specified in ${compose_file}`, !pattern.test(error));
     }
     return [project_name, compose_file];
   }

--- a/src/dependency-manager/utils/files.ts
+++ b/src/dependency-manager/utils/files.ts
@@ -40,7 +40,7 @@ export const insertFileDataFromRefs = (file_contents: string, config_path: strin
 
 export const replaceFileReference = (parsed_yml: ParsedYaml, config_path: string): string => {
   if ((parsed_yml || '').toString().trim().length === 0) {
-    throw new ArchitectError(`The file at ${config_path} is empty.  For help getting started take a look at our documentation here: https://docs.architect.io/reference/architect-yml`, false);
+    throw new ArchitectError(`The file at ${config_path} is empty.  For help getting started take a look at our documentation here: https://docs.architect.io/reference/architect-yml`);
   }
   const source_as_json = JSON.stringify(parsed_yml, null, 2);
   const replaced_source = insertFileDataFromRefs(source_as_json, config_path);

--- a/src/dependency-manager/utils/files.ts
+++ b/src/dependency-manager/utils/files.ts
@@ -38,7 +38,7 @@ export const insertFileDataFromRefs = (file_contents: string, config_path: strin
 };
 
 export const replaceFileReference = (parsed_yml: ParsedYaml, config_path: string): string => {
-  const source_as_json = JSON.stringify(parsed_yml, null, 2);
+  const source_as_json = JSON.stringify(parsed_yml || {}, null, 2);
   const replaced_source = insertFileDataFromRefs(source_as_json, config_path);
   const replaced_object = JSON.parse(replaced_source);
 

--- a/src/dependency-manager/utils/files.ts
+++ b/src/dependency-manager/utils/files.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import yaml from 'js-yaml';
 import path from 'path';
 import untildify from 'untildify';
+import { ArchitectError } from './errors';
 import { ParsedYaml } from './types';
 
 // https://stackoverflow.com/questions/4253367/how-to-escape-a-json-string-containing-newline-characters-using-javascript
@@ -38,7 +39,10 @@ export const insertFileDataFromRefs = (file_contents: string, config_path: strin
 };
 
 export const replaceFileReference = (parsed_yml: ParsedYaml, config_path: string): string => {
-  const source_as_json = JSON.stringify(parsed_yml || {}, null, 2);
+  if ((parsed_yml || '').toString().trim().length === 0) {
+    throw new ArchitectError(`The file at ${config_path} is empty.  For help getting started take a look at our documentation here: https://docs.architect.io/reference/architect-yml`, false);
+  }
+  const source_as_json = JSON.stringify(parsed_yml, null, 2);
   const replaced_source = insertFileDataFromRefs(source_as_json, config_path);
   const replaced_object = JSON.parse(replaced_source);
 

--- a/test/commands/dev/index.test.ts
+++ b/test/commands/dev/index.test.ts
@@ -1330,4 +1330,21 @@ describe('local dev environment', function () {
       const runCompose = Dev.prototype.runCompose as sinon.SinonStub;
       expect(runCompose.calledOnce).to.be.false;
     });
+
+  test
+    .timeout(20000)
+    .stub(ComponentBuilder, 'loadFile', () => {
+      return '';
+    })
+    .stub(Dev.prototype, 'failIfEnvironmentExists', sinon.stub().returns(undefined))
+    .stub(Dev.prototype, 'runCompose', sinon.stub().returns(undefined))
+    .stub(Dev.prototype, 'downloadSSLCerts', sinon.stub().returns(undefined))
+    .stub(Dev.prototype, 'readSSLCert', sinon.stub().returns('fake-cert'))
+    .stdout({ print })
+    .stderr({ print })
+    .command(['dev', './examples/hello-world/architect.yml'])
+    .catch(err => {
+      expect(err.message).to.include('For help getting started take a look at our documentation here: https://docs.architect.io/reference/architect-yml');
+    })
+    .it('Provide error if architect.yml is empty');
 });


### PR DESCRIPTION
## Overview
Please see:

https://gitlab.com/architect-io/architect-cli/-/issues/582

https://gitlab.com/architect-io/architect-cli/-/issues/602

## Changes

Add a check to see if yaml is empty before parsing. 
* Throws error if empty.

Add try catch around dev buildImage function. 
* Catch identified error message and display message to screen.

## Tests
run dev command against empty architect.yml file. See error message, and no sentry submission
run dev command with a dockerfile containing an exception. See error message, and no sentry submission.

```
test
    .timeout(20000)
    .stub(ComponentBuilder, 'loadFile', () => {
      return '';
    })
    .stub(Dev.prototype, 'failIfEnvironmentExists', sinon.stub().returns(undefined))
    .stub(Dev.prototype, 'runCompose', sinon.stub().returns(undefined))
    .stub(Dev.prototype, 'downloadSSLCerts', sinon.stub().returns(undefined))
    .stub(Dev.prototype, 'readSSLCert', sinon.stub().returns('fake-cert'))
    .stdout({ print })
    .stderr({ print })
    .command(['dev', './examples/hello-world/architect.yml'])
    .catch(err => {
      expect(err.message).to.include('For help getting started take a look at our documentation here: https://docs.architect.io/reference/architect-yml');
    })
    .it('Provide error if architect.yml is empty');
```


## Pictures

### Docker compose error
![image](https://user-images.githubusercontent.com/99742088/210638510-01be7fd4-d55f-4db8-ada3-5d3c579a7843.png)

## Empty architect.yml
![image](https://user-images.githubusercontent.com/99742088/210638651-5f802789-f8f2-44b2-892d-f068f04601c7.png)

