### PR TITLE
Incorrect cluster command when warning about deprecated platform command

### DIFF
--- a/src/commands/platforms/create.ts
+++ b/src/commands/platforms/create.ts
@@ -4,7 +4,7 @@ export default class PlatformCreate extends ClusterCreate {
   static aliases = ['platforms:register', 'platform:create', 'platforms:create'];
   static state = 'deprecated';
   static deprecationOptions = {
-    to: 'cluster:register',
+    to: 'clusters:register',
   };
   static hidden = true;
 

--- a/src/commands/platforms/destroy.ts
+++ b/src/commands/platforms/destroy.ts
@@ -4,7 +4,7 @@ export default class PlatformDestroy extends ClusterDestroy {
   static aliases = ['platforms:deregister', 'platform:destroy', 'platforms:destroy'];
   static state = 'deprecated';
   static deprecationOptions = {
-    to: 'cluster:deregister',
+    to: 'clusters:deregister',
   };
   static hidden = true;
 


### PR DESCRIPTION
These deprecation warnings were wrong - if you run `architect platform:create` it tells you to run `cluster:register` but the real command is `clusters:register` (same with deregister with any of the `platform:delete` equivalents)