### PR TITLE
Fix superset

### DIFF
--- a/test/integration/schedule-tasks/Dockerfile
+++ b/test/integration/schedule-tasks/Dockerfile
@@ -1,0 +1,26 @@
+# https://github.com/ellerbrock/docker-collection/blob/master/dockerfiles/alpine-bash-curl-ssl/Dockerfile
+FROM alpine:3.8
+
+# Optional Configuration Parameter
+ARG SERVICE_USER
+ARG SERVICE_HOME
+
+# Default Settings
+ENV SERVICE_USER ${SERVICE_USER:-download}
+ENV SERVICE_HOME ${SERVICE_HOME:-/home/${SERVICE_USER}}
+
+RUN \
+  adduser -h ${SERVICE_HOME} -s /sbin/nologin -u 1000 -D ${SERVICE_USER} && \
+  apk add --no-cache \
+  curl \
+  bash \
+  git \
+  dumb-init \
+  openssl
+
+USER    ${SERVICE_USER}
+WORKDIR ${SERVICE_HOME}
+VOLUME  ${SERVICE_HOME}
+
+ENTRYPOINT [ "/usr/bin/dumb-init", "--" ]
+CMD [ "curl", "--help" ]

--- a/test/integration/schedule-tasks/Readme.md
+++ b/test/integration/schedule-tasks/Readme.md
@@ -1,0 +1,32 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.architect.io/logo/horizontal-inverted.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://cdn.architect.io/logo/horizontal.png">
+    <img width="320" alt="Architect Logo" src="https://cdn.architect.io/logo/horizontal.png">
+  </picture>
+</p>
+
+<p align="center">
+  A dynamic microservices framework for building, connecting, and deploying cloud-native applications.
+</p>
+
+---
+
+# Task scheduling / cron jobs
+
+In addition to provisioning and updating persistent services, [Architect Components](//docs.architect.io/configuration) can also describe and create tasks that will run on a specified schedule (aka cron jobs).
+
+Just like `services`, `tasks` can take advantage of Architect's embedded service discovery and network security features to automatically connect to peer services without additional configuration. This means that no additional configuration is needed when deploying the component to ensure it can perform its duties.
+
+In this example component (described by the `architect.yml` file in this repo), we've registered a simple hello-world service and a `curler` task that will routinely make a call to the hello-world service. This task runs on a schedule indicated by the `schedule` field.
+
+### Testing the component
+
+When you run the component locally the task will be configured but won't run on its schedule. This is because the environment is short-lived by nature rendering schedules of little use. Instead, testing tasks can be done manually to ensure that they work correctly. Just run the component and then you'll be able to manually execute the task:
+
+```sh
+# Deploy the component locally
+$ architect dev architect.yml
+# In another terminal session, execute the task
+$ architect task:exec --local scheduled-tasks curler
+```

--- a/test/integration/schedule-tasks/architect.yml
+++ b/test/integration/schedule-tasks/architect.yml
@@ -1,0 +1,26 @@
+name: scheduled-tasks
+description: Example application that supports manual tasks and prints the results
+homepage: https://github.com/architect-team/architect-cli/tree/main/examples/scheduled-tasks
+
+tasks:
+  curler:
+    build:
+      context: .
+    schedule: '0 0 * * *' # every day at 12:00am
+    command:
+      - sh
+      - -c
+      - curl $SERVER_URL
+
+    environment:
+      SERVER_URL: ${{ services.api.interfaces.main.url }}
+
+services:
+  api:
+    build:
+      context: ../hello-world
+    interfaces:
+      main:
+        port: 3000
+        ingress:
+          subdomain: api

--- a/test/mocks/superset/architect.yml
+++ b/test/mocks/superset/architect.yml
@@ -235,7 +235,7 @@ tasks:
   curler-build:
     schedule: '*/5 * * * ?'
     build:
-      context: ../../integration/hello-world
+      context: ../../integration/schedule-tasks
     command:
       - sh
       - -c
@@ -246,7 +246,7 @@ tasks:
   ${{ if architect.environment == 'local' }}:
     curler-build-local:
       build:
-        context: ../../integration/hello-world
+        context: ../../integration/schedule-tasks
         dockerfile: ./Dockerfile
       command:
         - sh


### PR DESCRIPTION
## Overview
When removing examples from the superset we broke the ci because we partially broke being able to deploy the superset. This fixes those issues.


## Changes
Add back in support for tasks


## Tests
Was able to register and deploy the superset.