### PR TITLE
Pass up cluster information to allow it to work locally

### DIFF
--- a/src/architect/cluster/cluster.utils.ts
+++ b/src/architect/cluster/cluster.utils.ts
@@ -14,11 +14,11 @@ export interface CreateClusterInput {
 export type ClusterCredentials = KubernetesClusterCredentials;
 
 export interface KubernetesClusterCredentials {
-  kind: 'KUBERNETES';
+  kind: 'KUBERNETES' | 'AGENT';
 
   host: string;
-  cluster_ca_cert: string;
-  service_token: string;
+  cluster_ca_cert?: string;
+  service_token?: string;
 }
 
 export default class ClusterUtils {


### PR DESCRIPTION
## Overview
Send up cluster information to allow us to know if it is a local cluster.


## Changes
1. Add a function that can get a server for a context.
2. Send up the server to the API.

## Tests
Tested alongside https://gitlab.com/architect-io/hub-api/-/merge_requests/700