### PR TITLE
Update architect slug description

### DIFF
--- a/src/dependency-manager/spec/utils/slugs.ts
+++ b/src/dependency-manager/spec/utils/slugs.ts
@@ -20,11 +20,11 @@ export class Slugs {
   public static INSTANCE_DELIMITER = '@';
   public static SLUG_CHAR_LIMIT = 32;
 
-  public static ArchitectSlugDescription = `must contain only lower alphanumeric and single hyphens or underscores in the middle; max length ${Slugs.SLUG_CHAR_LIMIT}`;
+  public static ArchitectSlugDescription = `must contain only lower alphanumeric and single hyphens in the middle; max length ${Slugs.SLUG_CHAR_LIMIT}`;
   public static ArchitectSlugRegexBase = REGEX_LOOKBEHIND ? `(?!-)(?!.{0,${Slugs.SLUG_CHAR_LIMIT}}--)[a-z0-9-]{1,${Slugs.SLUG_CHAR_LIMIT}}(?<!-)` : `[a-z0-9]+(-[a-z0-9]+)*`;
   public static ArchitectSlugValidator = new RegExp(`^${Slugs.ArchitectSlugRegexBase}$`);
 
-  public static ArchitectSlugDescriptionCaseInsensitive = `must contain only alphanumeric and single hyphens or underscores in the middle; max length ${Slugs.SLUG_CHAR_LIMIT}`;
+  public static ArchitectSlugDescriptionCaseInsensitive = `must contain only alphanumeric and single hyphens in the middle; max length ${Slugs.SLUG_CHAR_LIMIT}`;
   public static ArchitectSlugRegexBaseCaseInsensitive = REGEX_LOOKBEHIND ? `(?!-)(?!.{0,${Slugs.SLUG_CHAR_LIMIT}}--)[A-Za-z0-9-]{1,${Slugs.SLUG_CHAR_LIMIT}}(?<!-)` : `[A-Za-z0-9]+(-[A-Za-z0-9]+)*`;
   public static ArchitectSlugValidatorCaseInsensitive = new RegExp(`^${Slugs.ArchitectSlugRegexBaseCaseInsensitive}$`);
 

--- a/test/commands/validate.test.ts
+++ b/test/commands/validate.test.ts
@@ -89,7 +89,7 @@ interfaces:
     })
     .it('correctly displays prettyValidationErrors error message to screen in place of a stacktrace', ctx => {
       expect(ctx.stderr).to.contain('›  1 | name: validation_errors');
-      expect(ctx.stderr).to.contain('must contain only lower alphanumeric and single hyphens or underscores in the middle; max length 32');
+      expect(ctx.stderr).to.contain('must contain only lower alphanumeric and single hyphens in the middle; max length 32');
       expect(ctx.stdout).to.equal('');
     });
 

--- a/test/dependency-manager/validation.test.ts
+++ b/test/dependency-manager/validation.test.ts
@@ -428,7 +428,7 @@ services:
       expect(errors.map(e => e.path)).members([
         'name',
       ]);
-      expect(errors[0].message).includes('must contain only lower alphanumeric and single hyphens or underscores in the middle;');
+      expect(errors[0].message).includes('must contain only lower alphanumeric and single hyphens in the middle;');
       expect(errors[0].component).eq('test_component');
       expect(errors[0].start?.row).eq(2);
       expect(errors[0].start?.column).eq(12);


### PR DESCRIPTION
## Overview
Closes: https://gitlab.com/architect-io/architect-hub/-/issues/664
The slug description that verifies account name, cluster name, etc states that underscores are allowed but the regex contains no underscores. We want to remove the mention of underscores in that slug description.

## Changes
Remove mention of underscores in architect slug description.

