### PR TITLE
Added command to log ingress URLs associated with an environment

### DIFF
--- a/src/commands/environments/ingresses.ts
+++ b/src/commands/environments/ingresses.ts
@@ -1,0 +1,64 @@
+import AccountUtils from '../../architect/account/account.utils';
+import Environment from '../../architect/environment/environment.entity';
+import BaseCommand from '../../base-command';
+
+type CertificateResponse = {
+  spec: {
+    dnsNames: string[];
+  };
+  status: {
+    notAfter: Date;
+    notBefore: Date;
+    renewalTime: Date;
+  }
+};
+
+export default class GetEnvironmentIngressesCmd extends BaseCommand {
+  static description = 'List the resolvable URLs for services exposed by your environment';
+  static aliases = ['environment:ingresses', 'envs:ingresses', 'env:ingresses'];
+
+  static flags = {
+    ...BaseCommand.flags,
+    ...AccountUtils.flags,
+  };
+
+  static args = [
+    {
+      sensitive: false,
+      required: true,
+      name: 'environment',
+      description: 'Name to give the environment',
+      parse: async (value: string): Promise<string> => value.toLowerCase(),
+    },
+  ];
+
+  async run() {
+    const { args, flags } = await this.parse(GetEnvironmentIngressesCmd);
+
+    if (!flags.account) {
+      this.error(`Missing 1 required flag: --account`);
+    }
+
+    try {
+      const { data: environment } = await this.app.api.get<Environment>(`/accounts/${flags.account}/environments/${args.environment}`);
+      const { data: certificates } = await this.app.api.get<CertificateResponse[]>(`/environments/${environment.id}/certificates`);
+
+      if (certificates.length > 0) {
+        const dns_records: string[] = [];
+        for (const cert of certificates) {
+          for (const dns_name of cert.spec.dnsNames
+            .filter(dns_name => !dns_name.startsWith('env--'))) {
+              dns_records.push(dns_name);
+            }
+        }
+        this.log(
+          dns_records
+            .map(record => `https://${record}`)
+            .join('\r\n'),
+        );
+      }
+    } catch (err: any) {
+      this.error(`Environment not found`);
+    }
+  }
+}

--- a/src/commands/environments/ingresses.ts
+++ b/src/commands/environments/ingresses.ts
@@ -32,7 +32,7 @@ export default class GetEnvironmentIngressesCmd extends BaseCommand {
     },
   ];
 
-  async run() {
+  async run(): Promise<void> {
     const { args, flags } = await this.parse(GetEnvironmentIngressesCmd);
 
     if (!flags.account) {

--- a/test/commands/environments/destroy.test.ts
+++ b/test/commands/environments/destroy.test.ts
@@ -51,14 +51,14 @@ describe('environment:destroy', () => {
   failing_mock_test_strict
     .command(['environment:destroy', '--auto-approve', '--strict=true', '-a', mock_account.name, failing_mock_env.name])
     .catch(e => {
-      expect(e.message).to.contain('Request failed with status code 404');
+      expect(e.message).to.contain(`Environment '${failing_mock_env.name}' not found`);
     })
     .it('should exit with error status when --strict is set explicitly to true');
 
   failing_mock_test_strict
     .command(['environment:destroy', '--auto-approve', '--strict', '-a', mock_account.name, failing_mock_env.name])
     .catch(e => {
-      expect(e.message).to.contain('Request failed with status code 404');
+      expect(e.message).to.contain(`Environment '${failing_mock_env.name}' not found`);
     })
     .it('should exit with error status when --strict is passed without explicit mapping');
 

--- a/test/commands/task.test.ts
+++ b/test/commands/task.test.ts
@@ -137,7 +137,7 @@ describe('task:exec', async function () {
     .stderr({ print })
     .command(['task:exec', '-a', mock_account.name, '-e', bad_env_name, tagged_component_name, mock_task.name])
     .catch(err => {
-      expect(err.message).to.contain('No environment found')
+      expect(err.message).to.contain(`Environment '${bad_env_name}' not found`)
     })
     .it('fails with a useful message if given a bad environment name');
 


### PR DESCRIPTION
## Overview

Added a command to log ingress URLs so the URLs can more easily be pushed into PR comments on preview environments.

## Changes

New command:

```
$ architect environment:ingresses <environment-name> -a <account-name>
https://api.localhost.architect.sh
https://app.localhost.architect.sh
# ...
```

## Docs

* https://github.com/architect-team/architect-documentation/pull/39
* https://github.com/architect-team/documentation/pull/3