### PR TITLE
updating ci release message to not skip ci

### DIFF
--- a/.github/workflows/test-local-deploy.yml
+++ b/.github/workflows/test-local-deploy.yml
@@ -1,0 +1,38 @@
+name: Test local superset deployment
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  test_local:
+    name: Superset local deployment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'npm'
+      - run: sudo apt-get update && sudo apt-get install curl
+      - run: npm ci
+      - run: ./bin/dev --version
+      - run: ./bin/dev config:set registry_host registry.dev.architect.io
+      - run: ./bin/dev config:set api_host https://api.dev.architect.io
+      - run: ./bin/dev config:set log_level debug
+      - run: ./bin/dev login -e ${{ secrets.ARCHITECT_EMAIL }} -p ${{ secrets.ARCHITECT_PASSWORD }}
+      - run: docker volume create volume-key
+      - run: ./bin/dev link test/integration/hello-world/architect.yml
+      - run: ./bin/dev link test/mocks/superset/deprecated.architect.yml
+      - run: ./bin/dev dev -e superset test/mocks/superset/architect.yml --browser=false -s param_unset=test -s world_text=Architect > ./tmp.txt 2>&1 &
+      - run: sh scripts/server_online.sh
+      - name: Check that the app is accessible locally
+        run: curl --fail -S -I https://hello.localhost.architect.sh
+      - name: Check that the app returns the expected response
+        run: curl --fail -S https://hello.localhost.architect.sh | grep "Hello Architect!"
+      - name: Run a local task
+        run: ./bin/dev task superset curler-build --local -e superset

--- a/.github/workflows/test-remote-deploy.yml
+++ b/.github/workflows/test-remote-deploy.yml
@@ -1,42 +1,9 @@
-name: Test superset deployment
+name: Test remote superset deployment
 
 on:
-  pull_request:
-    types:
-      - opened
-      - edited
-      - synchronize
-      - reopened
+  workflow_dispatch:
 
 jobs:
-  test_local:
-    name: Superset local deployment
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-          cache: 'npm'
-      - run: sudo apt-get update && sudo apt-get install curl
-      - run: npm ci
-      - run: ./bin/dev --version
-      - run: ./bin/dev config:set registry_host registry.dev.architect.io
-      - run: ./bin/dev config:set api_host https://api.dev.architect.io
-      - run: ./bin/dev config:set log_level debug
-      - run: ./bin/dev login -e ${{ secrets.ARCHITECT_EMAIL }} -p ${{ secrets.ARCHITECT_PASSWORD }}
-      - run: docker volume create volume-key
-      - run: ./bin/dev link test/integration/hello-world/architect.yml
-      - run: ./bin/dev link test/mocks/superset/deprecated.architect.yml
-      - run: ./bin/dev dev -e superset test/mocks/superset/architect.yml --browser=false -s param_unset=test -s world_text=Architect > ./tmp.txt 2>&1 &
-      - run: sh scripts/server_online.sh
-      - name: Check that the app is accessible locally
-        run: curl --fail -S -I https://hello.localhost.architect.sh
-      - name: Check that the app returns the expected response
-        run: curl --fail -S https://hello.localhost.architect.sh | grep "Hello Architect!"
-      - name: Run a local task
-        run: ./bin/dev task superset curler-build --local -e superset
-
   test_remote:
     name: Superset remote deployment
     if: github.base_ref == 'main'

--- a/.github/workflows/test-remote-deploy.yml
+++ b/.github/workflows/test-remote-deploy.yml
@@ -2,6 +2,7 @@ name: Test remote superset deployment
 
 on:
   workflow_dispatch:
+
   pull_request:
     types:
       - opened

--- a/.github/workflows/test-remote-deploy.yml
+++ b/.github/workflows/test-remote-deploy.yml
@@ -2,6 +2,12 @@ name: Test remote superset deployment
 
 on:
   workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
 
 jobs:
   test_remote:

--- a/release.config.js
+++ b/release.config.js
@@ -14,7 +14,6 @@ const git = [
       'architect-yml.md',
       'src/dependency-manager/schema/architect.schema.json',
     ],
-    'message': `chore(release): \${nextRelease.version} ${branch === 'main' ? '' : '[skip ci]'}\n\n\${nextRelease.notes}`,
   },
 ];
 const exec = [

--- a/release.config.js
+++ b/release.config.js
@@ -14,6 +14,7 @@ const git = [
       'architect-yml.md',
       'src/dependency-manager/schema/architect.schema.json',
     ],
+    'message': 'chore(release): ${nextRelease.version}\n\n${nextRelease.notes}',
   },
 ];
 const exec = [

--- a/release.config.js
+++ b/release.config.js
@@ -14,7 +14,7 @@ const git = [
       'architect-yml.md',
       'src/dependency-manager/schema/architect.schema.json',
     ],
-    'message': 'chore(release): ${nextRelease.version}\n\n${nextRelease.notes}',
+    'message': `chore(release): \${nextRelease.version} ${branch === 'main' ? '' : '[skip ci]'}\n\n\${nextRelease.notes}`,
   },
 ];
 const exec = [


### PR DESCRIPTION
## Overview
GitHub workflows don't run the CI workflows if the `chore(release)` includes `[skip ci]` and was the last commit of the PR - ex. https://github.com/architect-team/architect-cli/pull/828

## Changes
* Updated default chore commit message to only skip ci on branches that aren't `main`
  * Docs - https://github.com/semantic-release/git#options