### PR TITLE
Enable strict engine for npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
       - run: npm run generate:yarn-lock
       - name: npm publish
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_PUBLISH_TOKEN }}" > .npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_PUBLISH_TOKEN }}" > ~/.npmrc
           GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) npm run semantic-release
       - name: docs website re-build
         run: curl -X POST ${{ secrets.NETLIFY_BUILD_HOOK_URL }}

--- a/package.json
+++ b/package.json
@@ -123,9 +123,11 @@
   "engines": {
     "node": ">=12"
   },
+  "engineStrict": true,
   "files": [
     "/bin",
     "/lib",
+    ".npmrc",
     "/npm-shrinkwrap.json",
     "/oclif.manifest.json"
   ],


### PR DESCRIPTION
## Overview
In our `package.json` file we specify a minimum supported version of node for our CLI. Though right now this just appears as a warning. In order to make it an error we need to enable `strict engine` mode which can only be done in the `.npmrc` file. 

## Changes
1. Make sure the `.npmrc` file is packed into the app.
2. Make sure we write our token to the home directory version of `.npmrc` so it does not get committed into our repo during a release. (Tested this locally but we should monitor for a problem during first release in case we need to rotate the key because something went wrong)
3. Also added the deprecated `package.json` flag for really old versions of npm.

## Tests
Test all the changes locally. Our checks actually worked using `npm link` because the file existed. Also double checked that the containers being used would use the correct home directory which does not use the app folder.