### PR TITLE
Add dev:restart command

### DIFF
--- a/src/commands/dev/restart.ts
+++ b/src/commands/dev/restart.ts
@@ -1,0 +1,90 @@
+import { Flags, Interfaces } from '@oclif/core';
+import BaseCommand from '../../base-command';
+import { DockerComposeUtils } from '../../common/docker-compose';
+import { RequiresDocker } from '../../common/docker/helper';
+import { EnvironmentUtils } from '../../architect/environment/environment.utils';
+import inquirer from 'inquirer';
+import chalk from 'chalk';
+
+export default class DevRestart extends BaseCommand {
+  async auth_required(): Promise<boolean> {
+    return false;
+  }
+
+  static description = 'Restart or rebuild a running service';
+  static examples = [
+    'architect dev:restart',
+    'architect dev:restart --build hello-world.services.api',
+    'architect dev:restart hello-world.services.api hello-world.services.app',
+  ];
+
+  static flags = {
+    ...EnvironmentUtils.flags,
+    build: Flags.boolean({
+      char: 'b',
+      description: 'Rebuild the services image before restarting',
+      default: false,
+    }),
+  };
+
+  static args = [{
+    sensitive: false,
+    name: 'services',
+    description: 'Name of the service(s) to restart',
+    required: false,
+  }];
+
+  // overrides the oclif default parse to allow for args.services to be a list of services
+  async parse<F, A extends {
+    [name: string]: any;
+  }>(options?: Interfaces.Input<F, A>, argv = this.argv): Promise<Interfaces.ParserOutput<F, A>> {
+    if (!options) {
+      return super.parse(options, argv);
+    }
+    options.args = [];
+    for (const _ of argv) {
+      options.args.push({ name: 'filler' });
+    }
+    const parsed = await super.parse(options, argv) as Interfaces.ParserOutput<F, A>;
+    if (parsed.argv.length > 0) {
+      parsed.args.services = parsed.argv;
+    } else {
+      parsed.args.services = [];
+    }
+    return parsed;
+  }
+
+  @RequiresDocker({ compose: true })
+  async run(): Promise<void> {
+    // eslint-disable-next-line unicorn/prefer-module
+    inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'));
+
+    const { args, flags } = await this.parse(DevRestart);
+
+    const environment_name = await DockerComposeUtils.getLocalEnvironment(this.app.config.getConfigDir(), flags.environment);
+    const compose_file = DockerComposeUtils.buildComposeFilepath(this.app.config.getConfigDir(), environment_name);
+
+    // Convert service names to their resource name used by docker compose
+    const compose_services = [];
+    if (args.services.length > 0) {
+      for (const service_name of args.services) {
+        // Handles validating that the service supplied exists in the compose file -- throws an error if invalid
+        const service = await DockerComposeUtils.getLocalServiceForEnvironment(compose_file, service_name);
+        compose_services.push(service.name);
+      }
+    } else {
+      const service = await DockerComposeUtils.getLocalServiceForEnvironment(compose_file);
+      compose_services.push(service.name);
+    }
+
+    let compose_args;
+    if (flags.build) {
+      compose_args = ['-f', compose_file, '-p', environment_name, 'up', '--build', '--force-recreate', '--detach', ...compose_services];
+    } else {
+      compose_args = ['-f', compose_file, '-p', environment_name, 'restart', ...compose_services];
+    }
+
+    await DockerComposeUtils.dockerCompose(compose_args, { stdio: 'inherit' });
+    this.log(chalk.green(`Finished ${flags.build ? 'rebuilding' : 'restarting'}.`));
+  }
+}

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -108,7 +108,7 @@ export class DockerComposeUtils {
       }
 
       compose.services[gateway_node.ref] = {
-        image: 'traefik:v2.6.2',
+        image: 'traefik:v2.9.8',
         command: [
           '--api.insecure=true',
           '--pilot.dashboard=false',
@@ -118,6 +118,7 @@ export class DockerComposeUtils {
           '--accesslog.filters.statusCodes=400-599',
           `--entryPoints.web.address=:${gateway_port}`,
           '--providers.docker=true',
+          '--providers.docker.allowEmptyServices=true',
           '--providers.docker.exposedByDefault=false',
           `--providers.docker.constraints=Label(\`traefik.port\`,\`${gateway_port}\`)`,
           ...(ssl_cert && ssl_key ? [

--- a/test/commands/dev/index.test.ts
+++ b/test/commands/dev/index.test.ts
@@ -478,7 +478,7 @@ describe('local dev environment', function () {
         labels: ['architect.ref=database-seeding.services.my-demo-db'],
       },
       'gateway': {
-        'image': 'traefik:v2.6.2',
+        'image': 'traefik:v2.9.8',
         'command': [
           '--api.insecure=true',
           '--pilot.dashboard=false',
@@ -487,6 +487,7 @@ describe('local dev environment', function () {
           '--accesslog.filters.statusCodes=400-599',
           '--entryPoints.web.address=:80',
           '--providers.docker=true',
+          '--providers.docker.allowEmptyServices=true',
           '--providers.docker.exposedByDefault=false',
           '--providers.docker.constraints=Label(`traefik.port`,`80`)',
         ],
@@ -535,7 +536,7 @@ describe('local dev environment', function () {
         },
       },
       'gateway': {
-        'image': 'traefik:v2.6.2',
+        'image': 'traefik:v2.9.8',
         'command': [
           '--api.insecure=true',
           '--pilot.dashboard=false',
@@ -544,6 +545,7 @@ describe('local dev environment', function () {
           '--accesslog.filters.statusCodes=400-599',
           '--entryPoints.web.address=:80',
           '--providers.docker=true',
+          '--providers.docker.allowEmptyServices=true',
           '--providers.docker.exposedByDefault=false',
           '--providers.docker.constraints=Label(`traefik.port`,`80`)',
         ],
@@ -592,7 +594,7 @@ describe('local dev environment', function () {
         },
       },
       'gateway': {
-        'image': 'traefik:v2.6.2',
+        'image': 'traefik:v2.9.8',
         'command': [
           '--api.insecure=true',
           '--pilot.dashboard=false',
@@ -601,6 +603,7 @@ describe('local dev environment', function () {
           '--accesslog.filters.statusCodes=400-599',
           '--entryPoints.web.address=:443',
           '--providers.docker=true',
+          '--providers.docker.allowEmptyServices=true',
           '--providers.docker.exposedByDefault=false',
           '--providers.docker.constraints=Label(`traefik.port`,`443`)',
           '--serversTransport.insecureSkipVerify=true',
@@ -660,7 +663,7 @@ describe('local dev environment', function () {
         },
       },
       "gateway": {
-        "image": "traefik:v2.6.2",
+        "image": "traefik:v2.9.8",
         "command": [
           "--api.insecure=true",
           "--pilot.dashboard=false",
@@ -669,6 +672,7 @@ describe('local dev environment', function () {
           "--accesslog.filters.statusCodes=400-599",
           "--entryPoints.web.address=:80",
           "--providers.docker=true",
+          "--providers.docker.allowEmptyServices=true",
           "--providers.docker.exposedByDefault=false",
           "--providers.docker.constraints=Label(`traefik.port`,`80`)",
         ],
@@ -777,7 +781,7 @@ describe('local dev environment', function () {
         ]
       },
       "gateway": {
-        "image": "traefik:v2.6.2",
+        "image": "traefik:v2.9.8",
         "command": [
           "--api.insecure=true",
           "--pilot.dashboard=false",
@@ -786,6 +790,7 @@ describe('local dev environment', function () {
           "--accesslog.filters.statusCodes=400-599",
           "--entryPoints.web.address=:80",
           "--providers.docker=true",
+          "--providers.docker.allowEmptyServices=true",
           "--providers.docker.exposedByDefault=false",
           "--providers.docker.constraints=Label(`traefik.port`,`80`)",
         ],

--- a/test/commands/dev/restart.test.ts
+++ b/test/commands/dev/restart.test.ts
@@ -1,0 +1,54 @@
+import { expect } from '@oclif/test';
+import sinon, { SinonSpy } from 'sinon';
+import DevRestart from '../../../src/commands/dev/restart';
+import { DockerComposeUtils } from '../../../src/common/docker-compose';
+import { mockArchitectAuth } from '../../utils/mocks';
+
+describe('dev:restart', () => {
+  // set to true while working on tests for easier debugging; otherwise oclif/test eats the stdout/stderr
+  const print = true;
+
+  const test_env_name = 'test_env';
+  const test_service_name = 'test--service';
+
+  mockArchitectAuth()
+    .stub(DockerComposeUtils, 'getLocalEnvironment', sinon.stub().returns(test_env_name))
+    .stub(DevRestart.prototype, 'log', sinon.fake.returns(null))
+    .stub(DockerComposeUtils, 'getLocalServiceForEnvironment', sinon.stub().returns({ name: test_service_name }))
+    .stub(DockerComposeUtils, 'dockerCompose', sinon.stub().returns(null))
+    .command(['dev:restart'])
+    .it('restart a service with no args', ctx => {
+      const log_spy = DevRestart.prototype.log as SinonSpy;
+      expect(log_spy.firstCall.args[0]).to.contain('Finished restarting');
+
+      const compose_local_svc = DockerComposeUtils.getLocalServiceForEnvironment as sinon.SinonStub;
+      expect(compose_local_svc.callCount).to.eq(1);
+      // dev:restart with no args calls getLocalServiceForEnvironment with 1 arg to prompt service name
+      expect(compose_local_svc.firstCall.args.length).to.eq(1);
+
+      const compose = DockerComposeUtils.dockerCompose as sinon.SinonStub;
+      expect(compose.firstCall.args.length).to.eq(2);
+      expect(compose.firstCall.args[0]).to.deep.equal(['-f', `test/docker-compose/${test_env_name}.yml`, '-p', test_env_name, 'restart', test_service_name]);
+    });
+
+  mockArchitectAuth()
+    .stub(DockerComposeUtils, 'getLocalEnvironment', sinon.stub().returns(test_env_name))
+    .stub(DevRestart.prototype, 'log', sinon.fake.returns(null))
+    .stub(DockerComposeUtils, 'getLocalServiceForEnvironment', sinon.stub().returns({ name: test_service_name }))
+    .stub(DockerComposeUtils, 'dockerCompose', sinon.stub().returns(null))
+    .command(['dev:restart', '--build'])
+    .it('rebuild a service with no args', ctx => {
+      const log_spy = DevRestart.prototype.log as SinonSpy;
+      expect(log_spy.firstCall.args[0]).to.contain('Finished rebuilding');
+
+      const compose_local_svc = DockerComposeUtils.getLocalServiceForEnvironment as sinon.SinonStub;
+      expect(compose_local_svc.callCount).to.eq(1);
+      // dev:restart with no args calls getLocalServiceForEnvironment with 1 arg to prompt service name
+      expect(compose_local_svc.firstCall.args.length).to.eq(1);
+
+      const compose = DockerComposeUtils.dockerCompose as sinon.SinonStub;
+      expect(compose.firstCall.args.length).to.eq(2);
+      expect(compose.firstCall.args[0]).to.deep.equal(['-f', `test/docker-compose/${test_env_name}.yml`,
+        '-p', test_env_name, 'up', '--build', '--force-recreate', '--detach', test_service_name]);
+    });
+});

--- a/test/commands/dev/restart.test.ts
+++ b/test/commands/dev/restart.test.ts
@@ -3,6 +3,7 @@ import sinon, { SinonSpy } from 'sinon';
 import DevRestart from '../../../src/commands/dev/restart';
 import { DockerComposeUtils } from '../../../src/common/docker-compose';
 import { mockArchitectAuth } from '../../utils/mocks';
+import path from 'path';
 
 describe('dev:restart', () => {
   // set to true while working on tests for easier debugging; otherwise oclif/test eats the stdout/stderr
@@ -33,10 +34,10 @@ describe('dev:restart', () => {
       expect(compose_local_svc.firstCall.args.length).to.eq(1);
 
       const compose = DockerComposeUtils.dockerCompose as sinon.SinonStub;
+      const compose_path = path.join('test', 'docker-compose', `${test_env_name}.yml`);
       expect(compose.firstCall.args.length).to.eq(2);
       expect(compose.firstCall.args[0]).to.deep.equal([
-        '-f', `test/docker-compose/${test_env_name}.yml`,
-        '-p', test_env_name, 'restart', test_service_name,
+        '-f', compose_path, '-p', test_env_name, 'restart', test_service_name,
       ]);
     });
 
@@ -56,10 +57,10 @@ describe('dev:restart', () => {
       expect(compose_local_svc.firstCall.args[1]).to.eq('test.service.name');
 
       const compose = DockerComposeUtils.dockerCompose as sinon.SinonStub;
+      const compose_path = path.join('test', 'docker-compose', `${test_env_name}.yml`);
       expect(compose.firstCall.args.length).to.eq(2);
       expect(compose.firstCall.args[0]).to.deep.equal([
-        '-f', `test/docker-compose/${test_env_name}.yml`,
-        '-p', test_env_name, 'restart', test_service_name,
+        '-f', compose_path, '-p', test_env_name, 'restart', test_service_name,
       ]);
     });
 
@@ -80,10 +81,10 @@ describe('dev:restart', () => {
       expect(compose_local_svc.lastCall.args[1]).to.eq('test2.service.name');
 
       const compose = DockerComposeUtils.dockerCompose as sinon.SinonStub;
+      const compose_path = path.join('test', 'docker-compose', `${test_env_name}.yml`);
       expect(compose.firstCall.args.length).to.eq(2);
       expect(compose.firstCall.args[0]).to.deep.equal([
-        '-f', `test/docker-compose/${test_env_name}.yml`, '-p',
-        test_env_name, 'restart', test_service_name, test_service_name_2,
+        '-f', compose_path, '-p', test_env_name, 'restart', test_service_name, test_service_name_2,
       ]);
     });
 
@@ -103,9 +104,11 @@ describe('dev:restart', () => {
       expect(compose_local_svc.firstCall.args.length).to.eq(1);
 
       const compose = DockerComposeUtils.dockerCompose as sinon.SinonStub;
+      const compose_path = path.join('test', 'docker-compose', `${test_env_name}.yml`);
       expect(compose.firstCall.args.length).to.eq(2);
-      expect(compose.firstCall.args[0]).to.deep.equal(['-f', `test/docker-compose/${test_env_name}.yml`,
-        '-p', test_env_name, 'up', '--build', '--force-recreate', '--detach', test_service_name]);
+      expect(compose.firstCall.args[0]).to.deep.equal([
+        '-f', compose_path, '-p', test_env_name, 'up', '--build', '--force-recreate', '--detach', test_service_name,
+      ]);
     });
 
   mockArchitectAuth()
@@ -124,9 +127,11 @@ describe('dev:restart', () => {
       expect(compose_local_svc.firstCall.args[1]).to.eq('test.service.name');
 
       const compose = DockerComposeUtils.dockerCompose as sinon.SinonStub;
+      const compose_path = path.join('test', 'docker-compose', `${test_env_name}.yml`);
       expect(compose.firstCall.args.length).to.eq(2);
-      expect(compose.firstCall.args[0]).to.deep.equal(['-f', `test/docker-compose/${test_env_name}.yml`,
-        '-p', test_env_name, 'up', '--build', '--force-recreate', '--detach', test_service_name]);
+      expect(compose.firstCall.args[0]).to.deep.equal([
+        '-f', compose_path, '-p', test_env_name, 'up', '--build', '--force-recreate', '--detach', test_service_name,
+      ]);
     });
 
   mockArchitectAuth()
@@ -146,10 +151,10 @@ describe('dev:restart', () => {
       expect(compose_local_svc.lastCall.args[1]).to.eq('test2.service.name');
 
       const compose = DockerComposeUtils.dockerCompose as sinon.SinonStub;
+      const compose_path = path.join('test', 'docker-compose', `${test_env_name}.yml`);
       expect(compose.firstCall.args.length).to.eq(2);
       expect(compose.firstCall.args[0]).to.deep.equal([
-        '-f', `test/docker-compose/${test_env_name}.yml`,
-        '-p', test_env_name, 'up', '--build', '--force-recreate',
+        '-f', compose_path, '-p', test_env_name, 'up', '--build', '--force-recreate',
         '--detach', test_service_name, test_service_name_2,
       ]);
     });

--- a/test/commands/dev/restart.test.ts
+++ b/test/commands/dev/restart.test.ts
@@ -10,11 +10,17 @@ describe('dev:restart', () => {
 
   const test_env_name = 'test_env';
   const test_service_name = 'test--service';
+  const test_service_name_2 = 'test--service-2';
+
+  // Helper stubs for the result of getLocalServiceForEnvironment() in various situations
+  const local_service_result = () => sinon.stub().returns({ name: test_service_name });
+  const multiarg_local_service_result = () => sinon.stub().onCall(0).returns({ name: test_service_name })
+    .onCall(1).returns({ name: test_service_name_2 });
 
   mockArchitectAuth()
     .stub(DockerComposeUtils, 'getLocalEnvironment', sinon.stub().returns(test_env_name))
     .stub(DevRestart.prototype, 'log', sinon.fake.returns(null))
-    .stub(DockerComposeUtils, 'getLocalServiceForEnvironment', sinon.stub().returns({ name: test_service_name }))
+    .stub(DockerComposeUtils, 'getLocalServiceForEnvironment', local_service_result())
     .stub(DockerComposeUtils, 'dockerCompose', sinon.stub().returns(null))
     .command(['dev:restart'])
     .it('restart a service with no args', ctx => {
@@ -28,13 +34,63 @@ describe('dev:restart', () => {
 
       const compose = DockerComposeUtils.dockerCompose as sinon.SinonStub;
       expect(compose.firstCall.args.length).to.eq(2);
-      expect(compose.firstCall.args[0]).to.deep.equal(['-f', `test/docker-compose/${test_env_name}.yml`, '-p', test_env_name, 'restart', test_service_name]);
+      expect(compose.firstCall.args[0]).to.deep.equal([
+        '-f', `test/docker-compose/${test_env_name}.yml`,
+        '-p', test_env_name, 'restart', test_service_name,
+      ]);
     });
 
   mockArchitectAuth()
     .stub(DockerComposeUtils, 'getLocalEnvironment', sinon.stub().returns(test_env_name))
     .stub(DevRestart.prototype, 'log', sinon.fake.returns(null))
-    .stub(DockerComposeUtils, 'getLocalServiceForEnvironment', sinon.stub().returns({ name: test_service_name }))
+    .stub(DockerComposeUtils, 'getLocalServiceForEnvironment', local_service_result())
+    .stub(DockerComposeUtils, 'dockerCompose', sinon.stub().returns(null))
+    .command(['dev:restart', 'test.service.name'])
+    .it('restart a service with single arg', ctx => {
+      const log_spy = DevRestart.prototype.log as SinonSpy;
+      expect(log_spy.firstCall.args[0]).to.contain('Finished restarting');
+
+      const compose_local_svc = DockerComposeUtils.getLocalServiceForEnvironment as sinon.SinonStub;
+      expect(compose_local_svc.callCount).to.eq(1);
+      expect(compose_local_svc.firstCall.args.length).to.eq(2);
+      expect(compose_local_svc.firstCall.args[1]).to.eq('test.service.name');
+
+      const compose = DockerComposeUtils.dockerCompose as sinon.SinonStub;
+      expect(compose.firstCall.args.length).to.eq(2);
+      expect(compose.firstCall.args[0]).to.deep.equal([
+        '-f', `test/docker-compose/${test_env_name}.yml`,
+        '-p', test_env_name, 'restart', test_service_name,
+      ]);
+    });
+
+  mockArchitectAuth()
+    .stub(DockerComposeUtils, 'getLocalEnvironment', sinon.stub().returns(test_env_name))
+    .stub(DevRestart.prototype, 'log', sinon.fake.returns(null))
+    .stub(DockerComposeUtils, 'getLocalServiceForEnvironment', multiarg_local_service_result())
+    .stub(DockerComposeUtils, 'dockerCompose', sinon.stub().returns(null))
+    .command(['dev:restart', 'test.service.name', 'test2.service.name'])
+    .it('restart a service with multiple args', ctx => {
+      const log_spy = DevRestart.prototype.log as SinonSpy;
+      expect(log_spy.firstCall.args[0]).to.contain('Finished restarting');
+
+      const compose_local_svc = DockerComposeUtils.getLocalServiceForEnvironment as sinon.SinonStub;
+      expect(compose_local_svc.callCount).to.eq(2);
+      expect(compose_local_svc.firstCall.args.length).to.eq(2);
+      expect(compose_local_svc.firstCall.args[1]).to.eq('test.service.name');
+      expect(compose_local_svc.lastCall.args[1]).to.eq('test2.service.name');
+
+      const compose = DockerComposeUtils.dockerCompose as sinon.SinonStub;
+      expect(compose.firstCall.args.length).to.eq(2);
+      expect(compose.firstCall.args[0]).to.deep.equal([
+        '-f', `test/docker-compose/${test_env_name}.yml`, '-p',
+        test_env_name, 'restart', test_service_name, test_service_name_2,
+      ]);
+    });
+
+  mockArchitectAuth()
+    .stub(DockerComposeUtils, 'getLocalEnvironment', sinon.stub().returns(test_env_name))
+    .stub(DevRestart.prototype, 'log', sinon.fake.returns(null))
+    .stub(DockerComposeUtils, 'getLocalServiceForEnvironment', local_service_result())
     .stub(DockerComposeUtils, 'dockerCompose', sinon.stub().returns(null))
     .command(['dev:restart', '--build'])
     .it('rebuild a service with no args', ctx => {
@@ -50,5 +106,51 @@ describe('dev:restart', () => {
       expect(compose.firstCall.args.length).to.eq(2);
       expect(compose.firstCall.args[0]).to.deep.equal(['-f', `test/docker-compose/${test_env_name}.yml`,
         '-p', test_env_name, 'up', '--build', '--force-recreate', '--detach', test_service_name]);
+    });
+
+  mockArchitectAuth()
+    .stub(DockerComposeUtils, 'getLocalEnvironment', sinon.stub().returns(test_env_name))
+    .stub(DevRestart.prototype, 'log', sinon.fake.returns(null))
+    .stub(DockerComposeUtils, 'getLocalServiceForEnvironment', local_service_result())
+    .stub(DockerComposeUtils, 'dockerCompose', sinon.stub().returns(null))
+    .command(['dev:restart', '--build', 'test.service.name'])
+    .it('rebuild a service with single arg', ctx => {
+      const log_spy = DevRestart.prototype.log as SinonSpy;
+      expect(log_spy.firstCall.args[0]).to.contain('Finished rebuilding');
+
+      const compose_local_svc = DockerComposeUtils.getLocalServiceForEnvironment as sinon.SinonStub;
+      expect(compose_local_svc.callCount).to.eq(1);
+      expect(compose_local_svc.firstCall.args.length).to.eq(2);
+      expect(compose_local_svc.firstCall.args[1]).to.eq('test.service.name');
+
+      const compose = DockerComposeUtils.dockerCompose as sinon.SinonStub;
+      expect(compose.firstCall.args.length).to.eq(2);
+      expect(compose.firstCall.args[0]).to.deep.equal(['-f', `test/docker-compose/${test_env_name}.yml`,
+        '-p', test_env_name, 'up', '--build', '--force-recreate', '--detach', test_service_name]);
+    });
+
+  mockArchitectAuth()
+    .stub(DockerComposeUtils, 'getLocalEnvironment', sinon.stub().returns(test_env_name))
+    .stub(DevRestart.prototype, 'log', sinon.fake.returns(null))
+    .stub(DockerComposeUtils, 'getLocalServiceForEnvironment', multiarg_local_service_result())
+    .stub(DockerComposeUtils, 'dockerCompose', sinon.stub().returns(null))
+    .command(['dev:restart', '--build', 'test.service.name', 'test2.service.name'])
+    .it('rebuild a service with multiple args', ctx => {
+      const log_spy = DevRestart.prototype.log as SinonSpy;
+      expect(log_spy.firstCall.args[0]).to.contain('Finished rebuilding');
+
+      const compose_local_svc = DockerComposeUtils.getLocalServiceForEnvironment as sinon.SinonStub;
+      expect(compose_local_svc.callCount).to.eq(2);
+      expect(compose_local_svc.firstCall.args.length).to.eq(2);
+      expect(compose_local_svc.firstCall.args[1]).to.eq('test.service.name');
+      expect(compose_local_svc.lastCall.args[1]).to.eq('test2.service.name');
+
+      const compose = DockerComposeUtils.dockerCompose as sinon.SinonStub;
+      expect(compose.firstCall.args.length).to.eq(2);
+      expect(compose.firstCall.args[0]).to.deep.equal([
+        '-f', `test/docker-compose/${test_env_name}.yml`,
+        '-p', test_env_name, 'up', '--build', '--force-recreate',
+        '--detach', test_service_name, test_service_name_2,
+      ]);
     });
 });

--- a/test/commands/dev/restart.test.ts
+++ b/test/commands/dev/restart.test.ts
@@ -6,7 +6,7 @@ import { mockArchitectAuth } from '../../utils/mocks';
 
 describe('dev:restart', () => {
   // set to true while working on tests for easier debugging; otherwise oclif/test eats the stdout/stderr
-  const print = true;
+  const print = false;
 
   const test_env_name = 'test_env';
   const test_service_name = 'test--service';

--- a/test/commands/dev/stop.test.ts
+++ b/test/commands/dev/stop.test.ts
@@ -7,7 +7,6 @@ import { DockerComposeUtils } from '../../../src/common/docker-compose';
 import { mockArchitectAuth } from '../../utils/mocks';
 
 describe('dev:stop', () => {
-
   // set to true while working on tests for easier debugging; otherwise oclif/test eats the stdout/stderr
   const print = false;
 
@@ -21,16 +20,12 @@ describe('dev:stop', () => {
       State: 'exited',
       Health: '',
       ExitCode: 0,
-    }
-  ]
+    },
+  ];
 
   const mocked_connection = {
-    write: () => {
-      return;
-    },
-    on: () => {
-      return;
-    }
+    write: () => { },  // eslint-disable-line @typescript-eslint/no-empty-function
+    on: () => { },  // eslint-disable-line @typescript-eslint/no-empty-function
   };
 
   mockArchitectAuth()
@@ -42,7 +37,7 @@ describe('dev:stop', () => {
     .command(['dev:stop', 'test_env'])
     .it('stop a local deployment', ctx => {
       const log_spy = DevStop.prototype.log as SinonSpy;
-      expect(log_spy.firstCall.args[0]).to.contain("Successfully stopped local deployment");
+      expect(log_spy.firstCall.args[0]).to.contain('Successfully stopped local deployment');
 
       const connect = net.createConnection as sinon.SinonStub;
       expect(connect.callCount).to.eq(1);
@@ -59,7 +54,7 @@ describe('dev:stop', () => {
     .command(['dev:stop', 'test_env'])
     .it('stop a detached local deployment and remove left over compose file from when it started', ctx => {
       const log_spy = DevStop.prototype.log as SinonSpy;
-      expect(log_spy.firstCall.args[0]).to.contain("Successfully stopped local deployment");
+      expect(log_spy.firstCall.args[0]).to.contain('Successfully stopped local deployment');
 
       const remove_sync = fs.removeSync as sinon.SinonStub;
       expect(remove_sync.calledOnce).true;


### PR DESCRIPTION
## Overview

Adds the `dev:restart` command to rebuild or just restart a service running via `architect dev`

ex. `architect dev:restart --build hello-world.services.api` will rebuild the image for the api service of the hello-world component and restart it without needing to restart `architect dev`.

This also bumps the version of traefic to v2.9.8 to make use of the `providers.docker.allowEmptyServices` flag, which helps make the UX less confusing (preventing traefic from "forgetting" about the service until after a liveness probe passes, which also enables us to make a custom traefik error page to inform the user that nothing is broken)


## Testing

Two biggest test cases are
- A service without a liveness probe
- A service with a liveness probe

A service that starts quickly and has no liveness probe will be available almost immediate after restarting/rebuilding. If it has no liveness probe but has some startup time, it will obviously fail in some way until that startup is done, just like what would happen normally when running `architect dev`. If it has a liveness probe, there's a delay before the probe is checked initially so it will take ~5-10s before something is available again - during this time, Traefik will return a 500 when trying to reach the service, and this is the main spot that https://gitlab.com/architect-io/architect-cli/-/issues/627 will help with (adding a traefik error page that can tell the user that the service is not yet available but is currently restarting)