### PR TITLE
Depends on now supports dictionaries

### DIFF
--- a/src/common/docker-compose/converter.ts
+++ b/src/common/docker-compose/converter.ts
@@ -248,8 +248,12 @@ export class ComposeConverter {
   }
 
   private static convertDependsOn(depends_on_or_links: any, docker_compose: DockerComposeTemplate, architect_service: ServiceSpec): ComposeConversion {
-    if (depends_on_or_links.length === 0) {
+    if (!depends_on_or_links) {
       return {};
+    }
+
+    if (!Array.isArray(depends_on_or_links)) {
+      depends_on_or_links = Object.keys(depends_on_or_links);
     }
 
     const depends_on: string[] = [];

--- a/test/mocks/init-compose.yml
+++ b/test/mocks/init-compose.yml
@@ -106,7 +106,8 @@ services:
     networks:
       - elk
     depends_on:
-      - elasticsearch
+      elasticsearch:
+        condition: service_started
     environment:
       - DB_TYPE=postgres
       - DB_HOST # warning, invalid


### PR DESCRIPTION
## Overview
Docker compose import no longer breaks when the depends_on is a dictionary instead of an array.


## Changes
Fixed the issue


## Tests
```
services:
  web:
    build: .
    depends_on:
      db:
        condition: service_healthy
      redis:
        condition: service_started
  redis:
    image: redis
  db:
    image: postgres
```
Also modified a unit tests data to make sure this works.