### PR TITLE
Prevent liveness probes causing dev to think something is healthy immediately

### DIFF
--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -414,7 +414,17 @@ export default class Dev extends BaseCommand {
       if (service.status !== 'enabled') return false;
       if (!service.serverStatus) return false;
       if (service.provider !== 'docker') return false;
-      return Object.values(service.serverStatus).includes('UP');
+
+      let healthy = false;
+      for (const key in service.serverStatus) {
+        // When a liveness probe is running, service.serverStatus[key] will be 'UP'
+        // but the key will be an empty string. The service isn't available via the traefik URL
+        // until the key is no longer ''.
+        if (key !== '' && service.serverStatus[key] === 'UP') {
+          healthy = true;
+        }
+      }
+      return healthy;
     });
     return healthy_services;
   }


### PR DESCRIPTION
https://gitlab.com/architect-io/architect-cli/-/issues/630

The `serverStatus` object has a key with the service IP/port and a status like 'UP'. When there's a liveness probe and it's failing, it looks like this:
```ts
  serverStatus: { '': 'UP' },
```

so we incorrectly said it was healthy just because UP existed. But, UP exists because we tell traefik `allowEmptyServices` now.

Once the service has URL:
```ts
  serverStatus: { 'http://172.18.0.2:8080': 'UP' },
```

the liveness probe actually passed and we can now say it's healthy and open links in the browser.