### PR TITLE
Databases redacted secrets

### DIFF
--- a/src/dependency-manager/utils/parser.ts
+++ b/src/dependency-manager/utils/parser.ts
@@ -199,7 +199,8 @@ export class ArchitectParser {
           } else if (node.callee.value === 'parseUrl') {
             // Handle the edge case where connection_string is set to a secret but no value
             // is set on the secret or the secret is redacted we can just move forward
-            if (!node.arguments[0].value || node.arguments[0].value === '*******') {
+            const redacted_regex = /\**/g;
+            if (!node.arguments[0].value || redacted_regex.test(node.arguments[0].value)) {
               value = '';
             } else {
               try {

--- a/src/dependency-manager/utils/parser.ts
+++ b/src/dependency-manager/utils/parser.ts
@@ -206,7 +206,7 @@ export class ArchitectParser {
               try {
                 value = (new URL(node.arguments[0].value) as any)[node.arguments[1].value as string];
               } catch {
-                throw new Error(`Unable to parse url ${node.arguments[0].valu}.`);
+                throw new Error(`Unable to parse url ${node.arguments[0].value}.`);
               }
             }
           } else {

--- a/src/dependency-manager/utils/parser.ts
+++ b/src/dependency-manager/utils/parser.ts
@@ -198,14 +198,14 @@ export class ArchitectParser {
             value = node.arguments[0].value.startsWith(node.arguments[1].value);
           } else if (node.callee.value === 'parseUrl') {
             // Handle the edge case where connection_string is set to a secret but no value
-            // is set on the secret.
-            if (!node.arguments[0].value) {
+            // is set on the secret or the secret is redacted we can just move forward
+            if (!node.arguments[0].value || node.arguments[0].value === '*******') {
               value = '';
             } else {
               try {
                 value = (new URL(node.arguments[0].value) as any)[node.arguments[1].value as string];
               } catch {
-                throw new Error(`Unable to parse url ${value}.`);
+                throw new Error(`Unable to parse url ${node.arguments[0].valu}.`);
               }
             }
           } else {

--- a/test/dependency-manager/components.test.ts
+++ b/test/dependency-manager/components.test.ts
@@ -1148,6 +1148,44 @@ describe('components spec v1', function () {
       expect(graph.edges).to.have.length(1);
     });
 
+    it('throw error if database override not a valid url', async () => {
+      const yml = `
+        name: component
+
+        databases:
+          primary:
+            type: mariadb:10
+            connection_string: \${{ secrets.dbOverride }}
+
+        services:
+          api:
+            image: test:v1
+            environment:
+              DATABASE: \${{ databases.primary.connection_string }}
+        `;
+
+      mock_fs({
+        '/architect.yaml': yml,
+      });
+
+      const manager = new LocalDependencyManager(axios.create(), 'examples', {
+        'component': '/architect.yaml',
+      });
+
+      let error;
+      try {
+        await manager.getGraph([
+          ...await manager.loadComponentSpecs('component'),
+        ], {
+          '*': { 'dbOverride': 'garbage' }
+        })
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).to.be.instanceOf(ValidationErrors);
+    });
+
     it('throw error if database and service names collide', async () => {
       const yml = `
         name: component


### PR DESCRIPTION
## Overview
So we sometimes use redacted secrets and run validation. This allows redacted secrets to be valid for `parseUrl`. I am not 100% satisfied with this solution, but this can be reconsidered when we come back to configuration.


## Changes
1. Allow `*`'s as a valid input for parseUrl
2. Added a missing unit test


## Tests
Created `arc-databases-2` to test on the api and it all works.