### PR TITLE
Add starter flag to init command

### DIFF
--- a/src/architect/project/project.utils.ts
+++ b/src/architect/project/project.utils.ts
@@ -2,9 +2,8 @@ import axios from 'axios';
 import chalk from 'chalk';
 import execa from 'execa';
 import inquirer from 'inquirer';
-import PromptUtils from '../../common/utils/prompt-utils';
-import { Dictionary } from '../../dependency-manager/utils/dictionary';
 import inquirerPrompt from 'inquirer-autocomplete-prompt';
+import PromptUtils from '../../common/utils/prompt-utils';
 import LocalPaths from '../../paths';
 
 interface Selection {
@@ -15,7 +14,16 @@ interface Selection {
 }
 
 export default class ProjectUtils {
-  static async prompt(choices: Selection[], message: string): Promise<Selection> {
+  static async prompt(choices: Selection[], default_project_name: string, message: string): Promise<Selection> {
+    if (default_project_name) {
+      const possible_selection = choices.find(c => c.name.toLowerCase() === default_project_name.toLowerCase());
+      if (possible_selection) {
+        return possible_selection;
+      } else {
+        console.log(chalk.yellow(`Could not find starter project type with name ${default_project_name}`));
+      }
+    }
+
     inquirer.registerPrompt('autocomplete', inquirerPrompt);
     const answers: { selected: any } = await inquirer.prompt([
       {
@@ -43,10 +51,10 @@ export default class ProjectUtils {
 
   static async fetchJsonFromGitHub(url: string): Promise<Selection[]> {
     const response = await axios.get(url)
-    .then((res: any) => res.data)
-    .catch((err: any) => {
-      throw new Error(`Failed to fetch ${url}`);
-    });
+      .then((res: any) => res.data)
+      .catch((err: any) => {
+        throw new Error(`Failed to fetch ${url}`);
+      });
     return response.choices as Selection[];
   }
 
@@ -56,18 +64,18 @@ export default class ProjectUtils {
       await execa('git', ['clone', selection.repository.toString(), project_dir], { stdio: 'ignore' });
       await PromptUtils.oclifTimedSpinner(
         `Pulling down GitHub repository`,
-         selection.name.toLowerCase(),
+        selection.name.toLowerCase(),
         `${chalk.green('✓')} ${selection.name.toLowerCase()}`,
       );
     }
   }
 
-  static async getSelections(): Promise<Selection> {
+  static async getSelections(starter_template_name: string): Promise<Selection> {
     // get choices from template-configs repository
     const config_file = LocalPaths.GITHUB_TEMPLATE_CONFIG_URL;
     const config_json = await this.fetchJsonFromGitHub(config_file);
 
-    const project = await this.prompt(config_json, 'Please select a framework/language for your project');
+    const project = await this.prompt(config_json, starter_template_name, 'Please select a framework/language for your project');
 
     return project;
   }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,5 @@
 import { Flags, Interfaces } from '@oclif/core';
+import { OutputFlags } from '@oclif/core/lib/interfaces';
 import chalk from 'chalk';
 import fs from 'fs';
 import inquirer from 'inquirer';
@@ -80,7 +81,7 @@ export abstract class InitCommand extends BaseCommand {
 
   @RequiresGit()
   @RequiresDocker({ compose: true })
-  async runProjectCreation(project_name: string, flags: any): Promise<void> {
+  async runProjectCreation(project_name: string, flags: OutputFlags<typeof InitCommand.flags>): Promise<void> {
     if (fs.existsSync(`./${project_name}`)) {
       console.log(chalk.red(`The folder ./${project_name} already exists. Please choose a different project name or remove the folder`));
       return;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -59,6 +59,11 @@ export abstract class InitCommand extends BaseCommand {
     'from-compose': Flags.string({
       sensitive: false,
     }),
+    'starter': Flags.string({
+      description: 'Specify a starter project template to use as the base of your new Architect component.',
+      char: 's',
+      sensitive: false,
+    }),
   };
 
   static args = [{
@@ -75,12 +80,12 @@ export abstract class InitCommand extends BaseCommand {
 
   @RequiresGit()
   @RequiresDocker({ compose: true })
-  async runProjectCreation(project_name: string): Promise<void> {
+  async runProjectCreation(project_name: string, flags: any): Promise<void> {
     if (fs.existsSync(`./${project_name}`)) {
       console.log(chalk.red(`The folder ./${project_name} already exists. Please choose a different project name or remove the folder`));
       return;
     }
-    const selections = await ProjectUtils.getSelections();
+    const selections = await ProjectUtils.getSelections(flags.starter);
 
     this.log('\n######################################');
     this.log('##### Let\'s set up your project! #####');
@@ -199,7 +204,7 @@ export abstract class InitCommand extends BaseCommand {
       return;
     }
 
-    await this.runProjectCreation(args.name);
+    await this.runProjectCreation(args.name, flags);
   }
 
   async getComposeFromPath(flags: any): Promise<string | undefined> {

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -440,4 +440,19 @@ services:
       const download_repos = ProjectUtils.downloadGitHubRepos as sinon.SinonStub;
       expect(download_repos.callCount).to.eq(1);
     });
+
+  mockInit()
+    .stub(ProjectUtils, 'getSelections', sinon.stub().returns({}))
+    .stub(ProjectUtils, 'downloadGitHubRepos', sinon.stub())
+    .stdout({ print })
+    .stderr({ print })
+    .command(['init', 'my-react-project2', '--starter', 'Go'])
+    .it('Create project successfully with project flag and starter flag', async ctx => {
+      expect(ctx.stdout).to.contain('Successfully created project');
+      const download_repos = ProjectUtils.downloadGitHubRepos as sinon.SinonStub;
+      const get_selections = ProjectUtils.getSelections as sinon.SinonStub;
+      expect(download_repos.callCount).to.eq(1);
+      expect(get_selections.callCount).to.eq(1);
+      expect(get_selections.getCall(0).args[0]).to.eq('Go');
+    });
 });


### PR DESCRIPTION
## Overview
Add `starter` flag to the init command to specify which starter project to use.
`architect init --starter Go`

## Changes
1. Added starter flag
2. Add basic test case

## Tests
Created projects using each method to make sure nothing broke.
Created project using current command.
`npm run test`
