### PR TITLE
Fix init flow

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -45,10 +45,6 @@ export abstract class InitCommand extends BaseCommand {
       default: 'architect.yml',
       sensitive: false,
     }),
-    name: Flags.string({
-      char: 'n',
-      sensitive: false,
-    }),
     from_compose: Flags.string({
       description: `Please use --from-compose.`,
       hidden: true,
@@ -73,9 +69,18 @@ export abstract class InitCommand extends BaseCommand {
     required: false,
   }];
 
-  doesDockerComposeYmlExist(): boolean {
+  getDefaultDockerComposeFile(): string | undefined {
+    const priority_files = [
+      'docker-compose.yml',
+      'docker-compose.yaml',
+    ];
     const files_in_current_dir = fs.readdirSync('.');
-    const default_compose = files_in_current_dir.some(f => f.includes('compose') && (f.endsWith('.yml') || f.endsWith('.yaml')));
+    for (const priority_file of priority_files) {
+      if (files_in_current_dir.includes(priority_file)) {
+        return priority_file;
+      }
+    }
+    const default_compose = files_in_current_dir.find(f => f.includes('compose') && (f.endsWith('.yml') || f.endsWith('.yaml')));
     return default_compose;
   }
 
@@ -134,95 +139,57 @@ export abstract class InitCommand extends BaseCommand {
     return parsed;
   }
 
+  private isNameValid(name: string) {
+    if (!name) {
+      return false;
+    }
+    return ComponentSlugUtils.Validator.test(name);
+  }
+
   async run(): Promise<void> {
     const { flags, args } = await this.parse(InitCommand);
 
-    const compose_exist = this.doesDockerComposeYmlExist();
-    if (!args.name) {
-      const answers = await inquirer.prompt([
-        {
-          type: 'input',
-          name: 'name',
-          message: 'What is the name of your project?',
-          when: !flags.name,
-          filter: value => value.toLowerCase(),
-          validate: (value) => {
-            if ((new RegExp('^[a-z][a-z-]+[a-z]$').test(value))) {
-              return true;
-            }
-            return `Component name can only contain lowercase letters and dashes, and must start and end with a letter.`;
-          },
-        },
-      ]);
-      args.name = answers.name;
+    const default_compose_file = this.getDefaultDockerComposeFile();
+    const invalid_name_message = 'Component name can only contain lowercase letters and dashes, and must start and end with a letter.';
+
+    if (args.name && !this.isNameValid(args.name)) {
+      this.log(chalk.yellow(`Your project name is invalid. ${invalid_name_message} Please enter a new name.`));
     }
 
-    while (!ComponentSlugUtils.Validator.test(args.name)) {
-      const init_type = (compose_exist || flags['from-compose']) ? 'Component' : 'Project';
-      const err_msg = `${init_type} name can only contain lowercase letters and dashes, and must start and end with a letter.`;
-      this.log(chalk.yellow(err_msg));
-
-      const answers: any = await inquirer.prompt([
-        {
-          type: 'input',
-          name: 'name',
-          message: `Please provide a new name for your ${init_type.toLowerCase()}:`,
+    const answers = await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'name',
+        message: 'What is the name of your project?',
+        when: !this.isNameValid(args.name),
+        filter: value => value.toLowerCase(),
+        validate: (value) => {
+          if (this.isNameValid(value)) {
+            return true;
+          }
+          return invalid_name_message;
         },
-      ]);
-      args.name = answers.name;
-    }
+      },
+    ]);
+    args.name = args.name || answers.name;
 
-    let from_path = await this.getComposeFromPath(flags);
     if (flags['from-compose']) {
-      if (!from_path) {
-        throw new Error(`The Docker Compose file ${from_path} couldn't be found.`);
-      }
-      await this.runArchitectYamlConversion(from_path, args.name, flags['component-file']);
+      await this.runArchitectYamlConversion(path.resolve(untildify(flags['from-compose'])), args.name, flags['component-file']);
       return;
     }
 
-    if (compose_exist) {
-      const init_comp = await ProjectUtils.conversionPrompt(`Would you like to convert from ${from_path}?`);
-      if (init_comp) {
-        if (!from_path) {
-          throw new Error(`The Docker Compose file ${from_path} couldn't be found.`);
-        }
-        await this.runArchitectYamlConversion(from_path, args.name, flags['component-file']);
-      } else {
-        const answers = await inquirer.prompt([
-          {
-            type: 'input',
-            name: 'from_compose',
-            message: 'What is the filename of the Docker Compose file you would like to convert?',
-            validate: (value) => {
-              return fs.existsSync(value) && fs.statSync(value).isFile() ? true : `The Docker Compose file ${value} couldn't be found.`;
-            },
-          },
-        ]);
-        from_path = path.resolve(untildify(answers.from_compose));
-        await this.runArchitectYamlConversion(from_path, args.name, flags['component-file']);
+    if (default_compose_file) {
+      const confirmation_answers = await inquirer.prompt([{
+        type: 'confirm',
+        name: 'use_compose',
+        message: `We detected a ${default_compose_file} file. Would you like to use it for your project?`,
+      }]);
+      if (confirmation_answers.use_compose) {
+        await this.runArchitectYamlConversion(default_compose_file, args.name, flags['component-file']);
+        return;
       }
-      return;
     }
 
     await this.runProjectCreation(args.name, flags);
-  }
-
-  async getComposeFromPath(flags: any): Promise<string | undefined> {
-    let from_path;
-    if (flags['from-compose']) {
-      from_path = path.resolve(untildify(flags['from-compose']));
-    } else {
-      const files_in_current_dir = fs.readdirSync('.');
-      const default_compose = files_in_current_dir.find(f => f.includes('compose') && (f.endsWith('.yml') || f.endsWith('.yaml')));
-
-      if (default_compose) {
-        from_path = default_compose;
-        if (!fs.existsSync(from_path) || !fs.statSync(from_path).isFile()) {
-          throw new Error(`The Docker Compose file ${from_path} couldn't be found.`);
-        }
-      }
-    }
-    return from_path;
   }
 }

--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -439,7 +439,11 @@ export class DockerComposeUtils {
       }
     }
 
-    if (!file_contents || !file_path) {
+    if (!file_contents) {
+      throw new Error(`The file ${input} appears to be empty. Nothing to convert.`);
+    }
+
+    if (!file_path) {
       throw new Error(`No docker-compose file found at ${input}`);
     }
 

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -271,37 +271,35 @@ services:
       expect(ctx.stdout).to.contain(`Could not convert kibana property "networks"`);
     });
 
-  it('finds a compose file in the current directory if one was unspecified', async () => {
+  it('finds a compose file in the current directory', async () => {
     mock_fs({
       './docker-compose.yml': mock_compose_contents,
     });
 
-    const getComposeFromPath = InitCommand.prototype.getComposeFromPath;
-    const compose_path = await getComposeFromPath({});
+    const getDefaultDockerComposeFile = InitCommand.prototype.getDefaultDockerComposeFile;
+    const compose_path = await getDefaultDockerComposeFile();
     expect(compose_path).eq('docker-compose.yml');
   });
 
-  it('finds and returns a valid compose file path if it was specified', async () => {
+  it('finds an oddly named compose file in the current directory', async () => {
     mock_fs({
-      '/stack/docker-compose.yml': mock_compose_contents,
+      './compose.yml': mock_compose_contents,
     });
 
-    const getComposeFromPath = InitCommand.prototype.getComposeFromPath;
-    const compose_path = await getComposeFromPath({ 'from-compose': '/stack/docker-compose.yml' });
-    expect(compose_path).eq(path.join(path.parse(process.cwd()).root, 'stack', 'docker-compose.yml'));
+    const getDefaultDockerComposeFile = InitCommand.prototype.getDefaultDockerComposeFile;
+    const compose_path = await getDefaultDockerComposeFile();
+    expect(compose_path).eq('compose.yml');
   });
 
-  it(`returns an error if the compose file was specified, but it doesn't exist`, async () => {
+  it('finds the preferred docker compose file names first', async () => {
     mock_fs({
-      '/stack/docker-compose.yml': mock_compose_contents,
+      './compose.yml': mock_compose_contents,
+      './docker-compose.yaml': mock_compose_contents,
     });
 
-    const getComposeFromPath = InitCommand.prototype.getComposeFromPath;
-    try {
-      await getComposeFromPath({ 'from-compose': '/stack/bad-path/docker-compose.yml' });
-    } catch (err: any) {
-      expect(err.message).eq(`The Docker Compose file /stack/bad-path/docker-compose.yml couldn't be found.`);
-    }
+    const getDefaultDockerComposeFile = InitCommand.prototype.getDefaultDockerComposeFile;
+    const compose_path = await getDefaultDockerComposeFile();
+    expect(compose_path).eq('docker-compose.yaml');
   });
 
   mockInit()


### PR DESCRIPTION
## Overview
When trying to create a new project with a `docker-compose.yml` in the current working directory, there was no good mechanism to use a starter project. This PR fixes that core issue and streamlines some of the code.


## Changes
1. Changed the way we handle asking for the name. Makes it a bit cleaner.
2. Look for a docker compose file in the directory and ask if it should be used.
3. Removed some of the duplicate checks we did around finding and using the right file.
4. Added better error message if the file was empty.
5. 

## Tests
1. Went through each combination of the common. With and without a default file. With and without 2 docker compose files to test priority.
2. Tested the new name system.
3. Added and updated unit tests


## Pictures
![image](https://user-images.githubusercontent.com/532523/226447768-6b7055cd-a357-46cc-82c6-d4c09fbe8c17.png)

