### PR TITLE
Use expanded depends_on syntax for service health

### DIFF
--- a/src/common/docker-compose/index.ts
+++ b/src/common/docker-compose/index.ts
@@ -255,9 +255,14 @@ export class DockerComposeUtils {
         service.extra_hosts = ['host.docker.internal:host-gateway'];
       }
 
-      const depends_on = graph.getDependsOn(node).map(n => n.ref);
-
-      if (depends_on?.length) {
+      const depends_on_nodes = graph.getDependsOn(node);
+      if (depends_on_nodes?.length) {
+        const depends_on: Dictionary<{ condition: string }> = {};
+        for (const node of depends_on_nodes) {
+          depends_on[node.ref] = {
+            condition: node instanceof ServiceNode && node.config.liveness_probe ? 'service_healthy' : 'service_started',
+          };
+        }
         service.depends_on = depends_on;
       }
 

--- a/src/common/docker-compose/template.ts
+++ b/src/common/docker-compose/template.ts
@@ -1,3 +1,5 @@
+import { Dictionary } from '../../dependency-manager/utils/dictionary';
+
 interface XBakeConfig {
   platforms: string[];
   'cache-from'?: string | string[];
@@ -45,7 +47,7 @@ export interface DockerService {
   ports?: string[] | DockerComposeInterface[];
   image?: string;
   environment?: { [key: string]: any };
-  depends_on?: string[];
+  depends_on?: Dictionary<{ condition: string }> | string[];
   build?: DockerServiceBuild;
   volumes?: string[] | DockerComposeVolume[];
   command?: string[];

--- a/test/commands/dev/index.test.ts
+++ b/test/commands/dev/index.test.ts
@@ -324,9 +324,11 @@ describe('local dev environment', function () {
         'ports': [
           '50000:3000',
         ],
-        'depends_on': [
-          seed_db_ref,
-        ],
+        depends_on: {
+          [seed_db_ref]: {
+            condition: 'service_started'
+          }
+        },
         'environment': {
           'DATABASE_HOST': seed_db_ref,
           'DATABASE_PORT': '5432',

--- a/test/dependency-manager/interfaces.test.ts
+++ b/test/dependency-manager/interfaces.test.ts
@@ -239,7 +239,11 @@ describe('interfaces spec v1', () => {
       ]);
 
       const expected_leaf_compose: DockerService = {
-        depends_on: [leaf_api_ref],
+        depends_on: {
+          [leaf_api_ref]: {
+            condition: 'service_started'
+          }
+        },
         environment: {
           LEAF_HOST: leaf_api_ref,
           LEAF_PORT: '8080',
@@ -270,7 +274,11 @@ describe('interfaces spec v1', () => {
       expect(template.services[leaf_db_ref]).to.be.deep.equal(expected_leaf_db_compose);
 
       const expected_leaf_api_compose: DockerService = {
-        depends_on: [leaf_db_ref],
+        depends_on: {
+          [leaf_db_ref]: {
+            condition: 'service_started'
+          }
+        },
         environment: {
           DB_HOST: leaf_db_ref,
           DB_PORT: '5432',
@@ -307,7 +315,11 @@ describe('interfaces spec v1', () => {
       expect(template.services[other_leaf_db_ref]).to.be.deep.equal(expected_other_leaf_db_compose);
 
       const expected_other_leaf_api_compose: DockerService = {
-        depends_on: [other_leaf_db_ref],
+        depends_on: {
+          [other_leaf_db_ref]: {
+            condition: 'service_started'
+          }
+        },
         environment: {
           DB_HOST: other_leaf_db_ref,
           DB_PORT: '5432',

--- a/test/dependency-manager/interpolation.test.ts
+++ b/test/dependency-manager/interpolation.test.ts
@@ -187,9 +187,11 @@ describe('interpolation spec v1', () => {
             'context': path.resolve('/stack')
           },
           image: worker_ref,
-          'depends_on': [
-            web_ref
-          ],
+          depends_on: {
+            [web_ref]: {
+              condition: 'service_started'
+            }
+          },
           labels: ['architect.ref=worker.services.worker']
         },
       },
@@ -250,7 +252,11 @@ describe('interpolation spec v1', () => {
         'context': path.resolve('/stack')
       },
       image: worker_ref,
-      depends_on: [web_ref],
+      depends_on: {
+        [web_ref]: {
+          condition: 'service_started'
+        }
+      },
       external_links: [
         'gateway:public.arc.localhost'
       ],

--- a/test/dependency-manager/reserved-names.test.ts
+++ b/test/dependency-manager/reserved-names.test.ts
@@ -261,9 +261,9 @@ describe('components with reserved_name field set', function () {
       const expected_compose: DockerComposeTemplate = {
         "services": {
           [api_ref]: {
-            "depends_on": [
-              `${db_ref}`
-            ],
+            "depends_on": {
+              [`${db_ref}`]: { condition: 'service_started' }
+            },
             "environment": {
               "DB_ADDR": `http://${db_ref}:5432`
             },
@@ -274,9 +274,9 @@ describe('components with reserved_name field set', function () {
             labels: [`architect.ref=cloud.services.api`]
           },
           [app_ref]: {
-            "depends_on": [
-              `${reserved_name}`
-            ],
+            "depends_on": {
+              [`${reserved_name}`]: { condition: 'service_started' }
+            },
             "environment": {
               "API_ADDR": `http://${api_ref}:8080`
             },


### PR DESCRIPTION
## Overview
If a service defines a liveness probe then we should wait till it is healthy in the depends_on.

## Pictures
![image](https://user-images.githubusercontent.com/737712/226677317-f5592952-a20d-4f63-ac21-94a9c142c802.png)
