### PR TITLE
[DNM] - Update bin/run to hide ExperimentalWarnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# [1.36.0](https://github.com/architect-team/architect-cli/compare/v1.35.0...v1.36.0) (2023-03-21)
+
+
+### Bug Fixes
+
+* **databases:** Databases redacted secrets ([#855](https://github.com/architect-team/architect-cli/issues/855)) ([541e07e](https://github.com/architect-team/architect-cli/commit/541e07eed00abe9427342bf515eeefcdcf20f870))
+* **depends_on:** Use expanded depends_on syntax for service health ([#862](https://github.com/architect-team/architect-cli/issues/862)) ([9bc61ca](https://github.com/architect-team/architect-cli/commit/9bc61ca44e452f76d2cdca7ac1fe830b6f3b0434))
+* **init:** Add starter flag to init command ([#858](https://github.com/architect-team/architect-cli/issues/858)) ([8b9a564](https://github.com/architect-team/architect-cli/commit/8b9a564b248ff1b6ecd18c5b5f0ed2f15298f64e))
+* **init:** Fix init flow ([#861](https://github.com/architect-team/architect-cli/issues/861)) ([670738e](https://github.com/architect-team/architect-cli/commit/670738e442f9ed1431d30da4ccca327f03c282e0))
+* **prompt:** Shortcut prompt for cluster/environment if only one instance exists ([#859](https://github.com/architect-team/architect-cli/issues/859)) ([d664280](https://github.com/architect-team/architect-cli/commit/d66428064ba260bd47c4a55b288f234102ba9e7c))
+* **register:** Disable provenance to fix issues with image pulling in k8s clusters ([#860](https://github.com/architect-team/architect-cli/issues/860)) ([7b3580b](https://github.com/architect-team/architect-cli/commit/7b3580b6b4744eac120f8ae6db9c9ca08e360e4c))
+
+
+### Features
+
+* **dev:** Automatically clean up local docker cache for unused images ([291eeec](https://github.com/architect-team/architect-cli/commit/291eeec5d99ffa2155c94aad88447bc1422ac15a))
+* **port-forward:** Add port-forward command ([#854](https://github.com/architect-team/architect-cli/issues/854)) ([8bab709](https://github.com/architect-team/architect-cli/commit/8bab7090b0b971b79159af03e39d05dfede0a68f))
+
+
+### Reverts
+
+* Revert "feat(dev): Automatically clean up local docker cache for unused images" (#856) ([686ccfb](https://github.com/architect-team/architect-cli/commit/686ccfb5d628aeb53deb7e4e6997bed94ade2117)), closes [#856](https://github.com/architect-team/architect-cli/issues/856)
+
 # [1.35.0](https://github.com/architect-team/architect-cli/compare/v1.34.0...v1.35.0) (2023-03-10)
 
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ npm install -g @architect-io/cli
 $ architect COMMAND
 running command...
 $ architect (--version)
-@architect-io/cli/1.36.0 linux-x64 node-v16.19.1
+@architect-io/cli/1.36.1-arc-tyler.1 linux-x64 node-v16.19.1
 $ architect --help [COMMAND]
 USAGE
   $ architect COMMAND
@@ -134,7 +134,7 @@ EXAMPLES
   $ architect component:versions --account=myaccount mycomponent
 ```
 
-_See code: [src/commands/components/versions.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/components/versions.ts)_
+_See code: [src/commands/components/versions.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/components/versions.ts)_
 
 ## `architect config:get OPTION`
 
@@ -154,7 +154,7 @@ EXAMPLES
   $ architect config:get log_level
 ```
 
-_See code: [src/commands/config/get.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/config/get.ts)_
+_See code: [src/commands/config/get.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/config/get.ts)_
 
 ## `architect config:set OPTION VALUE`
 
@@ -175,7 +175,7 @@ EXAMPLES
   $ architect config:set log_level info
 ```
 
-_See code: [src/commands/config/set.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/config/set.ts)_
+_See code: [src/commands/config/set.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/config/set.ts)_
 
 ## `architect config:view`
 
@@ -195,7 +195,7 @@ EXAMPLES
   $ architect config
 ```
 
-_See code: [src/commands/config/view.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/config/view.ts)_
+_See code: [src/commands/config/view.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/config/view.ts)_
 
 ## `architect deploy [CONFIGS_OR_COMPONENTS]`
 
@@ -239,7 +239,7 @@ EXAMPLES
   $ architect deploy ./myfolder/architect.yml --secret-file=./mysecrets.yml --environment=myenvironment --account=myaccount --auto-approve
 ```
 
-_See code: [src/commands/deploy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/deploy.ts)_
+_See code: [src/commands/deploy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/deploy.ts)_
 
 ## `architect destroy`
 
@@ -265,7 +265,7 @@ EXAMPLES
   $ architect destroy --account=myaccount --environment=myenvironment --auto-approve
 ```
 
-_See code: [src/commands/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/destroy.ts)_
+_See code: [src/commands/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/destroy.ts)_
 
 ## `architect dev [CONFIGS_OR_COMPONENTS]`
 
@@ -308,7 +308,7 @@ EXAMPLES
   $ architect dev --port=81 --browser=false --debug=true --secret-file=./mycomponent/mysecrets.yml ./mycomponent/architect.yml
 ```
 
-_See code: [src/commands/dev/index.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/dev/index.ts)_
+_See code: [src/commands/dev/index.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/dev/index.ts)_
 
 ## `architect dev:list`
 
@@ -329,7 +329,7 @@ EXAMPLES
   $ architect dev:list
 ```
 
-_See code: [src/commands/dev/list.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/dev/list.ts)_
+_See code: [src/commands/dev/list.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/dev/list.ts)_
 
 ## `architect dev:restart [SERVICES]`
 
@@ -357,7 +357,7 @@ EXAMPLES
   $ architect dev:restart hello-world.services.api hello-world.services.app
 ```
 
-_See code: [src/commands/dev/restart.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/dev/restart.ts)_
+_See code: [src/commands/dev/restart.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/dev/restart.ts)_
 
 ## `architect dev:stop [NAME]`
 
@@ -377,7 +377,7 @@ EXAMPLES
   $ architect dev:stop <local-environment-name>
 ```
 
-_See code: [src/commands/dev/stop.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/dev/stop.ts)_
+_See code: [src/commands/dev/stop.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/dev/stop.ts)_
 
 ## `architect doctor`
 
@@ -399,7 +399,7 @@ EXAMPLES
   $ architect doctor -o ./myoutput.yml
 ```
 
-_See code: [src/commands/doctor.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/doctor.ts)_
+_See code: [src/commands/doctor.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/doctor.ts)_
 
 ## `architect environments:create [ENVIRONMENT]`
 
@@ -434,7 +434,7 @@ EXAMPLES
   environment:create --account=myaccount --ttl=5days --description="My new temporary Architect environment" myenvironment
 ```
 
-_See code: [src/commands/environments/create.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/environments/create.ts)_
+_See code: [src/commands/environments/create.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/environments/create.ts)_
 
 ## `architect environments:destroy [ENVIRONMENT]`
 
@@ -468,7 +468,7 @@ EXAMPLES
   $ architect environment:deregister --account=myaccount --auto-approve --force myenvironment
 ```
 
-_See code: [src/commands/environments/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/environments/destroy.ts)_
+_See code: [src/commands/environments/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/environments/destroy.ts)_
 
 ## `architect environments:ingresses [ENVIRONMENT]`
 
@@ -493,7 +493,7 @@ ALIASES
   $ architect env:ingresses
 ```
 
-_See code: [src/commands/environments/ingresses.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/environments/ingresses.ts)_
+_See code: [src/commands/environments/ingresses.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/environments/ingresses.ts)_
 
 ## `architect exec [RESOURCE] [FLAGS] -- [COMMAND]`
 
@@ -526,7 +526,7 @@ EXAMPLES
   $ architect exec --account myaccount --environment myenvironment mycomponent.services.app --replica 0 -- /bin/sh
 ```
 
-_See code: [src/commands/exec.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/exec.ts)_
+_See code: [src/commands/exec.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/exec.ts)_
 
 ## `architect help [COMMAND]`
 
@@ -576,7 +576,7 @@ EXAMPLES
   $ architect init --from-compose=mycompose.yml --component-file=architect.yml
 ```
 
-_See code: [src/commands/init.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/init.ts)_
 
 ## `architect link [COMPONENTPATH]`
 
@@ -598,7 +598,7 @@ EXAMPLES
   $ architect link -p ./mycomponent/architect.yml
 ```
 
-_See code: [src/commands/link/index.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/link/index.ts)_
+_See code: [src/commands/link/index.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/link/index.ts)_
 
 ## `architect link:list`
 
@@ -615,7 +615,7 @@ EXAMPLES
   $ architect link:list
 ```
 
-_See code: [src/commands/link/list.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/link/list.ts)_
+_See code: [src/commands/link/list.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/link/list.ts)_
 
 ## `architect login`
 
@@ -638,7 +638,7 @@ EXAMPLES
   $ architect login -e my-email-address@my-email-domain.com
 ```
 
-_See code: [src/commands/login.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/login.ts)_
 
 ## `architect logout`
 
@@ -655,7 +655,7 @@ EXAMPLES
   $ architect logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/logout.ts)_
 
 ## `architect logs [RESOURCE]`
 
@@ -690,7 +690,7 @@ EXAMPLES
   $ architect logs --follow --raw --timestamps
 ```
 
-_See code: [src/commands/logs.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/logs.ts)_
+_See code: [src/commands/logs.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/logs.ts)_
 
 ## `architect port-forward [RESOURCE] [FLAGS]`
 
@@ -725,7 +725,7 @@ EXAMPLES
   $ architect port-forward --address 0.0.0.0 --port 8080
 ```
 
-_See code: [src/commands/port-forward.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/port-forward.ts)_
+_See code: [src/commands/port-forward.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/port-forward.ts)_
 
 ## `architect register [COMPONENT]`
 
@@ -767,7 +767,7 @@ EXAMPLES
   $ architect register -a myaccount -t latest --arg NODE_ENV=dev ./architect.yml
 ```
 
-_See code: [src/commands/register.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/register.ts)_
+_See code: [src/commands/register.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/register.ts)_
 
 ## `architect scale [SERVICE]`
 
@@ -798,7 +798,7 @@ EXAMPLES
   $ architect scale api --component my-component --clear
 ```
 
-_See code: [src/commands/scale.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/scale.ts)_
+_See code: [src/commands/scale.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/scale.ts)_
 
 ## `architect secrets:download SECRETS_FILE`
 
@@ -831,7 +831,7 @@ EXAMPLES
   $ architect secrets --account=myaccount --environment=myenvironment ./mysecrets.yml
 ```
 
-_See code: [src/commands/secrets/download.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/secrets/download.ts)_
+_See code: [src/commands/secrets/download.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/secrets/download.ts)_
 
 ## `architect secrets:upload SECRETS_FILE`
 
@@ -870,7 +870,7 @@ EXAMPLES
   $ architect secrets:set --account=myaccount --environment=myenvironment --override ./mysecrets.yml
 ```
 
-_See code: [src/commands/secrets/upload.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/secrets/upload.ts)_
+_See code: [src/commands/secrets/upload.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/secrets/upload.ts)_
 
 ## `architect task COMPONENT TASK`
 
@@ -900,7 +900,7 @@ EXAMPLES
   $ architect task --account=myaccount --environment=myenvironment mycomponent:latest mytask
 ```
 
-_See code: [src/commands/task.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/task.ts)_
+_See code: [src/commands/task.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/task.ts)_
 
 ## `architect unlink [COMPONENTPATHORNAME]`
 
@@ -924,5 +924,5 @@ EXAMPLES
   $ architect unlink -p mycomponent
 ```
 
-_See code: [src/commands/unlink.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0/src/commands/unlink.ts)_
+_See code: [src/commands/unlink.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-arc-tyler.1/src/commands/unlink.ts)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ npm install -g @architect-io/cli
 $ architect COMMAND
 running command...
 $ architect (--version)
-@architect-io/cli/1.36.0-rc.7 linux-x64 node-v16.19.1
+@architect-io/cli/1.36.0-rc.8 linux-x64 node-v16.19.1
 $ architect --help [COMMAND]
 USAGE
   $ architect COMMAND
@@ -134,7 +134,7 @@ EXAMPLES
   $ architect component:versions --account=myaccount mycomponent
 ```
 
-_See code: [src/commands/components/versions.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/components/versions.ts)_
+_See code: [src/commands/components/versions.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/components/versions.ts)_
 
 ## `architect config:get OPTION`
 
@@ -154,7 +154,7 @@ EXAMPLES
   $ architect config:get log_level
 ```
 
-_See code: [src/commands/config/get.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/config/get.ts)_
+_See code: [src/commands/config/get.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/config/get.ts)_
 
 ## `architect config:set OPTION VALUE`
 
@@ -175,7 +175,7 @@ EXAMPLES
   $ architect config:set log_level info
 ```
 
-_See code: [src/commands/config/set.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/config/set.ts)_
+_See code: [src/commands/config/set.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/config/set.ts)_
 
 ## `architect config:view`
 
@@ -195,7 +195,7 @@ EXAMPLES
   $ architect config
 ```
 
-_See code: [src/commands/config/view.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/config/view.ts)_
+_See code: [src/commands/config/view.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/config/view.ts)_
 
 ## `architect deploy [CONFIGS_OR_COMPONENTS]`
 
@@ -239,7 +239,7 @@ EXAMPLES
   $ architect deploy ./myfolder/architect.yml --secret-file=./mysecrets.yml --environment=myenvironment --account=myaccount --auto-approve
 ```
 
-_See code: [src/commands/deploy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/deploy.ts)_
+_See code: [src/commands/deploy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/deploy.ts)_
 
 ## `architect destroy`
 
@@ -265,7 +265,7 @@ EXAMPLES
   $ architect destroy --account=myaccount --environment=myenvironment --auto-approve
 ```
 
-_See code: [src/commands/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/destroy.ts)_
+_See code: [src/commands/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/destroy.ts)_
 
 ## `architect dev [CONFIGS_OR_COMPONENTS]`
 
@@ -308,7 +308,7 @@ EXAMPLES
   $ architect dev --port=81 --browser=false --debug=true --secret-file=./mycomponent/mysecrets.yml ./mycomponent/architect.yml
 ```
 
-_See code: [src/commands/dev/index.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/dev/index.ts)_
+_See code: [src/commands/dev/index.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/dev/index.ts)_
 
 ## `architect dev:list`
 
@@ -329,7 +329,7 @@ EXAMPLES
   $ architect dev:list
 ```
 
-_See code: [src/commands/dev/list.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/dev/list.ts)_
+_See code: [src/commands/dev/list.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/dev/list.ts)_
 
 ## `architect dev:restart [SERVICES]`
 
@@ -357,7 +357,7 @@ EXAMPLES
   $ architect dev:restart hello-world.services.api hello-world.services.app
 ```
 
-_See code: [src/commands/dev/restart.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/dev/restart.ts)_
+_See code: [src/commands/dev/restart.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/dev/restart.ts)_
 
 ## `architect dev:stop [NAME]`
 
@@ -377,7 +377,7 @@ EXAMPLES
   $ architect dev:stop <local-environment-name>
 ```
 
-_See code: [src/commands/dev/stop.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/dev/stop.ts)_
+_See code: [src/commands/dev/stop.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/dev/stop.ts)_
 
 ## `architect doctor`
 
@@ -399,7 +399,7 @@ EXAMPLES
   $ architect doctor -o ./myoutput.yml
 ```
 
-_See code: [src/commands/doctor.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/doctor.ts)_
+_See code: [src/commands/doctor.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/doctor.ts)_
 
 ## `architect environments:create [ENVIRONMENT]`
 
@@ -434,7 +434,7 @@ EXAMPLES
   environment:create --account=myaccount --ttl=5days --description="My new temporary Architect environment" myenvironment
 ```
 
-_See code: [src/commands/environments/create.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/environments/create.ts)_
+_See code: [src/commands/environments/create.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/environments/create.ts)_
 
 ## `architect environments:destroy [ENVIRONMENT]`
 
@@ -468,7 +468,7 @@ EXAMPLES
   $ architect environment:deregister --account=myaccount --auto-approve --force myenvironment
 ```
 
-_See code: [src/commands/environments/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/environments/destroy.ts)_
+_See code: [src/commands/environments/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/environments/destroy.ts)_
 
 ## `architect environments:ingresses [ENVIRONMENT]`
 
@@ -493,7 +493,7 @@ ALIASES
   $ architect env:ingresses
 ```
 
-_See code: [src/commands/environments/ingresses.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/environments/ingresses.ts)_
+_See code: [src/commands/environments/ingresses.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/environments/ingresses.ts)_
 
 ## `architect exec [RESOURCE] [FLAGS] -- [COMMAND]`
 
@@ -526,7 +526,7 @@ EXAMPLES
   $ architect exec --account myaccount --environment myenvironment mycomponent.services.app --replica 0 -- /bin/sh
 ```
 
-_See code: [src/commands/exec.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/exec.ts)_
+_See code: [src/commands/exec.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/exec.ts)_
 
 ## `architect help [COMMAND]`
 
@@ -576,7 +576,7 @@ EXAMPLES
   $ architect init --from-compose=mycompose.yml --component-file=architect.yml
 ```
 
-_See code: [src/commands/init.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/init.ts)_
 
 ## `architect link [COMPONENTPATH]`
 
@@ -598,7 +598,7 @@ EXAMPLES
   $ architect link -p ./mycomponent/architect.yml
 ```
 
-_See code: [src/commands/link/index.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/link/index.ts)_
+_See code: [src/commands/link/index.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/link/index.ts)_
 
 ## `architect link:list`
 
@@ -615,7 +615,7 @@ EXAMPLES
   $ architect link:list
 ```
 
-_See code: [src/commands/link/list.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/link/list.ts)_
+_See code: [src/commands/link/list.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/link/list.ts)_
 
 ## `architect login`
 
@@ -638,7 +638,7 @@ EXAMPLES
   $ architect login -e my-email-address@my-email-domain.com
 ```
 
-_See code: [src/commands/login.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/login.ts)_
 
 ## `architect logout`
 
@@ -655,7 +655,7 @@ EXAMPLES
   $ architect logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/logout.ts)_
 
 ## `architect logs [RESOURCE]`
 
@@ -690,7 +690,7 @@ EXAMPLES
   $ architect logs --follow --raw --timestamps
 ```
 
-_See code: [src/commands/logs.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/logs.ts)_
+_See code: [src/commands/logs.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/logs.ts)_
 
 ## `architect port-forward [RESOURCE] [FLAGS]`
 
@@ -725,7 +725,7 @@ EXAMPLES
   $ architect port-forward --address 0.0.0.0 --port 8080
 ```
 
-_See code: [src/commands/port-forward.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/port-forward.ts)_
+_See code: [src/commands/port-forward.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/port-forward.ts)_
 
 ## `architect register [COMPONENT]`
 
@@ -767,7 +767,7 @@ EXAMPLES
   $ architect register -a myaccount -t latest --arg NODE_ENV=dev ./architect.yml
 ```
 
-_See code: [src/commands/register.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/register.ts)_
+_See code: [src/commands/register.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/register.ts)_
 
 ## `architect scale [SERVICE]`
 
@@ -798,7 +798,7 @@ EXAMPLES
   $ architect scale api --component my-component --clear
 ```
 
-_See code: [src/commands/scale.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/scale.ts)_
+_See code: [src/commands/scale.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/scale.ts)_
 
 ## `architect secrets:download SECRETS_FILE`
 
@@ -831,7 +831,7 @@ EXAMPLES
   $ architect secrets --account=myaccount --environment=myenvironment ./mysecrets.yml
 ```
 
-_See code: [src/commands/secrets/download.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/secrets/download.ts)_
+_See code: [src/commands/secrets/download.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/secrets/download.ts)_
 
 ## `architect secrets:upload SECRETS_FILE`
 
@@ -870,7 +870,7 @@ EXAMPLES
   $ architect secrets:set --account=myaccount --environment=myenvironment --override ./mysecrets.yml
 ```
 
-_See code: [src/commands/secrets/upload.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/secrets/upload.ts)_
+_See code: [src/commands/secrets/upload.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/secrets/upload.ts)_
 
 ## `architect task COMPONENT TASK`
 
@@ -900,7 +900,7 @@ EXAMPLES
   $ architect task --account=myaccount --environment=myenvironment mycomponent:latest mytask
 ```
 
-_See code: [src/commands/task.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/task.ts)_
+_See code: [src/commands/task.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/task.ts)_
 
 ## `architect unlink [COMPONENTPATHORNAME]`
 
@@ -924,5 +924,5 @@ EXAMPLES
   $ architect unlink -p mycomponent
 ```
 
-_See code: [src/commands/unlink.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.7/src/commands/unlink.ts)_
+_See code: [src/commands/unlink.ts](https://github.com/architect-team/architect-cli/blob/v1.36.0-rc.8/src/commands/unlink.ts)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ npm install -g @architect-io/cli
 $ architect COMMAND
 running command...
 $ architect (--version)
-@architect-io/cli/1.36.1-rc.1 linux-x64 node-v16.19.1
+@architect-io/cli/1.36.1-rc.2 linux-x64 node-v16.19.1
 $ architect --help [COMMAND]
 USAGE
   $ architect COMMAND
@@ -134,7 +134,7 @@ EXAMPLES
   $ architect component:versions --account=myaccount mycomponent
 ```
 
-_See code: [src/commands/components/versions.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/components/versions.ts)_
+_See code: [src/commands/components/versions.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/components/versions.ts)_
 
 ## `architect config:get OPTION`
 
@@ -154,7 +154,7 @@ EXAMPLES
   $ architect config:get log_level
 ```
 
-_See code: [src/commands/config/get.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/config/get.ts)_
+_See code: [src/commands/config/get.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/config/get.ts)_
 
 ## `architect config:set OPTION VALUE`
 
@@ -175,7 +175,7 @@ EXAMPLES
   $ architect config:set log_level info
 ```
 
-_See code: [src/commands/config/set.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/config/set.ts)_
+_See code: [src/commands/config/set.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/config/set.ts)_
 
 ## `architect config:view`
 
@@ -195,7 +195,7 @@ EXAMPLES
   $ architect config
 ```
 
-_See code: [src/commands/config/view.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/config/view.ts)_
+_See code: [src/commands/config/view.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/config/view.ts)_
 
 ## `architect deploy [CONFIGS_OR_COMPONENTS]`
 
@@ -239,7 +239,7 @@ EXAMPLES
   $ architect deploy ./myfolder/architect.yml --secret-file=./mysecrets.yml --environment=myenvironment --account=myaccount --auto-approve
 ```
 
-_See code: [src/commands/deploy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/deploy.ts)_
+_See code: [src/commands/deploy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/deploy.ts)_
 
 ## `architect destroy`
 
@@ -265,7 +265,7 @@ EXAMPLES
   $ architect destroy --account=myaccount --environment=myenvironment --auto-approve
 ```
 
-_See code: [src/commands/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/destroy.ts)_
+_See code: [src/commands/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/destroy.ts)_
 
 ## `architect dev [CONFIGS_OR_COMPONENTS]`
 
@@ -308,7 +308,7 @@ EXAMPLES
   $ architect dev --port=81 --browser=false --debug=true --secret-file=./mycomponent/mysecrets.yml ./mycomponent/architect.yml
 ```
 
-_See code: [src/commands/dev/index.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/dev/index.ts)_
+_See code: [src/commands/dev/index.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/dev/index.ts)_
 
 ## `architect dev:list`
 
@@ -329,7 +329,7 @@ EXAMPLES
   $ architect dev:list
 ```
 
-_See code: [src/commands/dev/list.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/dev/list.ts)_
+_See code: [src/commands/dev/list.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/dev/list.ts)_
 
 ## `architect dev:restart [SERVICES]`
 
@@ -357,7 +357,7 @@ EXAMPLES
   $ architect dev:restart hello-world.services.api hello-world.services.app
 ```
 
-_See code: [src/commands/dev/restart.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/dev/restart.ts)_
+_See code: [src/commands/dev/restart.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/dev/restart.ts)_
 
 ## `architect dev:stop [NAME]`
 
@@ -377,7 +377,7 @@ EXAMPLES
   $ architect dev:stop <local-environment-name>
 ```
 
-_See code: [src/commands/dev/stop.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/dev/stop.ts)_
+_See code: [src/commands/dev/stop.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/dev/stop.ts)_
 
 ## `architect doctor`
 
@@ -399,7 +399,7 @@ EXAMPLES
   $ architect doctor -o ./myoutput.yml
 ```
 
-_See code: [src/commands/doctor.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/doctor.ts)_
+_See code: [src/commands/doctor.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/doctor.ts)_
 
 ## `architect environments:create [ENVIRONMENT]`
 
@@ -434,7 +434,7 @@ EXAMPLES
   environment:create --account=myaccount --ttl=5days --description="My new temporary Architect environment" myenvironment
 ```
 
-_See code: [src/commands/environments/create.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/environments/create.ts)_
+_See code: [src/commands/environments/create.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/environments/create.ts)_
 
 ## `architect environments:destroy [ENVIRONMENT]`
 
@@ -468,7 +468,7 @@ EXAMPLES
   $ architect environment:deregister --account=myaccount --auto-approve --force myenvironment
 ```
 
-_See code: [src/commands/environments/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/environments/destroy.ts)_
+_See code: [src/commands/environments/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/environments/destroy.ts)_
 
 ## `architect environments:ingresses [ENVIRONMENT]`
 
@@ -493,7 +493,7 @@ ALIASES
   $ architect env:ingresses
 ```
 
-_See code: [src/commands/environments/ingresses.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/environments/ingresses.ts)_
+_See code: [src/commands/environments/ingresses.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/environments/ingresses.ts)_
 
 ## `architect exec [RESOURCE] [FLAGS] -- [COMMAND]`
 
@@ -526,7 +526,7 @@ EXAMPLES
   $ architect exec --account myaccount --environment myenvironment mycomponent.services.app --replica 0 -- /bin/sh
 ```
 
-_See code: [src/commands/exec.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/exec.ts)_
+_See code: [src/commands/exec.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/exec.ts)_
 
 ## `architect help [COMMAND]`
 
@@ -576,7 +576,7 @@ EXAMPLES
   $ architect init --from-compose=mycompose.yml --component-file=architect.yml
 ```
 
-_See code: [src/commands/init.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/init.ts)_
 
 ## `architect link [COMPONENTPATH]`
 
@@ -598,7 +598,7 @@ EXAMPLES
   $ architect link -p ./mycomponent/architect.yml
 ```
 
-_See code: [src/commands/link/index.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/link/index.ts)_
+_See code: [src/commands/link/index.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/link/index.ts)_
 
 ## `architect link:list`
 
@@ -615,7 +615,7 @@ EXAMPLES
   $ architect link:list
 ```
 
-_See code: [src/commands/link/list.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/link/list.ts)_
+_See code: [src/commands/link/list.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/link/list.ts)_
 
 ## `architect login`
 
@@ -638,7 +638,7 @@ EXAMPLES
   $ architect login -e my-email-address@my-email-domain.com
 ```
 
-_See code: [src/commands/login.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/login.ts)_
 
 ## `architect logout`
 
@@ -655,7 +655,7 @@ EXAMPLES
   $ architect logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/logout.ts)_
 
 ## `architect logs [RESOURCE]`
 
@@ -690,7 +690,7 @@ EXAMPLES
   $ architect logs --follow --raw --timestamps
 ```
 
-_See code: [src/commands/logs.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/logs.ts)_
+_See code: [src/commands/logs.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/logs.ts)_
 
 ## `architect port-forward [RESOURCE] [FLAGS]`
 
@@ -725,7 +725,7 @@ EXAMPLES
   $ architect port-forward --address 0.0.0.0 --port 8080
 ```
 
-_See code: [src/commands/port-forward.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/port-forward.ts)_
+_See code: [src/commands/port-forward.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/port-forward.ts)_
 
 ## `architect register [COMPONENT]`
 
@@ -767,7 +767,7 @@ EXAMPLES
   $ architect register -a myaccount -t latest --arg NODE_ENV=dev ./architect.yml
 ```
 
-_See code: [src/commands/register.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/register.ts)_
+_See code: [src/commands/register.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/register.ts)_
 
 ## `architect scale [SERVICE]`
 
@@ -798,7 +798,7 @@ EXAMPLES
   $ architect scale api --component my-component --clear
 ```
 
-_See code: [src/commands/scale.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/scale.ts)_
+_See code: [src/commands/scale.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/scale.ts)_
 
 ## `architect secrets:download SECRETS_FILE`
 
@@ -831,7 +831,7 @@ EXAMPLES
   $ architect secrets --account=myaccount --environment=myenvironment ./mysecrets.yml
 ```
 
-_See code: [src/commands/secrets/download.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/secrets/download.ts)_
+_See code: [src/commands/secrets/download.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/secrets/download.ts)_
 
 ## `architect secrets:upload SECRETS_FILE`
 
@@ -870,7 +870,7 @@ EXAMPLES
   $ architect secrets:set --account=myaccount --environment=myenvironment --override ./mysecrets.yml
 ```
 
-_See code: [src/commands/secrets/upload.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/secrets/upload.ts)_
+_See code: [src/commands/secrets/upload.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/secrets/upload.ts)_
 
 ## `architect task COMPONENT TASK`
 
@@ -900,7 +900,7 @@ EXAMPLES
   $ architect task --account=myaccount --environment=myenvironment mycomponent:latest mytask
 ```
 
-_See code: [src/commands/task.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/task.ts)_
+_See code: [src/commands/task.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/task.ts)_
 
 ## `architect unlink [COMPONENTPATHORNAME]`
 
@@ -924,5 +924,5 @@ EXAMPLES
   $ architect unlink -p mycomponent
 ```
 
-_See code: [src/commands/unlink.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.1/src/commands/unlink.ts)_
+_See code: [src/commands/unlink.ts](https://github.com/architect-team/architect-cli/blob/v1.36.1-rc.2/src/commands/unlink.ts)_
 <!-- commandsstop -->

--- a/bin/run
+++ b/bin/run
@@ -1,4 +1,13 @@
-#!/usr/bin/env -S node --no-warnings
+#!/usr/bin/env node
+
+// Hide ExperimentalWarnings that appear from oclif when users are running earlier version of node 18
+// https://github.com/netlify/cli/issues/4608#issuecomment-1452541908
+process.removeAllListeners('warning');
+process.on('warning', (l) => {
+  if (l.name !== 'ExperimentalWarning') {
+    console.warn(l);
+  }
+});
 
 require('reflect-metadata')
 

--- a/bin/run
+++ b/bin/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --no-warnings
 
 require('reflect-metadata')
 

--- a/bin/run
+++ b/bin/run
@@ -1,4 +1,7 @@
-#!/usr/bin/env -S node --no-warnings
+#!/usr/bin/env node
+
+// Disable node ExperimentalWarning from release execution
+process.env.NODE_NO_WARNINGS = 1;
 
 require('reflect-metadata')
 

--- a/bin/run
+++ b/bin/run
@@ -1,7 +1,4 @@
-#!/usr/bin/env node
-
-// Disable node ExperimentalWarning from release execution
-process.env.NODE_NO_WARNINGS = 1;
+#!/usr/bin/env -S node --no-warnings
 
 require('reflect-metadata')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@architect-io/cli",
-  "version": "1.36.1-arc-tyler.1",
+  "version": "1.36.1-arc-tyler.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@architect-io/cli",
-      "version": "1.36.1-arc-tyler.1",
+      "version": "1.36.1-arc-tyler.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@kubernetes/client-node": "^0.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@architect-io/cli",
-  "version": "1.36.0-rc.8",
+  "version": "1.36.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@architect-io/cli",
-      "version": "1.36.0-rc.8",
+      "version": "1.36.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@kubernetes/client-node": "^0.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@architect-io/cli",
-  "version": "1.36.1-rc.2",
+  "version": "1.36.1-arc-tyler.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@architect-io/cli",
-      "version": "1.36.1-rc.2",
+      "version": "1.36.1-arc-tyler.3",
       "license": "GPL-3.0",
       "dependencies": {
         "@kubernetes/client-node": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@architect-io/cli",
   "description": "Command-line interface for Architect.io",
-  "version": "1.36.0-rc.8",
+  "version": "1.36.0",
   "author": "Architect.io",
   "bin": {
     "architect": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@architect-io/cli",
   "description": "Command-line interface for Architect.io",
-  "version": "1.36.1-rc.2",
+  "version": "1.36.1-arc-tyler.3",
   "author": "Architect.io",
   "bin": {
     "architect": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@architect-io/cli",
   "description": "Command-line interface for Architect.io",
-  "version": "1.36.1-arc-tyler.1",
+  "version": "1.36.1-arc-tyler.2",
   "author": "Architect.io",
   "bin": {
     "architect": "./bin/run"


### PR DESCRIPTION
Related to https://gitlab.com/architect-io/architect-cli/-/issues/640

Using node 18.0.0 until 18.1(ish,) Axios has some code that emits a warning, and that happens to run when running `architect init` but also any other architect command - something in oclif is running the code that ends up emitting this warning.

With node 18.0.0, this warning now goes away:
```sh
~/code/architect/architect-cli (arc-tyler) » ./bin/dev init                                                    
? What is the name of your project? (node:12303) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
~/code/architect/architect-cli (arc-tyler) » ./bin/run init                                               
? What is the name of your project?
~/code/architect/architect-cli (arc-tyler) » node --version            
v18.0.0
```

Won't affect dev so we can still see these warnings, which seems potentially important

Also confirmed this works on windows via powershell:
```
PS F:\architect\architect-cli> .\bin\run.cmd init
? What is the filename of the Docker Compose file you would like to convert?
PS F:\architect\architect-cli> .\bin\dev.cmd init
? What is the name of your project? (node:5032) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
PS F:\architect\architect-cli> ^C
```