### PR TITLE
Require nodejs version of 14 or greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript": "^4.5.5"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "engineStrict": true,
   "files": [


### PR DESCRIPTION
## Overview
Make incompatible with version 12 of nodejs. This version has been deprecated.


## Changes
Change engine version


## Tests
Run npm install on version 12 of nodejs
```
muesch@Michael-PC:~/Architect/code/architect-cli$ npm install
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for @architect-io/cli@1.36.0: wanted: {"node":">=14"} (current: {"node":"12.22.12","npm":"6.14.16"})
npm ERR! notsup Not compatible with your version of node/npm: @architect-io/cli@1.36.0
npm ERR! notsup Not compatible with your version of node/npm: @architect-io/cli@1.36.0
npm ERR! notsup Required: {"node":">=14"}
npm ERR! notsup Actual:   {"npm":"6.14.16","node":"12.22.12"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/muesch/.npm/_logs/2023-03-22T17_57_14_031Z-debug.log
```