### PR TITLE
Remove docker as required for init

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,7 +11,6 @@ import ProjectUtils from '../architect/project/project.utils';
 import BaseCommand from '../base-command';
 import { DockerComposeUtils } from '../common/docker-compose';
 import { ComposeConverter } from '../common/docker-compose/converter';
-import { RequiresDocker } from '../common/docker/helper';
 import { RequiresGit } from '../common/utils/git/helper';
 import PromptUtils from '../common/utils/prompt-utils';
 import { ComponentSlugUtils } from '../dependency-manager/spec/utils/slugs';
@@ -85,7 +84,6 @@ export abstract class InitCommand extends BaseCommand {
   }
 
   @RequiresGit()
-  @RequiresDocker({ compose: true })
   async runProjectCreation(project_name: string, flags: OutputFlags<typeof InitCommand.flags>): Promise<void> {
     if (fs.existsSync(`./${project_name}`)) {
       console.log(chalk.red(`The folder ./${project_name} already exists. Please choose a different project name or remove the folder`));


### PR DESCRIPTION
## Overview
Docker should not be required to generate a starter project.


## Changes
Remove docker required annotation


## Tests
Ran tests locally.
1. Stop docker
2. Run architect init
3. Profit