### PR TITLE
Add checks for kubectl and server connection

### DIFF
--- a/src/commands/clusters/create.ts
+++ b/src/commands/clusters/create.ts
@@ -12,6 +12,7 @@ import Cluster from '../../architect/cluster/cluster.entity';
 import ClusterUtils, { CreateClusterInput } from '../../architect/cluster/cluster.utils';
 import PipelineUtils from '../../architect/pipeline/pipeline.utils';
 import BaseCommand from '../../base-command';
+import { RequiresKubectl } from '../../common/kubectl/helper';
 import { AgentClusterUtils } from '../../common/utils/agent-cluster.utils';
 import { booleanString } from '../../common/utils/oclif';
 
@@ -79,6 +80,7 @@ export default class ClusterCreate extends BaseCommand {
     return parsed;
   }
 
+  @RequiresKubectl()
   async run(): Promise<void> {
     await this.createCluster();
   }
@@ -146,7 +148,7 @@ export default class ClusterCreate extends BaseCommand {
     }
 
     const kube_contexts = await this.setupKubeContext(flags);
-    await ClusterUtils.checkClientVersion(flags.kubeconfig);
+    await ClusterUtils.checkServerVersion(flags.kubeconfig);
 
     try {
       const cluster_dto = {

--- a/src/common/kubectl/helper.ts
+++ b/src/common/kubectl/helper.ts
@@ -1,0 +1,50 @@
+import which from 'which';
+import { ArchitectError } from '../../dependency-manager/utils/errors';
+
+class _KubectlHelper {
+  kubectl_installed: boolean;
+
+  constructor() {
+    this.kubectl_installed = this.checkKubectlInstalled();
+  }
+
+  static getTestHelper(): _KubectlHelper {
+    const helper = new _KubectlHelper();
+    helper.kubectl_installed = true;
+    return helper;
+  }
+
+  checkKubectlInstalled(): boolean {
+    try {
+      which.sync('kubectl');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  verifyKubectl(): void {
+    if (!this.kubectl_installed) {
+      throw new ArchitectError('Architect requires Kubectl to be installed.\nPlease install kubectl and try again: https://kubernetes.io/docs/tasks/tools/#kubectl');
+    }
+  }
+}
+
+export const KubernetesHelper = process.env.TEST === '1' ? _KubectlHelper.getTestHelper() : new _KubectlHelper();
+
+/**
+ * Used to wrap functions that require kubectl. Makes sure that kubectl is installed
+ * before work begins.
+ */
+export function RequiresKubectl(): (target: any, propertyKey: string, descriptor: PropertyDescriptor) => any {
+  return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+    const wrappedFunc = descriptor.value;
+    descriptor.value = function (this: any, ...args: any[]) {
+      // We always want to verify kubectl is installed
+      KubernetesHelper.verifyKubectl();
+
+      return wrappedFunc.apply(this, args);
+    };
+    return descriptor;
+  };
+}

--- a/test/commands/clusters/create.test.ts
+++ b/test/commands/clusters/create.test.ts
@@ -34,7 +34,7 @@ describe('cluster:create', function () {
 
   const create_test = () => {
     return test
-      .stub(ClusterUtils, 'getClientVersion', sinon.stub().returns(MIN_CLUSTER_SEMVER.version))
+      .stub(ClusterUtils, 'getServerVersion', sinon.stub().returns(MIN_CLUSTER_SEMVER.version))
       .stub(ClusterCreate.prototype, 'log', sinon.stub())
       .stub(PipelineUtils, 'pollPipeline', async () => mock_pipeline)
       .stub(fs, 'readJSONSync', () => {
@@ -144,7 +144,7 @@ describe('cluster:create', function () {
     })
 
   test
-    .stub(ClusterUtils, 'getClientVersion', sinon.stub().returns('v1.0.0'))
+    .stub(ClusterUtils, 'getServerVersion', sinon.stub().returns('v1.0.0'))
     .stub(ClusterCreate.prototype, 'log', sinon.stub())
     .stub(PipelineUtils, 'pollPipeline', async () => mock_pipeline)
     .stub(fs, 'readJSONSync', () => {

--- a/test/commands/platforms/create.test.ts
+++ b/test/commands/platforms/create.test.ts
@@ -35,7 +35,7 @@ describe('platform:create', function () {
 
   const create_test = () => {
     return test
-      .stub(ClusterUtils, 'getClientVersion', sinon.stub().returns(MIN_CLUSTER_SEMVER.version))
+      .stub(ClusterUtils, 'getServerVersion', sinon.stub().returns(MIN_CLUSTER_SEMVER.version))
       .stub(PlatformCreate.prototype, 'log', sinon.stub())
       .stub(PipelineUtils, 'pollPipeline', async () => mock_pipeline)
       .stub(fs, 'readJSONSync', () => {
@@ -145,7 +145,7 @@ describe('platform:create', function () {
     })
 
   test
-    .stub(ClusterUtils, 'getClientVersion', sinon.stub().returns('v1.0.0'))
+    .stub(ClusterUtils, 'getServerVersion', sinon.stub().returns('v1.0.0'))
     .stub(ClusterCreate.prototype, 'log', sinon.stub())
     .stub(PipelineUtils, 'pollPipeline', async () => mock_pipeline)
     .stub(fs, 'readJSONSync', () => {


### PR DESCRIPTION
## Overview
We now make sure that we can reach a cluster before we attempt to register it. We also make sure that the user has kubectl installed and provide better support if we do not.

## Changes
1. We were checking the wrong version when using kubectl. It was grabbing the client version and not the server version.
2. Using the same version check we now make sure a cluster is reachable before moving forward.
3. Added a `requiresKubectl` function to make sure it is installed. Long term we should use the Plugin system for this, but now at least we provide the user with more information than before.


## Tests
1. All tests run
2. Tested on machine without kubectl installed
3. Tested on an unreachable cluster
4. Tested with kubectl installed and a reachable cluster


## Pictures

<img width="1231" alt="WindowsTerminal_tRau1wOshV" src="https://user-images.githubusercontent.com/532523/228338447-017da244-574c-4114-b427-15434f5c8864.png">
<img width="1191" alt="WindowsTerminal_j3M2rhM19F" src="https://user-images.githubusercontent.com/532523/228338497-8c2d805e-5dcc-4204-ae41-4c03bcf8fea4.png">
