### PR TITLE
Fix build args integer issue

### DIFF
--- a/src/common/docker-compose/converter.ts
+++ b/src/common/docker-compose/converter.ts
@@ -115,6 +115,9 @@ export class ComposeConverter {
       build.args = {};
       if (Array.isArray(compose_build.args)) {
         for (const arg of compose_build.args) {
+          if (!arg) {
+ continue;
+}
           const [key, value] = arg.split('=');
           build.args[key] = value ? value.toString() : null;
         }

--- a/src/common/docker-compose/converter.ts
+++ b/src/common/docker-compose/converter.ts
@@ -116,15 +116,11 @@ export class ComposeConverter {
       if (Array.isArray(compose_build.args)) {
         for (const arg of compose_build.args) {
           const [key, value] = arg.split('=');
-          if (key && value) {
-            build.args[key] = value;
-          } else {
-            warnings.push(`Could not convert environment variable ${arg}`);
-          }
+          build.args[key] = value ? value.toString() : null;
         }
-      } else {
-        for (const [key, value] of Object.entries(compose_build.args as Dictionary<string>)) {
-          build.args[key] = value.toString();
+      } else if (compose_build.args instanceof Object && Object.keys(compose_build.args).length > 0) {
+        for (const [key, value] of Object.entries(compose_build.args as Dictionary<any>)) {
+          build.args[key] = value ? value.toString() : null;
         }
       }
       build.context = compose_build.context;

--- a/src/common/docker-compose/converter.ts
+++ b/src/common/docker-compose/converter.ts
@@ -112,8 +112,8 @@ export class ComposeConverter {
     if (typeof compose_build === 'string') {
       build.context = compose_build;
     } else {
+      build.args = {};
       if (Array.isArray(compose_build.args)) {
-        build.args = {};
         for (const arg of compose_build.args) {
           const [key, value] = arg.split('=');
           if (key && value) {
@@ -123,7 +123,9 @@ export class ComposeConverter {
           }
         }
       } else {
-        build.args = compose_build.args;
+        for (const [key, value] of Object.entries(compose_build.args as Dictionary<string>)) {
+          build.args[key] = value.toString();
+        }
       }
       build.context = compose_build.context;
       if (compose_build.dockerfile) {

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -78,6 +78,7 @@ services:
       expect(component_config.services.logstash.build!.args!.ELK_VERSION).eq('$ELK_VERSION');
       expect(component_config.services.logstash.build!.args!.INT_ARG).eq('1');
       expect(component_config.services.logstash.build!.args!.BOOL_ARG).eq('true');
+      expect(component_config.services.logstash.build!.args!.EMPTY_ARG).eq('null');
     });
 
   mockInit()
@@ -157,6 +158,10 @@ services:
 
       const component_config = buildConfigFromYml(writeFileSync.args[0][1]);
       expect(component_config.services.elasticsearch.build!.args!.ELK_VERSION).eq('$ELK_VERSION');
+      expect(component_config.services.elasticsearch.build!.args!.INT_ARG).eq('1');
+      expect(component_config.services.elasticsearch.build!.args!.BOOL_ARG).eq('true');
+      expect(component_config.services.elasticsearch.build!.args!.EMPTY_ARG).eq('null');
+      expect(component_config.services.elasticsearch.build!.args!.EMPTY_ARG2).eq('null');
       expect(component_config.services.elasticsearch.build!.context).eq('elasticsearch/');
       expect(component_config.services.elasticsearch.build!.dockerfile).eq('Dockerfile.elasticsearch');
     });

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -69,6 +69,18 @@ services:
     });
 
   mockInit()
+    .command(['init', '--from-compose', compose_file_path, 'test-component', '-o', 'test-directory/architect.yml'])
+    .it('converts different types of build arg value of the docker compose file', ctx => {
+      const writeFileSync = fs.writeFileSync as sinon.SinonStub;
+      expect(writeFileSync.called).to.be.true;
+      expect(writeFileSync.args[0][0]).eq('test-directory/architect.yml');
+      const component_config = buildConfigFromYml(writeFileSync.args[0][1]);
+      expect(component_config.services.logstash.build!.args!.ELK_VERSION).eq('$ELK_VERSION');
+      expect(component_config.services.logstash.build!.args!.INT_ARG).eq('1');
+      expect(component_config.services.logstash.build!.args!.BOOL_ARG).eq('true');
+    });
+
+  mockInit()
     .command(['init', '--from-compose', compose_file_path, 'test-component'])
     .it('adds environment variables to each service', ctx => {
       const writeFileSync = fs.writeFileSync as sinon.SinonStub;

--- a/test/mocks/init-compose.yml
+++ b/test/mocks/init-compose.yml
@@ -6,6 +6,10 @@ services:
       context: elasticsearch/
       args:
         - ELK_VERSION=$ELK_VERSION
+        - INT_ARG=1
+        - BOOL_ARG=true
+        - EMPTY_ARG
+        - EMPTY_ARG2=
       dockerfile: Dockerfile.elasticsearch
       target: production
     volumes:
@@ -42,6 +46,7 @@ services:
         ELK_VERSION: $ELK_VERSION
         INT_ARG: 1
         BOOL_ARG: true
+        EMPTY_ARG:
       target: build
     volumes:
       - type: bind

--- a/test/mocks/init-compose.yml
+++ b/test/mocks/init-compose.yml
@@ -10,6 +10,7 @@ services:
         - BOOL_ARG=true
         - EMPTY_ARG
         - EMPTY_ARG2=
+        -
       dockerfile: Dockerfile.elasticsearch
       target: production
     volumes:

--- a/test/mocks/init-compose.yml
+++ b/test/mocks/init-compose.yml
@@ -40,6 +40,8 @@ services:
       context: logstash/
       args:
         ELK_VERSION: $ELK_VERSION
+        INT_ARG: 1
+        BOOL_ARG: true
       target: build
     volumes:
       - type: bind


### PR DESCRIPTION
## Overview
Closes https://gitlab.com/architect-io/architect-cli/-/issues/645  
Fix issue with build args value that occurred when converting a docker-compose.yml to architect.yml.


## Changes
If build args is a map, cast each value to string.


## Tests
docker-compose.yml  
```
version: "3"
services:
  app:
    build:
      context: .
      args:
        INT_ARG: 1
        BOOL_ARG: true
```

Run `architect-local init --from-compose=docker-compose.yml test`.   
Should generate the following architect.yml 
```
name: test
services:
  app:
    build:
      args:
        INT_ARG: '1'
        BOOL_ARG: 'true'
      context: .
    reserved_name: app
```
