### PR TITLE
648 rounding number

### DIFF
--- a/src/common/utils/deploy.utils.ts
+++ b/src/common/utils/deploy.utils.ts
@@ -1,4 +1,3 @@
-import { isNumberString } from 'class-validator';
 import deepmerge from 'deepmerge';
 import * as dotenv from 'dotenv';
 import * as dotenvExpand from 'dotenv-expand';
@@ -7,7 +6,7 @@ import yaml from 'js-yaml';
 import { ArchitectError, Dictionary } from '../../';
 import { SecretsDict } from '../../dependency-manager/secrets/type';
 import { SecretSpecValue } from '../../dependency-manager/spec/secret-spec';
-import { parseValue } from './secret/helper';
+import { parseEnvironmentVariable } from './secret/helper';
 
 export default class DeployUtils {
   private static getExtraSecrets(secrets: string[] = []): Dictionary<string | number | null> {
@@ -16,8 +15,7 @@ export default class DeployUtils {
     for (const [secret_name, secret_value] of Object.entries(process.env || {})) {
       if (secret_name.startsWith('ARC_')) {
         const key = secret_name.substring(4);
-        const value = parseValue(secret_value);
-        extra_secrets[key] = value;
+        extra_secrets[key] = parseEnvironmentVariable(secret_value);
       }
     }
 
@@ -26,11 +24,7 @@ export default class DeployUtils {
       if (secret_split.length !== 2) {
         throw new ArchitectError(`Bad format for secret ${secret}. Please specify in the format --secret SECRET_NAME=SECRET_VALUE`, false);
       }
-      let value: string | number = secret_split[1];
-      if (isNumberString(value)) {
-        value = Number.parseFloat(value);
-      }
-      extra_secrets[secret_split[0]] = value;
+      extra_secrets[secret_split[0]] = parseEnvironmentVariable(secret_split[1]);
     }
 
     return extra_secrets;

--- a/src/common/utils/deploy.utils.ts
+++ b/src/common/utils/deploy.utils.ts
@@ -7,18 +7,16 @@ import yaml from 'js-yaml';
 import { ArchitectError, Dictionary } from '../../';
 import { SecretsDict } from '../../dependency-manager/secrets/type';
 import { SecretSpecValue } from '../../dependency-manager/spec/secret-spec';
+import { parseValue } from './secret/helper';
 
 export default class DeployUtils {
-  private static getExtraSecrets(secrets: string[] = []): Dictionary<string | number | undefined> {
-    const extra_secrets: { [s: string]: string | number | undefined } = {};
+  private static getExtraSecrets(secrets: string[] = []): Dictionary<string | number | null> {
+    const extra_secrets: { [s: string]: string | number | null } = {};
 
     for (const [secret_name, secret_value] of Object.entries(process.env || {})) {
       if (secret_name.startsWith('ARC_')) {
         const key = secret_name.substring(4);
-        let value: string | number | undefined = secret_value;
-        if (value && isNumberString(value)) {
-          value = Number.parseFloat(value);
-        }
+        const value = parseValue(secret_value);
         extra_secrets[key] = value;
       }
     }

--- a/src/common/utils/secret/helper.ts
+++ b/src/common/utils/secret/helper.ts
@@ -1,6 +1,6 @@
 import { isNumberString } from 'class-validator';
 
-export const parseValue = (secret_value: string | undefined): (string | number | null) => {
+export const parseEnvironmentVariable = (secret_value: string | undefined): (string | number | null) => {
   if (!secret_value) {
     return null;
   }

--- a/src/common/utils/secret/helper.ts
+++ b/src/common/utils/secret/helper.ts
@@ -1,0 +1,16 @@
+import { isNumberString } from 'class-validator';
+
+export const parseValue = (secret_value: string | undefined): (string | number | null) => {
+  if (!secret_value) {
+    return null;
+  }
+
+  let value: string | number = secret_value;
+  if (value && isNumberString(value)) {
+    value = Number.parseFloat(value);
+  }
+  if (`${value}`.length !== secret_value?.length) {
+    value = secret_value;
+  }
+  return value;
+};

--- a/test/commands/dev/index.test.ts
+++ b/test/commands/dev/index.test.ts
@@ -1466,4 +1466,60 @@ describe('local dev environment', function () {
       expect(e.message).contains(`--ssl=false`);
     })
     .it('Show helpful error msg if dev fails without internet connection.');
+
+  test
+    .timeout(20000)
+    .stub(ComponentBuilder, 'buildSpecFromPath', () => {
+      return buildSpecFromYml(local_component_config_with_environment_secret);
+    })
+    .nock(MOCK_API_HOST, api => api
+      .get(`/accounts/${account.name}`)
+      .reply(200, account)
+      .persist())
+    .stub(SecretUtils, 'getSecrets', () => {
+      return [
+        {
+          key: 'a_required_key',
+          value: '12345.123456789',
+          scope: '*',
+        },
+      ];
+    })
+    .stub(Dev.prototype, 'failIfEnvironmentExists', sinon.stub().returns(undefined))
+    .stub(Dev.prototype, 'runCompose', sinon.stub().returns(undefined))
+    .stub(Dev.prototype, 'downloadSSLCerts', sinon.stub().returns(undefined))
+    .stdout({ print })
+    .stderr({ print })
+    .command(['dev', getMockComponentFilePath('hello-world'), '--secrets-env=env', '-a', 'examples', '--ssl=false'])
+    .it('Create a local dev with a number secret in an environment secret', ctx => {
+      const runCompose = Dev.prototype.runCompose as sinon.SinonStub;
+      expect(runCompose.calledOnce).to.be.true;
+      const hello_world_environment = (runCompose.firstCall.args[0].services[hello_api_ref] as any).environment;
+      expect(hello_world_environment.a_required_key).to.equal('12345.123456789');
+    });
+
+  test
+    .timeout(20000)
+    .stub(ComponentBuilder, 'buildSpecFromPath', () => {
+      return buildSpecFromYml(local_component_config_with_environment_secret);
+    })
+    .nock(MOCK_API_HOST, api => api
+      .get(`/accounts/${account.name}`)
+      .reply(200, account)
+      .persist())
+    .stub(SecretUtils, 'getSecrets', () => {
+      return [];
+    })
+    .stub(Dev.prototype, 'failIfEnvironmentExists', sinon.stub().returns(undefined))
+    .stub(Dev.prototype, 'runCompose', sinon.stub().returns(undefined))
+    .stub(Dev.prototype, 'downloadSSLCerts', sinon.stub().returns(undefined))
+    .stdout({ print })
+    .stderr({ print })
+    .command(['dev', getMockComponentFilePath('hello-world'), '-s', 'a_required_key=12345.123456789', '-a', 'examples', '--ssl=false'])
+    .it('Create a local dev with a number secret with many digits after decimal point', ctx => {
+      const runCompose = Dev.prototype.runCompose as sinon.SinonStub;
+      expect(runCompose.calledOnce).to.be.true;
+      const hello_world_environment = (runCompose.firstCall.args[0].services[hello_api_ref] as any).environment;
+      expect(hello_world_environment.a_required_key).to.equal('12345.123456789');
+    });
 });


### PR DESCRIPTION
## Overview
Closes https://gitlab.com/architect-io/architect-cli/-/issues/648.  
Fix rounding issue when reading local environment variable with `dotenv`.


## Changes
If the secret value get rounded when casting to a number, use its string format instead.


## Tests
Export an environment variable    
$ export ARC_world_text=1232456789.1232456789   
Run hello-world example    
$ architect dev   

I tested it this way instead of using the `dotenv` command, `dotenv -e .env architect dev`, because the new code doesn't seem to be picked up.

Test remote   
Use package `"@architect-io/cli": "1.37.0-arc-mary.1"` in the API.    
$ architect-local register  
$ architect-dev register  
Deploy it with the following `world_text` value  
![Screenshot 2023-04-04 at 10 00 19 AM](https://user-images.githubusercontent.com/102971990/229819287-4a1d95f7-74e9-4d30-950c-9071d967757a.png)
![Screenshot 2023-04-04 at 10 07 55 AM](https://user-images.githubusercontent.com/102971990/229819320-cee725b7-d88c-48ba-8953-fb8580d75c30.png)

