### PR TITLE
throwing a useful error if a user attempts to register a cluster with no nodes

### DIFF
--- a/src/architect/cluster/cluster.utils.ts
+++ b/src/architect/cluster/cluster.utils.ts
@@ -116,4 +116,15 @@ export default class ClusterUtils {
       throw new ArchitectError(`Currently, we only support Kubernetes clusters on version ${MIN_CLUSTER_SEMVER.version} or greater. Your cluster is currently on version ${client_semver.version} which is below the minimum required version. Please upgrade your cluster before registering it with Architect.`);
     }
   }
+
+  public static async checkClusterNodes(kubeconfig_path: string): Promise<void> {
+    const set_kubeconfig = ['--kubeconfig', untildify(kubeconfig_path)];
+    const { stderr } = await execa('kubectl', [
+      ...set_kubeconfig,
+      'get', 'nodes',
+    ]);
+    if (stderr === 'No resources found') {
+      throw new Error('No nodes were detected for the Kubernetes cluster. Please add nodes to the cluster in order for your applications to run.');
+    }
+  }
 }

--- a/src/commands/clusters/create.ts
+++ b/src/commands/clusters/create.ts
@@ -149,6 +149,7 @@ export default class ClusterCreate extends BaseCommand {
 
     const kube_contexts = await this.setupKubeContext(flags);
     await ClusterUtils.checkServerVersion(flags.kubeconfig);
+    await ClusterUtils.checkClusterNodes(flags.kubeconfig);
 
     try {
       const cluster_dto = {

--- a/test/commands/platforms/create.test.ts
+++ b/test/commands/platforms/create.test.ts
@@ -36,6 +36,7 @@ describe('platform:create', function () {
   const create_test = () => {
     return test
       .stub(ClusterUtils, 'getServerVersion', sinon.stub().returns(MIN_CLUSTER_SEMVER.version))
+      .stub(ClusterUtils, 'checkClusterNodes', sinon.stub().resolves())
       .stub(PlatformCreate.prototype, 'log', sinon.stub())
       .stub(PipelineUtils, 'pollPipeline', async () => mock_pipeline)
       .stub(fs, 'readJSONSync', () => {
@@ -146,6 +147,7 @@ describe('platform:create', function () {
 
   test
     .stub(ClusterUtils, 'getServerVersion', sinon.stub().returns('v1.0.0'))
+    .stub(ClusterUtils, 'checkClusterNodes', sinon.stub().resolves())
     .stub(ClusterCreate.prototype, 'log', sinon.stub())
     .stub(PipelineUtils, 'pollPipeline', async () => mock_pipeline)
     .stub(fs, 'readJSONSync', () => {
@@ -172,4 +174,32 @@ describe('platform:create', function () {
       expect(e.message).contains(`Currently, we only support Kubernetes clusters on version ${MIN_CLUSTER_SEMVER.version} or greater. Your cluster is currently on version 1.0.0`);
     })
     .it('create cluster with older cluster version fails');
+
+  test
+    .stub(ClusterUtils, 'getServerVersion', sinon.stub().returns(MIN_CLUSTER_SEMVER.version))
+    .stub(ClusterUtils, 'checkClusterNodes', sinon.stub().rejects(new Error('No nodes were detected for the Kubernetes cluster. Please add nodes to the cluster in order for your applications to run.')))
+    .stub(fs, 'readJSONSync', () => {
+      return {
+        log_level: 'debug',
+      };
+    })
+    .stub(AppService, 'create', () => new AppService('', '1.0.0'))
+    .stub(ClusterCreate.prototype, <any>'setupKubeContext', async () => {
+      return {
+        original_context: "original_context",
+        current_context: "current_context",
+      }
+    })
+    .stub(ClusterCreate.prototype, <any>'setContext', async () => { })
+    .nock('https://api.architect.io', api => api
+      .get(`/accounts/${account.name}`)
+      .reply(200, account))
+    .nock('https://api.architect.io', api => api
+      .get(`/accounts/${account.id}/clusters`)
+      .reply(200, clusters))
+    .command(['platform:create', '-a', account.name, 'my-cluster'])
+    .catch(e => {
+      expect(e.message).contains('No nodes were detected for the Kubernetes cluster. Please add nodes to the cluster in order for your applications to run.');
+    })
+    .it(`A cluster can't be registered if it has no nodes`);
 });


### PR DESCRIPTION
## Overview
Closes https://gitlab.com/architect-io/architect-cli/-/issues/573

## Changes
* Throwing a useful error if a user attempts to register a cluster with no nodes

## Tests
* Added tests
* Attempted to register a cluster that had no nodes and a different cluster that had nodes