### PR TITLE
Require dev port selected is 80, 443, or between 1024-65535 

### DIFF
--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -58,7 +58,7 @@ export default class Dev extends BaseCommand {
   static examples = [
     'architect dev ./mycomponent/architect.yml',
     'architect dev ./mycomponent/architect.yml -a myaccount --secrets-env=myenvironment',
-    'architect dev --port=81 --browser=false --debug=true --secret-file=./mycomponent/mysecrets.yml ./mycomponent/architect.yml',
+    'architect dev --port=1234 --browser=false --debug=true --secret-file=./mycomponent/mysecrets.yml ./mycomponent/architect.yml',
   ];
 
   static flags = {
@@ -123,8 +123,10 @@ export default class Dev extends BaseCommand {
       sensitive: false,
     }),
     port: Flags.integer({
-      description: '[default: 443] Port for the gateway',
+      description: 'Port for the gateway. Defaults to 443, or 80 if --ssl=false. When specified, must be between 1024 and 65535.',
       sensitive: false,
+      min: 1024,
+      max: 65535,
     }),
     // Used for proxy from deploy to dev. These will be removed once --local is deprecated
     local: booleanString({
@@ -432,10 +434,11 @@ export default class Dev extends BaseCommand {
           name: 'port',
           message: `Trying to listen on port ${port}, but something is already using it. What port would you like us to run the API gateway on (you can use the '--port' flag to skip this message in the future)?`,
           validate: (value) => {
-            if (new RegExp('^[1-9]+\\d*$').test(value)) {
-              return true;
+            const port = Number.parseInt(value);
+            if (Number.isNaN(port) || port < 1024 || port > 65535) {
+              return `Port must be positive number between 1024 and 65535.`;
             }
-            return `Port can only be positive number.`;
+            return true;
           },
         },
       ]);


### PR DESCRIPTION
TIcket: https://gitlab.com/architect-io/architect-cli/-/issues/644 


This prevents _most_ cases of getting `ERR_UNSAFE_PORT` errors from Chrome/Firefox/etc. if the user happens to choose a port that browsers disallow connections to.

A full list of disallowed ports is browser dependent - [Chrome](https://chromium.googlesource.com/chromium/src.git/+/refs/heads/master/net/base/port_util.cc) and [Firefox](https://www-archive.mozilla.org/projects/netlib/portbanning#portlist) examples here. Ports 1-1023 are [Well-known ports](https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Well-known_ports) and many are reserved for specific services, so by forcing users to choose ports >= 1024 and <= 65535 the chance of selecting a well-known port that is blocked is less likely. 