### PR TITLE
649 liveness probe port path

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import fs from 'fs';
 import inquirer from 'inquirer';
 import AccountUtils from '../architect/account/account.utils';
+import Deployment from '../architect/deployment/deployment.entity';
 import { EnvironmentUtils, GetEnvironmentOptions } from '../architect/environment/environment.utils';
 import Pipeline from '../architect/pipeline/pipeline.entity';
 import PipelineUtils from '../architect/pipeline/pipeline.utils';
@@ -308,6 +309,22 @@ export default class Deploy extends DeployCommand {
       this.log('Deployed services are now available at the following URLs:\n');
       for (const url of available_urls) {
         this.log(`\t${url}`);
+      }
+    }
+
+    // Warnings for the deprecation of liveness_probe path and port
+    const response = await this.app.api.get(`/pipelines/${pipeline.id}/deployments`);
+    const deployments: Deployment[] = response.data;
+    this.generateDeprecateWarnings(deployments);
+  }
+
+  private generateDeprecateWarnings(deployments: Deployment[]) {
+    for (const deployment of deployments) {
+      for (const service of Object.values(deployment.component_version.config.services || {})) {
+        if (service.liveness_probe && (service.liveness_probe.path || service.liveness_probe.port)) {
+          this.log(chalk.yellow(`Deprecated warnings: The liveness probe 'path' and 'port' will no longer be supported starting October of 2023. We recommend that you update your configuration to use the 'command' option https://docs.architect.io/reference/release-notes.`));
+          return;
+        }
       }
     }
   }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -322,7 +322,7 @@ export default class Deploy extends DeployCommand {
     for (const deployment of deployments) {
       for (const service of Object.values(deployment.component_version.config.services || {})) {
         if (service.liveness_probe && (service.liveness_probe.path || service.liveness_probe.port)) {
-          this.log(chalk.yellow(`Deprecated warnings: The liveness probe 'path' and 'port' will no longer be supported starting October of 2023. We recommend that you update your configuration to use the 'command' option https://docs.architect.io/reference/release-notes.`));
+          this.log(chalk.yellow(`Deprecation warning: The liveness probe 'path' and 'port' will no longer be supported starting August of 2023. We recommend that you update your configuration to use the 'command' option https://docs.architect.io/reference/release-notes.`));
           return;
         }
       }

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -317,6 +317,18 @@ export default class ComponentRegister extends BaseCommand {
     }
 
     console.timeEnd('Time');
+    this.generateDeprecateWarnings(new_spec);
+  }
+
+  private generateDeprecateWarnings(component_spec: ComponentSpec) {
+    if (component_spec.services) {
+      for (const service of Object.values(component_spec.services)) {
+        if (service.liveness_probe && (service.liveness_probe.path || service.liveness_probe.port)) {
+          this.log(chalk.yellow(`Deprecated warnings: The liveness probe 'path' and 'port' will no longer be supported starting October of 2023. We recommend that you update your configuration to use the 'command' option https://docs.architect.io/reference/release-notes.`));
+          return;
+        }
+      }
+    }
   }
 
   private async setImageRef(composes: Composes, graph: Readonly<DependencyGraphMutable>): Promise<ImageRefOutput> {

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -324,7 +324,7 @@ export default class ComponentRegister extends BaseCommand {
     if (component_spec.services) {
       for (const service of Object.values(component_spec.services)) {
         if (service.liveness_probe && (service.liveness_probe.path || service.liveness_probe.port)) {
-          this.log(chalk.yellow(`Deprecated warnings: The liveness probe 'path' and 'port' will no longer be supported starting October of 2023. We recommend that you update your configuration to use the 'command' option https://docs.architect.io/reference/release-notes.`));
+          this.log(chalk.yellow(`Deprecation warning: The liveness probe 'path' and 'port' will no longer be supported starting August of 2023. We recommend that you update your configuration to use the 'command' option https://docs.architect.io/reference/release-notes.`));
           return;
         }
       }

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@oclif/test';
 import sinon, { SinonSpy } from 'sinon';
-import { ComponentVersionSlugUtils } from '../../src';
+import { ComponentVersionSlugUtils, LivenessProbeConfig, RecursivePartial } from '../../src';
 import PipelineUtils from '../../src/architect/pipeline/pipeline.utils';
 import Deploy from '../../src/commands/deploy';
 import ComponentRegister from '../../src/commands/register';
@@ -49,6 +49,26 @@ const mock_certificates = [
   },
 ];
 
+const mock_liveness_probe: RecursivePartial<LivenessProbeConfig> = {
+  port: 3000,
+  path: '/',
+};
+
+const mock_deployments = [
+  {
+    component_version: {
+      config: {
+        name: 'hello-world',
+        services: {
+          app: {
+            liveness_probe: mock_liveness_probe,
+          },
+        },
+      },
+    },
+  },
+];
+
 describe('remote deploy environment', function () {
   new MockArchitectApi()
     .getAccount(account)
@@ -57,6 +77,7 @@ describe('remote deploy environment', function () {
     .getEnvironmentCertificates(environment, mock_certificates)
     .approvePipeline(mock_pipeline)
     .pollPipeline(mock_pipeline)
+    .getPipelineDeployments(mock_pipeline, [])
     .getTests()
     .command(['deploy', '-e', environment.name, '-a', account.name, '--auto-approve', 'echo:latest'])
     .it('Creates a remote deployment when env exists with env and account flags', ctx => {
@@ -70,6 +91,7 @@ describe('remote deploy environment', function () {
     .getEnvironmentCertificates(environment, mock_certificates)
     .approvePipeline(mock_pipeline)
     .pollPipeline(mock_pipeline)
+    .getPipelineDeployments(mock_pipeline, [])
     .getTests()
     .stub(ComponentRegister.prototype, 'run', sinon.stub().returns(Promise.resolve()))
     .stub(ComponentBuilder, 'buildSpecFromPath', sinon.stub().returns(Promise.resolve()))
@@ -90,6 +112,7 @@ describe('remote deploy environment', function () {
     .getEnvironmentCertificates(environment, mock_certificates)
     .approvePipeline(mock_pipeline)
     .pollPipeline(mock_pipeline)
+    .getPipelineDeployments(mock_pipeline, [])
     .getTests()
     .stub(ComponentRegister.prototype, 'run', sinon.stub().returns(Promise.resolve()))
     .stub(ComponentBuilder, 'buildSpecFromPath', sinon.stub().returns(Promise.resolve()))
@@ -115,6 +138,7 @@ describe('remote deploy environment', function () {
     .getEnvironmentCertificates(environment, mock_certificates)
     .approvePipeline(mock_pipeline)
     .pollPipeline(mock_pipeline)
+    .getPipelineDeployments(mock_pipeline, [])
     .getTests()
     .command(['deploy', '-e', environment.name, '-a', account.name, '--auto-approve', 'echo:latest'])
     .it('Remote deployment outputs URLs from for the deployed component and not other components in the same environment', ctx => {
@@ -129,6 +153,7 @@ describe('remote deploy environment', function () {
     .getEnvironmentCertificates(environment, mock_certificates)
     .approvePipeline(mock_pipeline)
     .pollPipeline(mock_pipeline)
+    .getPipelineDeployments(mock_pipeline, [])
     .getTests()
     .command(['deploy', '-e', environment.name, '-a', account.name, '--auto-approve', 'echo'])
     .it('Remote deployment outputs URLs from for the deployed component with no tag and not other components in the same environment', ctx => {
@@ -144,6 +169,7 @@ describe('remote deploy environment', function () {
       .getEnvironmentCertificates(environment, mock_certificates)
       .approvePipeline(mock_pipeline)
       .pollPipeline(mock_pipeline)
+      .getPipelineDeployments(mock_pipeline, [])
       .getTests()
       .command(['deploy', '-e', environment.name, '-a', account.name, '--auto-approve', 'echo:latest@tenant-1'])
       .it('Creates a remote deployment when env exists with env and account flags', ctx => {
@@ -160,6 +186,7 @@ describe('auto-approve flag with underscore style still works', function () {
     .getEnvironmentCertificates(environment, mock_certificates)
     .approvePipeline(mock_pipeline)
     .pollPipeline(mock_pipeline)
+    .getPipelineDeployments(mock_pipeline, [])
     .getTests()
     .command(['deploy', '-e', environment.name, '-a', account.name, '--auto_approve', 'echo:latest'])
     .it('works but also emits a deprecation warning', ctx => {
@@ -174,6 +201,7 @@ describe('auto-approve flag with underscore style still works', function () {
     .getEnvironmentCertificates(environment, mock_certificates)
     .approvePipeline(mock_pipeline)
     .pollPipeline(mock_pipeline)
+    .getPipelineDeployments(mock_pipeline, [])
     .getTests()
     .command(['deploy', '-e', environment.name, '-a', account.name, '--auto_approve=true', 'echo:latest'])
     .it('works but also emits a deprecation warning 2', ctx => {
@@ -408,5 +436,22 @@ describe('deployment secrets', function () {
     .command(['deploy', '-e', environment.name, '-a', account.name, 'echo:latest', '--secret-file', './examples/echo/.env'])
     .it('passing a dotenv secrets file', ctx => {
       expect((Deploy.prototype.approvePipeline as SinonSpy).getCalls().length).to.equal(1);
+    });
+});
+
+describe('liveness_probe deprecation warning', function () {
+  new MockArchitectApi()
+    .getAccount(account)
+    .getEnvironment(account, environment)
+    .deployComponent(environment, mock_pipeline)
+    .getEnvironmentCertificates(environment, mock_certificates)
+    .approvePipeline(mock_pipeline)
+    .pollPipeline(mock_pipeline)
+    .getPipelineDeployments(mock_pipeline, mock_deployments)
+    .getTests()
+    .command(['deploy', '-e', environment.name, '-a', account.name, '--auto-approve', 'echo:latest'])
+    .it('warn when liveness_probe path and port are found in deployments', ctx => {
+      expect(ctx.stdout).to.contain(`Deprecated warnings: The liveness probe 'path' and 'port' will no longer be supported`);
+      expect(ctx.stdout).to.contain('deployed');
     });
 });

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -451,7 +451,7 @@ describe('liveness_probe deprecation warning', function () {
     .getTests()
     .command(['deploy', '-e', environment.name, '-a', account.name, '--auto-approve', 'echo:latest'])
     .it('warn when liveness_probe path and port are found in deployments', ctx => {
-      expect(ctx.stdout).to.contain(`Deprecated warnings: The liveness probe 'path' and 'port' will no longer be supported`);
+      expect(ctx.stdout).to.contain(`Deprecation warning: The liveness probe 'path' and 'port' will no longer be supported`);
       expect(ctx.stdout).to.contain('deployed');
     });
 });

--- a/test/commands/register.test.ts
+++ b/test/commands/register.test.ts
@@ -513,7 +513,7 @@ describe('register', function () {
     .stub(DockerBuildXUtils, 'convertToBuildxPlatforms', sinon.stub().returns([]))
     .command(['register', 'test/mocks/deprecations/liveness-probe-path-port.architect.yml', '-t', '1.0.0', '-a', 'examples'])
     .it('warn when register component with liveness_probe path and port', ctx => {
-      expect(ctx.stdout).to.contain(`Deprecated warnings: The liveness probe 'path' and 'port' will no longer be supported`);
+      expect(ctx.stdout).to.contain(`Deprecation warning: The liveness probe 'path' and 'port' will no longer be supported`);
       expect(ctx.stdout).to.contain('Successfully registered component');
     });
 });

--- a/test/commands/register.test.ts
+++ b/test/commands/register.test.ts
@@ -15,7 +15,6 @@ import PluginManager from '../../src/common/plugins/plugin-manager';
 import BuildPackUtils from '../../src/common/utils/buildpack';
 import { IF_EXPRESSION_REGEX } from '../../src/dependency-manager/spec/utils/interpolation';
 import { getMockComponentContextPath, getMockComponentFilePath, MockArchitectApi, ReplyCallback } from '../utils/mocks';
-import { Body, ReplyBody } from 'nock/types';
 
 describe('register', function () {
   const mock_account_response = {
@@ -503,6 +502,18 @@ describe('register', function () {
     .it('register component to account with name consists of uppercase letters', ctx => {
       const convert_to_buildx_platforms = DockerBuildXUtils.convertToBuildxPlatforms as SinonStub;
       expect(convert_to_buildx_platforms.calledOnce).true;
+      expect(ctx.stdout).to.contain('Successfully registered component');
+    });
+
+  new MockArchitectApi()
+    .getAccount(mock_account_response)
+    .architectRegistryHeadRequest()
+    .registerComponentDigest(mock_account_response)
+    .getTests()
+    .stub(DockerBuildXUtils, 'convertToBuildxPlatforms', sinon.stub().returns([]))
+    .command(['register', 'test/mocks/deprecations/liveness-probe-path-port.architect.yml', '-t', '1.0.0', '-a', 'examples'])
+    .it('warn when register component with liveness_probe path and port', ctx => {
+      expect(ctx.stdout).to.contain(`Deprecated warnings: The liveness probe 'path' and 'port' will no longer be supported`);
       expect(ctx.stdout).to.contain('Successfully registered component');
     });
 });

--- a/test/mocks/deprecations/liveness-probe-path-port.architect.yml
+++ b/test/mocks/deprecations/liveness-probe-path-port.architect.yml
@@ -1,0 +1,27 @@
+name: hello-world
+description: A simple hello-world component that returns "Hello World!" on every request.
+homepage: https://github.com/architect-team/architect-cli/tree/main/examples/hello-world
+keywords:
+  - hello-world
+  - nodejs
+  - architect
+  - examples
+
+secrets:
+  world_text:
+    default: World
+
+services:
+  api:
+    build:
+      context: ../../integration/hello-world
+    interfaces:
+      main:
+        port: 8080
+        ingress:
+          subdomain: hello
+    environment:
+      WORLD_TEXT: ${{ secrets.world_text }}
+    liveness_probe:
+      port: 3000
+      path: /


### PR DESCRIPTION
## Overview
Warn the user if the component they register or deploy uses liveness_probe `path` and `port`. I set the removal date to be October of 2023 but do let me know when is the best time. Also, we need to merge the docs first. 

## Tests
Add to the hello-world service:
```
    liveness_probe:
      port: 3000
      path: /
```
Then run
- $ architect-local register
<img width="1037" alt="Screenshot 2023-04-18 at 9 59 24 PM" src="https://user-images.githubusercontent.com/102971990/233240614-37d8dd1e-2cbb-4fc4-b401-cd5c643fb132.png">

- $ architect-dev register   
- $ architect-deploy hello-world  
<img width="906" alt="Screenshot 2023-04-19 at 10 18 32 PM" src="https://user-images.githubusercontent.com/102971990/233240767-f5c9f71e-5396-4a99-8d8f-34510dccf8b7.png">

## Docs
https://github.com/architect-team/documentation/pull/36

