### PR TITLE
Warn for deleted cluster deployment

### DIFF
--- a/src/architect/cluster/cluster.entity.ts
+++ b/src/architect/cluster/cluster.entity.ts
@@ -10,4 +10,11 @@ export default interface Cluster {
   type: string;
   account: Account;
   token: Token;
+  properties: {
+    is_shared?: boolean;
+    is_managed?: boolean;
+    is_local?: boolean;
+    host?: string;
+    traefik_version: string;
+  };
 }

--- a/src/architect/deployment/deployment.entity.ts
+++ b/src/architect/deployment/deployment.entity.ts
@@ -9,6 +9,7 @@ export default interface Deployment {
   failed_at?: string;
   aborted_at?: string;
   type: string;
+  action: string;
   metadata: {
     instance_name?: string;
   }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -235,10 +235,11 @@ export default class Deploy extends DeployCommand {
     const environment = await EnvironmentUtils.getEnvironment(this.app.api, account, get_environment_options);
     const has_cluster_deployment = await DeployUtils.hasClusterDeployment(this.app, environment.cluster);
     if (!has_cluster_deployment) {
+      const cluster_apps_url = `${this.app.config.app_host}/${environment.cluster.account.name}/clusters/${environment.cluster.name}/apps`;
       const confirmation_answers = await inquirer.prompt([{
         type: 'confirm',
         name: 'continue_deployment',
-        message: `We detected the application 'API Gateway' is not installed on your cluster '${environment.cluster.name}' which may lead to deployment failure. Would you like to continue your deployment?`,
+        message: `We detected that required applications aren't installed in your cluster which will lead to deployment failure. Please install the applications at ${cluster_apps_url} before attempting to deploy.`,
       }]);
       if (!confirmation_answers.continue_deployment) {
         this.exit(0);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -233,6 +233,17 @@ export default class Deploy extends DeployCommand {
     const account = await AccountUtils.getAccount(this.app, flags.account);
     const get_environment_options: GetEnvironmentOptions = { environment_name: flags.environment };
     const environment = await EnvironmentUtils.getEnvironment(this.app.api, account, get_environment_options);
+    const has_cluster_deployment = await DeployUtils.hasClusterDeployment(this.app, environment.cluster);
+    if (!has_cluster_deployment) {
+      const confirmation_answers = await inquirer.prompt([{
+        type: 'confirm',
+        name: 'continue_deployment',
+        message: `We detected the application 'API Gateway' is not installed on your cluster '${environment.cluster.name}' which may lead to deployment failure. Would you like to continue your deployment?`,
+      }]);
+      if (!confirmation_answers.continue_deployment) {
+        this.exit(0);
+      }
+    }
 
     const component_names: Set<string> = new Set<string>();
     for (const component of components) {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -236,14 +236,7 @@ export default class Deploy extends DeployCommand {
     const has_cluster_deployment = await DeployUtils.hasClusterDeployment(this.app, environment.cluster);
     if (!has_cluster_deployment) {
       const cluster_apps_url = `${this.app.config.app_host}/${environment.cluster.account.name}/clusters/${environment.cluster.name}/apps`;
-      const confirmation_answers = await inquirer.prompt([{
-        type: 'confirm',
-        name: 'continue_deployment',
-        message: `We detected that required applications aren't installed in your cluster which will lead to deployment failure. Please install the applications at ${cluster_apps_url} before attempting to deploy.`,
-      }]);
-      if (!confirmation_answers.continue_deployment) {
-        this.exit(0);
-      }
+      this.log(chalk.yellow(`We detected that required applications aren't installed in your cluster and this deployment will not succeed. Please cancel the deployment and install the "API Gateway" and "Service Mesh" at ${cluster_apps_url} before attempting to deploy.`));
     }
 
     const component_names: Set<string> = new Set<string>();

--- a/src/common/utils/deploy.utils.ts
+++ b/src/common/utils/deploy.utils.ts
@@ -106,7 +106,7 @@ export default class DeployUtils {
   static async hasClusterDeployment(app: AppService, cluster: Cluster): Promise<boolean> {
     if (cluster && !cluster.properties.is_shared && !cluster.properties.is_managed) {
       const cluster_deployment: Deployment = (await app.api.get(`clusters/${cluster.id}/apps`)).data;
-      return !(cluster_deployment && cluster_deployment.action === 'delete');
+      return Boolean(cluster_deployment) && cluster_deployment.action !== 'delete';
     }
     return true;
   }

--- a/src/common/utils/deploy.utils.ts
+++ b/src/common/utils/deploy.utils.ts
@@ -6,6 +6,9 @@ import { ArchitectError, Dictionary, parseSourceYml } from '../../';
 import { SecretsDict } from '../../dependency-manager/secrets/type';
 import { SecretSpecValue } from '../../dependency-manager/spec/secret-spec';
 import { parseEnvironmentVariable } from './secret/helper';
+import Cluster from '../../architect/cluster/cluster.entity';
+import AppService from '../../app-config/service';
+import Deployment from '../../architect/deployment/deployment.entity';
 
 export default class DeployUtils {
   private static getExtraSecrets(secrets: string[] = []): Dictionary<string | number | null> {
@@ -98,5 +101,13 @@ export default class DeployUtils {
       interfaces_map[key] = value || key;
     }
     return interfaces_map;
+  }
+
+  static async hasClusterDeployment(app: AppService, cluster: Cluster): Promise<boolean> {
+    if (cluster && cluster.name !== 'architect' && cluster.name !== 'architect-cloud') {
+      const cluster_deployment: Deployment = (await app.api.get(`clusters/${cluster.id}/apps`)).data;
+      return !(cluster_deployment && cluster_deployment.action === 'delete');
+    }
+    return true;
   }
 }

--- a/src/common/utils/deploy.utils.ts
+++ b/src/common/utils/deploy.utils.ts
@@ -106,7 +106,7 @@ export default class DeployUtils {
   static async hasClusterDeployment(app: AppService, cluster: Cluster): Promise<boolean> {
     if (cluster && !cluster.properties.is_shared && !cluster.properties.is_managed) {
       const cluster_deployment: Deployment = (await app.api.get(`clusters/${cluster.id}/apps`)).data;
-      return Boolean(cluster_deployment) && cluster_deployment.action !== 'delete';
+      return cluster_deployment && cluster_deployment.action !== 'delete';
     }
     return true;
   }

--- a/src/common/utils/deploy.utils.ts
+++ b/src/common/utils/deploy.utils.ts
@@ -104,7 +104,7 @@ export default class DeployUtils {
   }
 
   static async hasClusterDeployment(app: AppService, cluster: Cluster): Promise<boolean> {
-    if (cluster && cluster.name !== 'architect' && cluster.name !== 'architect-cloud') {
+    if (cluster && !cluster.properties.is_shared && !cluster.properties.is_managed) {
       const cluster_deployment: Deployment = (await app.api.get(`clusters/${cluster.id}/apps`)).data;
       return !(cluster_deployment && cluster_deployment.action === 'delete');
     }


### PR DESCRIPTION
## Overview
Closes https://gitlab.com/architect-io/hub-api/-/issues/493.   
Warn the user when cluster deployment is deleted.


## Changes
Add a check for deleted cluster deployment.


## Tests
- Register your own cluster and create an env
- Go to cluster `Apps` and uninstall `Service Mesh`
- Deploy the hello-world component `architect-local deploy hello-world -e env --auto-approve`


## Pictures
<img width="932" alt="Screenshot 2023-05-01 at 11 47 28 AM" src="https://user-images.githubusercontent.com/102971990/235489306-32363c61-a64f-4409-9b1b-7e81e2355655.png">


