### PR TITLE
Validate interpolation in register

### DIFF
--- a/test/dependency-manager/interpolation-validation.test.ts
+++ b/test/dependency-manager/interpolation-validation.test.ts
@@ -188,5 +188,44 @@ describe('interpolation-validation', () => {
       const component_spec = buildSpecFromYml(component_config)
       validateInterpolation(component_spec)
     });
+
+    it('fail when using interpolation where path does not exist', () => {
+      const component_config = `
+        name: hello-world
+        services:
+          api:
+            build:
+              context: .
+            environment:
+              DB_ADDR: \${{ services.database.interfaces.main.url }}
+        `;
+
+      const component_spec = buildSpecFromYml(component_config);
+
+      expect(() => {
+        validateInterpolation(component_spec);
+      }).to.be.throws(ValidationErrors);
+    });
+
+    it('fail when secret does not exist', () => {
+      const component_config = `
+        name: hello-world
+        secrets:
+          world_text:
+            default: World
+        services:
+          api:
+            build:
+              context: .
+            environment:
+              WORLD_TEXT: \${{ secrets.notfound }}
+        `;
+
+      const component_spec = buildSpecFromYml(component_config);
+
+      expect(() => {
+        validateInterpolation(component_spec);
+      }).to.be.throws(ValidationErrors);
+    });
   });
 });

--- a/test/mocks/superset/architect.yml
+++ b/test/mocks/superset/architect.yml
@@ -161,7 +161,7 @@ services:
     interfaces:
       http: 8080
     environment:
-      BACKUP_DB_ADDR: ${{ databases.api-db.connection_string }}
+      BACKUP_DB_ADDR: ${{ databases.api-db2.connection_string }}
       DB_ADDR: ${{ services.api-db.interfaces.postgres.url }}/${{ secrets.db_name }}
       DB_USER: ${{ secrets.db_user }}
       DB_PASS: ${{ secrets.db_pass }}


### PR DESCRIPTION
## Overview
Closes https://gitlab.com/architect-io/architect-cli/-/issues/620.  
Validate interpolation of component during register.


## Changes
Add validation checks for interpolations


## Tests
The following should fail
```
name: hello-world
services:
  api:
    build:
      context: .
    interfaces:
      main: 3000
    environment:
      WORLD_TEXT: ${{ nonsense.world_text }}
```
Test dependencies    
```
name: hello-world
dependencies:
  authentication: latest
services:
  api:
    build:
      context: ./
    environment:
      AUTH_INTERNAL: ${{ dependencies.nonsense.services.auth.interfaces.main.url }}
```
