### PR TITLE
Fix local exec

### DIFF
--- a/src/architect/account/account.utils.ts
+++ b/src/architect/account/account.utils.ts
@@ -39,6 +39,10 @@ export default class AccountUtils {
   }
 
   static async getAccount(app: AppService, account_name?: string, options?: { account_message?: string, ask_local_account?: boolean }): Promise<Account> {
+    if (account_name === 'dev') {
+      return this.getLocalAccount();
+    }
+
     const config_account = app.config.defaultAccount();
     // Set the account name from the config only if an account name wasn't set as cli flag
     if (config_account && !account_name && !options?.ask_local_account) {

--- a/src/architect/account/account.utils.ts
+++ b/src/architect/account/account.utils.ts
@@ -38,8 +38,12 @@ export default class AccountUtils {
     return account.id === 'dev';
   }
 
+  static isLocalAccountName(account_name: string | undefined): boolean {
+    return account_name === 'dev';
+  }
+
   static async getAccount(app: AppService, account_name?: string, options?: { account_message?: string, ask_local_account?: boolean }): Promise<Account> {
-    if (account_name === 'dev') {
+    if (this.isLocalAccountName(account_name)) {
       return this.getLocalAccount();
     }
 


### PR DESCRIPTION
## Overview
Allow to run an exec command locally without needing to go through prompts


## Changes
Return account `dev` when requested


## Tests
- Go to springboot starter project
- run `architect dev`
- run `architect exec --account dev springboot.services.app -- mvn compile`
