### PR TITLE
Use a list of restricted ports instead of allowing ports > 1023.

### DIFF
--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -24,7 +24,7 @@ import { OverlayServer } from '../../common/overlay/overlay-server';
 import BuildPackUtils from '../../common/utils/buildpack';
 import DeployUtils from '../../common/utils/deploy.utils';
 import { booleanString } from '../../common/utils/oclif';
-import PortUtil from '../../common/utils/port';
+import PortUtil, { RESTRICTED_PORTS } from '../../common/utils/port';
 import { SecretsDict } from '../../dependency-manager/secrets/type';
 
 type TraefikHttpService = {
@@ -126,7 +126,7 @@ export default class Dev extends BaseCommand {
       sensitive: false,
     }),
     port: Flags.integer({
-      description: 'Port for the gateway. Defaults to 443, or 80 if --ssl=false. Allowed port numbers are 80, 443, or any port between 1024 and 66535.',
+      description: 'Port for the gateway. Defaults to 443. If --ssl=false is set, defaults to 80 instead.',
       sensitive: false,
       max: 65535,
     }),
@@ -493,15 +493,19 @@ export default class Dev extends BaseCommand {
 
   private async getAvailablePort(port: number): Promise<number> {
     while (!(await PortUtil.isPortAvailable(port))) {
+      let message = `Trying to listen on port ${port}, but something is already using it. What port would you like us to run the API gateway on (you can use the '--port' flag to skip this message in the future)?`;
+      if (RESTRICTED_PORTS.has(port)) {
+        message = `Port ${port} is restricted by browsers. What port would you like us to run the API gateway on instead?`;
+      }
       const answers = await inquirer.prompt([
         {
           type: 'input',
           name: 'port',
-          message: `Trying to listen on port ${port}, but something is already using it. What port would you like us to run the API gateway on (you can use the '--port' flag to skip this message in the future)?`,
+          message,
           validate: (value) => {
             const port = Number.parseInt(value);
-            if (!this.isValidPort(port)) {
-              return 'Port must be 80, 443, or any port between 1024 and 66535.';
+            if (!port || port <= 0 || port > 65535) {
+              return 'Port must be a positive number below 65536.';
             }
             return true;
           },
@@ -598,19 +602,6 @@ $ architect dev -e new_env_name_here .`));
     return env_secrets;
   }
 
-  /**
-   * Only allowed ports for architect dev are 1024-65535, or 80/443 (default http/https ports)
-   * This is to prevent users from choosing a well-known port that browers won't allow connections
-   * to (e.g. port 95 or 101).
-   */
-  private isValidPort(port: number): boolean {
-    if (Number.isNaN(port)) {
-      return false;
-    }
-
-    return (port >= 1024 && port <= 65535) || port === 443 || port === 80;
-  }
-
   private async runLocal() {
     const { args, flags } = await this.parse(Dev);
 
@@ -618,9 +609,6 @@ $ architect dev -e new_env_name_here .`));
     await this.failIfEnvironmentExists(environment);
 
     flags.port = await this.getAvailablePort(flags.port || (flags.ssl ? 443 : 80));
-    if (!this.isValidPort(flags.port)) {
-      throw new Error('Invalid port number. Port must be 80, 443, or any port between 1024 and 66535.');
-    }
 
     if (flags.ssl) {
       await this.downloadSSLCerts();

--- a/src/common/utils/port.ts
+++ b/src/common/utils/port.ts
@@ -2,10 +2,105 @@ import net from 'net';
 
 const PORT_RANGE = Array.from({ length: 1000 }, (_, k) => k);
 
+/**
+ * Chromium restricted ports:
+ *   https://chromium.googlesource.com/chromium/src.git/+/refs/heads/master/net/base/port_util.cc#27
+ * Firefox restricted ports is a subset of this list as well:
+ *   https://www-archive.mozilla.org/projects/netlib/portbanning#portlist
+ * Browsers will not allow you to connect to local services on these ports, so
+ * they aren't allowed to be assigned to services.
+ */
+export const RESTRICTED_PORTS = new Set([
+  1,      // tcpmux
+  7,      // echo
+  9,      // discard
+  11,     // systat
+  13,     // daytime
+  15,     // netstat
+  17,     // qotd
+  19,     // chargen
+  20,     // ftp data
+  21,     // ftp access
+  22,     // ssh
+  23,     // telnet
+  25,     // smtp
+  37,     // time
+  42,     // name
+  43,     // nicname
+  53,     // domain
+  69,     // tftp
+  77,     // priv-rjs
+  79,     // finger
+  87,     // ttylink
+  95,     // supdup
+  101,    // hostriame
+  102,    // iso-tsap
+  103,    // gppitnp
+  104,    // acr-nema
+  109,    // pop2
+  110,    // pop3
+  111,    // sunrpc
+  113,    // auth
+  115,    // sftp
+  117,    // uucp-path
+  119,    // nntp
+  123,    // NTP
+  135,    // loc-srv /epmap
+  137,    // netbios
+  139,    // netbios
+  143,    // imap2
+  161,    // snmp
+  179,    // BGP
+  389,    // ldap
+  427,    // SLP (Also used by Apple Filing Protocol)
+  465,    // smtp+ssl
+  512,    // print / exec
+  513,    // login
+  514,    // shell
+  515,    // printer
+  526,    // tempo
+  530,    // courier
+  531,    // chat
+  532,    // netnews
+  540,    // uucp
+  548,    // AFP (Apple Filing Protocol)
+  554,    // rtsp
+  556,    // remotefs
+  563,    // nntp+ssl
+  587,    // smtp (rfc6409)
+  601,    // syslog-conn (rfc3195)
+  636,    // ldap+ssl
+  989,    // ftps-data
+  990,    // ftps
+  993,    // ldap+ssl
+  995,    // pop3+ssl
+  1719,   // h323gatestat
+  1720,   // h323hostcall
+  1723,   // pptp
+  2049,   // nfs
+  3659,   // apple-sasl / PasswordServer
+  4045,   // lockd
+  5060,   // sip
+  5061,   // sips
+  6000,   // X11
+  6566,   // sane-port
+  6665,   // Alternate IRC [Apple addition]
+  6666,   // Alternate IRC [Apple addition]
+  6667,   // Standard IRC [Apple addition]
+  6668,   // Alternate IRC [Apple addition]
+  6669,   // Alternate IRC [Apple addition]
+  6697,   // IRC + TLS
+  10080,  // Amanda
+]);
+
 export default class PortUtil {
   private static tested_ports = new Set();
 
   static async isPortAvailable(port: number): Promise<boolean> {
+    if (RESTRICTED_PORTS.has(port)) {
+      return false;
+    }
+
     const promise = new Promise(((resolve, reject) => {
       const socket = new net.Socket();
 


### PR DESCRIPTION
Related to the issue here: https://gitlab.com/architect-io/architect-cli/-/issues/662 and an update of https://github.com/architect-team/architect-cli/pull/895.

Restricting ports to 80, 443, and > 1023 wasn't quite doing what we wanted because there's still restricted ports above 1024 (like 6000, which TJ ran into when randomly choosing a port). 

Instead of limiting ports based on range, instead use Chrome/FF's restricted port list and don't allow those specifically. 