### PR TITLE
Re-enable network policy test

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -38,7 +38,8 @@ jobs:
 
   test_remote:
     name: Superset remote deployment
-    if: github.base_ref == 'main'
+    # TODO: Uncomment
+    # if: github.base_ref == 'main'
     env:
       ACCOUNT_NAME: architect-ci
       ENVIRONMENT_NAME: example-environment

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -59,7 +59,7 @@ jobs:
       - run: ./bin/dev config:set log_level debug
       - run: ./bin/dev login -e ${{ secrets.ARCHITECT_EMAIL }} -p ${{ secrets.ARCHITECT_PASSWORD }}
       - run: ./bin/dev register -a $ACCOUNT_NAME test/integration/hello-world/architect.yml test/mocks/superset/deprecated.architect.yml
-      - run: ./bin/dev env:create $ENVIRONMENT_NAME -a $ACCOUNT_NAME --cluster $CLUSTER_NAME
+      - run: ./bin/dev env:create $ENVIRONMENT_NAME -a $ACCOUNT_NAME --cluster $CLUSTER_NAME --flag zero-trust
       - run: ./bin/dev deploy -a $ACCOUNT_NAME --auto-approve -e $ENVIRONMENT_NAME test/mocks/superset/architect.yml -s param_unset=test -s world_text=Architect
       - run: sleep 180
       - name: Check that the app returns the expected response
@@ -68,10 +68,10 @@ jobs:
         run: |
           export CERT_DATA=$(openssl s_client -showcerts -connect hello.$ENVIRONMENT_NAME.$ACCOUNT_NAME.dev.arcitect.io:443 </dev/null | openssl x509 -noout -issuer)
           if [[ "$CERT_DATA" = "issuer=C = US, O = Let's Encrypt, CN = R3" || "$CERT_DATA" = "issuer=C = US, O = (STAGING) Let's Encrypt, CN = (STAGING) Artificial Apricot R3" ]]; then echo "Valid cert generated"; else exit 1; fi
-      # - name: Ensure that network policies are being enforced in the cluster and a service can't connect to one that it shouldn't be able to
-      #   run: |
-      #     ./bin/dev exec -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME superset.services.stateful-api -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://hello-world--api:3000/ || true" > network_policy_test.txt 2>&1 </dev/null
-      #     if [[ $(cat network_policy_test.txt) == *"Connection timeout"* ]]; then exit 0; else exit 1; fi
+      - name: Ensure that network policies are being enforced in the cluster and a service can't connect to one that it shouldn't be able to
+        run: |
+          ./bin/dev exec -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME superset.services.stateful-api -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://hello-world--api:3000/ || true" > network_policy_test.txt 2>&1 </dev/null
+          if [[ $(cat network_policy_test.txt) == *"Connection timeout"* ]]; then exit 0; else exit 1; fi
       - name: Ensure that network policies are being enforced in the cluster and a service can connect to one that it should be able to
         run: ./bin/dev exec -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME superset.services.stateful-frontend -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://stateful-reserved-name:8080/"
       - name: Run a remote task

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -38,8 +38,7 @@ jobs:
 
   test_remote:
     name: Superset remote deployment
-    # TODO: Uncomment
-    # if: github.base_ref == 'main'
+    if: github.base_ref == 'main'
     env:
       ACCOUNT_NAME: architect-ci
       ENVIRONMENT_NAME: example-environment

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -70,8 +70,8 @@ jobs:
           if [[ "$CERT_DATA" = "issuer=C = US, O = Let's Encrypt, CN = R3" || "$CERT_DATA" = "issuer=C = US, O = (STAGING) Let's Encrypt, CN = (STAGING) Artificial Apricot R3" ]]; then echo "Valid cert generated"; else exit 1; fi
       - name: Ensure that network policies are being enforced in the cluster and a service can't connect to one that it shouldn't be able to
         run: |
-          ./bin/dev exec -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME superset.services.stateful-api -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://hello-world--api:3000/ || true" > network_policy_test.txt 2>&1 </dev/null
-          if [[ $(cat network_policy_test.txt) == *"Connection timeout"* ]]; then exit 0; else exit 1; fi
+          ./bin/dev exec -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME superset.services.stateful-api -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://hello-world--api:8080/ || true" > network_policy_test.txt 2>&1 </dev/null
+          if [[ $(cat network_policy_test.txt) == *"Timeout was reached"* ]]; then exit 0; else exit 1; fi
       - name: Ensure that network policies are being enforced in the cluster and a service can connect to one that it should be able to
         run: ./bin/dev exec -a $ACCOUNT_NAME -e $ENVIRONMENT_NAME superset.services.stateful-frontend -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://stateful-reserved-name:8080/"
       - name: Run a remote task


### PR DESCRIPTION
Re-enabling the network policy test now that we can create an env from the command line with zero-trust enabled: https://gitlab.com/architect-io/architect-cli/-/issues/583

The port number and error message we were looking for both seem to have been changed since this test last worked - I tested this against an environment with zero-trust enabled and disabled to make sure the test worked correctly:


(Environment with zero-trust enabled is `ztrust`, the default disabled zero trust is `example-environment`)
```
~/code/architect/architect-cli (reenable-network-policy-test*) » architect-dev exec -a test-tyler -e ztrust superset.services.stateful-api -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://hello-world--api:8080/ || true" > network_policy_test.txt 2>&1 </dev/null
if [[ $(cat network_policy_test.txt) == *"Timeout was reached"* ]]; then echo "good"; else echo "bad"; fi
good
--------------------------------------------------------------------------------------------------------------------------------------
~/code/architect/architect-cli (reenable-network-policy-test*) » architect-dev exec -a test-tyler -e example-environment superset.services.stateful-api -- sh -c  "curl --connect-timeout 10 --insecure -L -I http://hello-world--api:8080/ || true" > network_policy_test.txt 2>&1 </dev/null
if [[ $(cat network_policy_test.txt) == *"Timeout was reached"* ]]; then echo "good"; else echo "bad"; fi
bad
```


Working superset test when I modified the action to run on this branch: https://github.com/architect-team/architect-cli/actions/runs/4993800453/jobs/8943435801