### PR TITLE
Allow secrets to be used as tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ npm install -g @architect-io/cli
 $ architect COMMAND
 running command...
 $ architect (--version)
-@architect-io/cli/1.42.1-rc.1 linux-x64 node-v16.20.1
+@architect-io/cli/1.42.1 linux-x64 node-v16.20.1
 $ architect --help [COMMAND]
 USAGE
   $ architect COMMAND
@@ -143,7 +143,7 @@ EXAMPLES
   $ architect clusters --account=myaccount mycluster
 ```
 
-_See code: [src/commands/clusters/index.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/clusters/index.ts)_
+_See code: [src/commands/clusters/index.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/clusters/index.ts)_
 
 ## `architect clusters:create [CLUSTER]`
 
@@ -178,7 +178,7 @@ EXAMPLES
   $ architect clusters:register --account=myaccount --kubeconfig=~/.kube/config --auto-approve
 ```
 
-_See code: [src/commands/clusters/create.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/clusters/create.ts)_
+_See code: [src/commands/clusters/create.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/clusters/create.ts)_
 
 ## `architect clusters:destroy [CLUSTER]`
 
@@ -209,7 +209,7 @@ EXAMPLES
   $ architect clusters:deregister --account=myaccount --auto-approve --force architect
 ```
 
-_See code: [src/commands/clusters/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/clusters/destroy.ts)_
+_See code: [src/commands/clusters/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/clusters/destroy.ts)_
 
 ## `architect components:versions [COMPONENT_NAME]`
 
@@ -235,7 +235,7 @@ EXAMPLES
   $ architect component:versions --account=myaccount mycomponent
 ```
 
-_See code: [src/commands/components/versions.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/components/versions.ts)_
+_See code: [src/commands/components/versions.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/components/versions.ts)_
 
 ## `architect config:get OPTION`
 
@@ -255,7 +255,7 @@ EXAMPLES
   $ architect config:get log_level
 ```
 
-_See code: [src/commands/config/get.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/config/get.ts)_
+_See code: [src/commands/config/get.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/config/get.ts)_
 
 ## `architect config:set OPTION VALUE`
 
@@ -276,7 +276,7 @@ EXAMPLES
   $ architect config:set log_level info
 ```
 
-_See code: [src/commands/config/set.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/config/set.ts)_
+_See code: [src/commands/config/set.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/config/set.ts)_
 
 ## `architect config:view`
 
@@ -296,7 +296,7 @@ EXAMPLES
   $ architect config
 ```
 
-_See code: [src/commands/config/view.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/config/view.ts)_
+_See code: [src/commands/config/view.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/config/view.ts)_
 
 ## `architect deploy [CONFIGS_OR_COMPONENTS]`
 
@@ -339,7 +339,7 @@ EXAMPLES
   $ architect deploy ./myfolder/architect.yml --secret-file=./mysecrets.yml --environment=myenvironment --account=myaccount --auto-approve
 ```
 
-_See code: [src/commands/deploy.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/deploy.ts)_
+_See code: [src/commands/deploy.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/deploy.ts)_
 
 ## `architect destroy`
 
@@ -365,7 +365,7 @@ EXAMPLES
   $ architect destroy --account=myaccount --environment=myenvironment --auto-approve
 ```
 
-_See code: [src/commands/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/destroy.ts)_
+_See code: [src/commands/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/destroy.ts)_
 
 ## `architect dev [CONFIGS_OR_COMPONENTS]`
 
@@ -410,7 +410,7 @@ EXAMPLES
   $ architect dev --port=1234 --browser=false --debug=true --secret-file=./mycomponent/mysecrets.yml ./mycomponent/architect.yml
 ```
 
-_See code: [src/commands/dev/index.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/dev/index.ts)_
+_See code: [src/commands/dev/index.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/dev/index.ts)_
 
 ## `architect dev:list`
 
@@ -431,7 +431,7 @@ EXAMPLES
   $ architect dev:list
 ```
 
-_See code: [src/commands/dev/list.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/dev/list.ts)_
+_See code: [src/commands/dev/list.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/dev/list.ts)_
 
 ## `architect dev:restart [SERVICES]`
 
@@ -459,7 +459,7 @@ EXAMPLES
   $ architect dev:restart hello-world.services.api hello-world.services.app
 ```
 
-_See code: [src/commands/dev/restart.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/dev/restart.ts)_
+_See code: [src/commands/dev/restart.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/dev/restart.ts)_
 
 ## `architect dev:stop [NAME]`
 
@@ -479,7 +479,7 @@ EXAMPLES
   $ architect dev:stop <local-environment-name>
 ```
 
-_See code: [src/commands/dev/stop.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/dev/stop.ts)_
+_See code: [src/commands/dev/stop.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/dev/stop.ts)_
 
 ## `architect doctor`
 
@@ -501,7 +501,7 @@ EXAMPLES
   $ architect doctor -o ./myoutput.yml
 ```
 
-_See code: [src/commands/doctor.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/doctor.ts)_
+_See code: [src/commands/doctor.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/doctor.ts)_
 
 ## `architect environments:create [ENVIRONMENT]`
 
@@ -538,7 +538,7 @@ EXAMPLES
   environment:create --account=myaccount --ttl=5days --description="My new temporary Architect environment" myenvironment
 ```
 
-_See code: [src/commands/environments/create.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/environments/create.ts)_
+_See code: [src/commands/environments/create.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/environments/create.ts)_
 
 ## `architect environments:destroy [ENVIRONMENT]`
 
@@ -572,7 +572,7 @@ EXAMPLES
   $ architect environment:deregister --account=myaccount --auto-approve --force myenvironment
 ```
 
-_See code: [src/commands/environments/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/environments/destroy.ts)_
+_See code: [src/commands/environments/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/environments/destroy.ts)_
 
 ## `architect environments:ingresses [ENVIRONMENT]`
 
@@ -597,7 +597,7 @@ ALIASES
   $ architect env:ingresses
 ```
 
-_See code: [src/commands/environments/ingresses.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/environments/ingresses.ts)_
+_See code: [src/commands/environments/ingresses.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/environments/ingresses.ts)_
 
 ## `architect exec [RESOURCE] [FLAGS] -- [COMMAND]`
 
@@ -630,7 +630,7 @@ EXAMPLES
   $ architect exec --account myaccount --environment myenvironment mycomponent.services.app --replica 0 -- /bin/sh
 ```
 
-_See code: [src/commands/exec.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/exec.ts)_
+_See code: [src/commands/exec.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/exec.ts)_
 
 ## `architect help [COMMAND]`
 
@@ -680,7 +680,7 @@ EXAMPLES
   $ architect init --from-compose=mycompose.yml --component-file=architect.yml
 ```
 
-_See code: [src/commands/init.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/init.ts)_
 
 ## `architect link [COMPONENTPATH]`
 
@@ -702,7 +702,7 @@ EXAMPLES
   $ architect link -p ./mycomponent/architect.yml
 ```
 
-_See code: [src/commands/link/index.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/link/index.ts)_
+_See code: [src/commands/link/index.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/link/index.ts)_
 
 ## `architect link:list`
 
@@ -719,7 +719,7 @@ EXAMPLES
   $ architect link:list
 ```
 
-_See code: [src/commands/link/list.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/link/list.ts)_
+_See code: [src/commands/link/list.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/link/list.ts)_
 
 ## `architect login`
 
@@ -742,7 +742,7 @@ EXAMPLES
   $ architect login -e my-email-address@my-email-domain.com
 ```
 
-_See code: [src/commands/login.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/login.ts)_
 
 ## `architect logout`
 
@@ -759,7 +759,7 @@ EXAMPLES
   $ architect logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/logout.ts)_
 
 ## `architect logs [RESOURCE]`
 
@@ -794,7 +794,7 @@ EXAMPLES
   $ architect logs --follow --raw --timestamps
 ```
 
-_See code: [src/commands/logs.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/logs.ts)_
+_See code: [src/commands/logs.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/logs.ts)_
 
 ## `architect port-forward [RESOURCE] [FLAGS]`
 
@@ -829,7 +829,7 @@ EXAMPLES
   $ architect port-forward --address 0.0.0.0 --port 8080
 ```
 
-_See code: [src/commands/port-forward.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/port-forward.ts)_
+_See code: [src/commands/port-forward.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/port-forward.ts)_
 
 ## `architect register [COMPONENT]`
 
@@ -871,7 +871,7 @@ EXAMPLES
   $ architect register -a myaccount -t latest --arg NODE_ENV=dev ./architect.yml
 ```
 
-_See code: [src/commands/register.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/register.ts)_
+_See code: [src/commands/register.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/register.ts)_
 
 ## `architect scale [SERVICE]`
 
@@ -902,7 +902,7 @@ EXAMPLES
   $ architect scale api --component my-component --clear
 ```
 
-_See code: [src/commands/scale.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/scale.ts)_
+_See code: [src/commands/scale.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/scale.ts)_
 
 ## `architect secrets:download SECRETS_FILE`
 
@@ -935,7 +935,7 @@ EXAMPLES
   $ architect secrets --account=myaccount --environment=myenvironment ./mysecrets.yml
 ```
 
-_See code: [src/commands/secrets/download.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/secrets/download.ts)_
+_See code: [src/commands/secrets/download.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/secrets/download.ts)_
 
 ## `architect secrets:upload SECRETS_FILE`
 
@@ -974,7 +974,7 @@ EXAMPLES
   $ architect secrets:set --account=myaccount --environment=myenvironment --override ./mysecrets.yml
 ```
 
-_See code: [src/commands/secrets/upload.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/secrets/upload.ts)_
+_See code: [src/commands/secrets/upload.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/secrets/upload.ts)_
 
 ## `architect task COMPONENT TASK`
 
@@ -1004,7 +1004,7 @@ EXAMPLES
   $ architect task --account=myaccount --environment=myenvironment mycomponent:latest mytask
 ```
 
-_See code: [src/commands/task.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/task.ts)_
+_See code: [src/commands/task.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/task.ts)_
 
 ## `architect unlink [COMPONENTPATHORNAME]`
 
@@ -1028,5 +1028,5 @@ EXAMPLES
   $ architect unlink -p mycomponent
 ```
 
-_See code: [src/commands/unlink.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1-rc.1/src/commands/unlink.ts)_
+_See code: [src/commands/unlink.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/unlink.ts)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ npm install -g @architect-io/cli
 $ architect COMMAND
 running command...
 $ architect (--version)
-@architect-io/cli/1.42.1 linux-x64 node-v16.20.1
+@architect-io/cli/1.43.0-arc-tag-secrets.1 linux-x64 node-v16.20.1
 $ architect --help [COMMAND]
 USAGE
   $ architect COMMAND
@@ -143,7 +143,7 @@ EXAMPLES
   $ architect clusters --account=myaccount mycluster
 ```
 
-_See code: [src/commands/clusters/index.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/clusters/index.ts)_
+_See code: [src/commands/clusters/index.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/clusters/index.ts)_
 
 ## `architect clusters:create [CLUSTER]`
 
@@ -178,7 +178,7 @@ EXAMPLES
   $ architect clusters:register --account=myaccount --kubeconfig=~/.kube/config --auto-approve
 ```
 
-_See code: [src/commands/clusters/create.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/clusters/create.ts)_
+_See code: [src/commands/clusters/create.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/clusters/create.ts)_
 
 ## `architect clusters:destroy [CLUSTER]`
 
@@ -209,7 +209,7 @@ EXAMPLES
   $ architect clusters:deregister --account=myaccount --auto-approve --force architect
 ```
 
-_See code: [src/commands/clusters/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/clusters/destroy.ts)_
+_See code: [src/commands/clusters/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/clusters/destroy.ts)_
 
 ## `architect components:versions [COMPONENT_NAME]`
 
@@ -235,7 +235,7 @@ EXAMPLES
   $ architect component:versions --account=myaccount mycomponent
 ```
 
-_See code: [src/commands/components/versions.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/components/versions.ts)_
+_See code: [src/commands/components/versions.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/components/versions.ts)_
 
 ## `architect config:get OPTION`
 
@@ -255,7 +255,7 @@ EXAMPLES
   $ architect config:get log_level
 ```
 
-_See code: [src/commands/config/get.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/config/get.ts)_
+_See code: [src/commands/config/get.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/config/get.ts)_
 
 ## `architect config:set OPTION VALUE`
 
@@ -276,7 +276,7 @@ EXAMPLES
   $ architect config:set log_level info
 ```
 
-_See code: [src/commands/config/set.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/config/set.ts)_
+_See code: [src/commands/config/set.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/config/set.ts)_
 
 ## `architect config:view`
 
@@ -296,7 +296,7 @@ EXAMPLES
   $ architect config
 ```
 
-_See code: [src/commands/config/view.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/config/view.ts)_
+_See code: [src/commands/config/view.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/config/view.ts)_
 
 ## `architect deploy [CONFIGS_OR_COMPONENTS]`
 
@@ -339,7 +339,7 @@ EXAMPLES
   $ architect deploy ./myfolder/architect.yml --secret-file=./mysecrets.yml --environment=myenvironment --account=myaccount --auto-approve
 ```
 
-_See code: [src/commands/deploy.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/deploy.ts)_
+_See code: [src/commands/deploy.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/deploy.ts)_
 
 ## `architect destroy`
 
@@ -365,7 +365,7 @@ EXAMPLES
   $ architect destroy --account=myaccount --environment=myenvironment --auto-approve
 ```
 
-_See code: [src/commands/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/destroy.ts)_
+_See code: [src/commands/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/destroy.ts)_
 
 ## `architect dev [CONFIGS_OR_COMPONENTS]`
 
@@ -410,7 +410,7 @@ EXAMPLES
   $ architect dev --port=1234 --browser=false --debug=true --secret-file=./mycomponent/mysecrets.yml ./mycomponent/architect.yml
 ```
 
-_See code: [src/commands/dev/index.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/dev/index.ts)_
+_See code: [src/commands/dev/index.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/dev/index.ts)_
 
 ## `architect dev:list`
 
@@ -431,7 +431,7 @@ EXAMPLES
   $ architect dev:list
 ```
 
-_See code: [src/commands/dev/list.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/dev/list.ts)_
+_See code: [src/commands/dev/list.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/dev/list.ts)_
 
 ## `architect dev:restart [SERVICES]`
 
@@ -459,7 +459,7 @@ EXAMPLES
   $ architect dev:restart hello-world.services.api hello-world.services.app
 ```
 
-_See code: [src/commands/dev/restart.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/dev/restart.ts)_
+_See code: [src/commands/dev/restart.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/dev/restart.ts)_
 
 ## `architect dev:stop [NAME]`
 
@@ -479,7 +479,7 @@ EXAMPLES
   $ architect dev:stop <local-environment-name>
 ```
 
-_See code: [src/commands/dev/stop.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/dev/stop.ts)_
+_See code: [src/commands/dev/stop.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/dev/stop.ts)_
 
 ## `architect doctor`
 
@@ -501,7 +501,7 @@ EXAMPLES
   $ architect doctor -o ./myoutput.yml
 ```
 
-_See code: [src/commands/doctor.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/doctor.ts)_
+_See code: [src/commands/doctor.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/doctor.ts)_
 
 ## `architect environments:create [ENVIRONMENT]`
 
@@ -538,7 +538,7 @@ EXAMPLES
   environment:create --account=myaccount --ttl=5days --description="My new temporary Architect environment" myenvironment
 ```
 
-_See code: [src/commands/environments/create.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/environments/create.ts)_
+_See code: [src/commands/environments/create.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/environments/create.ts)_
 
 ## `architect environments:destroy [ENVIRONMENT]`
 
@@ -572,7 +572,7 @@ EXAMPLES
   $ architect environment:deregister --account=myaccount --auto-approve --force myenvironment
 ```
 
-_See code: [src/commands/environments/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/environments/destroy.ts)_
+_See code: [src/commands/environments/destroy.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/environments/destroy.ts)_
 
 ## `architect environments:ingresses [ENVIRONMENT]`
 
@@ -597,7 +597,7 @@ ALIASES
   $ architect env:ingresses
 ```
 
-_See code: [src/commands/environments/ingresses.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/environments/ingresses.ts)_
+_See code: [src/commands/environments/ingresses.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/environments/ingresses.ts)_
 
 ## `architect exec [RESOURCE] [FLAGS] -- [COMMAND]`
 
@@ -630,7 +630,7 @@ EXAMPLES
   $ architect exec --account myaccount --environment myenvironment mycomponent.services.app --replica 0 -- /bin/sh
 ```
 
-_See code: [src/commands/exec.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/exec.ts)_
+_See code: [src/commands/exec.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/exec.ts)_
 
 ## `architect help [COMMAND]`
 
@@ -680,7 +680,7 @@ EXAMPLES
   $ architect init --from-compose=mycompose.yml --component-file=architect.yml
 ```
 
-_See code: [src/commands/init.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/init.ts)_
 
 ## `architect link [COMPONENTPATH]`
 
@@ -702,7 +702,7 @@ EXAMPLES
   $ architect link -p ./mycomponent/architect.yml
 ```
 
-_See code: [src/commands/link/index.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/link/index.ts)_
+_See code: [src/commands/link/index.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/link/index.ts)_
 
 ## `architect link:list`
 
@@ -719,7 +719,7 @@ EXAMPLES
   $ architect link:list
 ```
 
-_See code: [src/commands/link/list.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/link/list.ts)_
+_See code: [src/commands/link/list.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/link/list.ts)_
 
 ## `architect login`
 
@@ -742,7 +742,7 @@ EXAMPLES
   $ architect login -e my-email-address@my-email-domain.com
 ```
 
-_See code: [src/commands/login.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/login.ts)_
 
 ## `architect logout`
 
@@ -759,7 +759,7 @@ EXAMPLES
   $ architect logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/logout.ts)_
 
 ## `architect logs [RESOURCE]`
 
@@ -794,7 +794,7 @@ EXAMPLES
   $ architect logs --follow --raw --timestamps
 ```
 
-_See code: [src/commands/logs.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/logs.ts)_
+_See code: [src/commands/logs.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/logs.ts)_
 
 ## `architect port-forward [RESOURCE] [FLAGS]`
 
@@ -829,7 +829,7 @@ EXAMPLES
   $ architect port-forward --address 0.0.0.0 --port 8080
 ```
 
-_See code: [src/commands/port-forward.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/port-forward.ts)_
+_See code: [src/commands/port-forward.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/port-forward.ts)_
 
 ## `architect register [COMPONENT]`
 
@@ -871,7 +871,7 @@ EXAMPLES
   $ architect register -a myaccount -t latest --arg NODE_ENV=dev ./architect.yml
 ```
 
-_See code: [src/commands/register.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/register.ts)_
+_See code: [src/commands/register.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/register.ts)_
 
 ## `architect scale [SERVICE]`
 
@@ -902,7 +902,7 @@ EXAMPLES
   $ architect scale api --component my-component --clear
 ```
 
-_See code: [src/commands/scale.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/scale.ts)_
+_See code: [src/commands/scale.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/scale.ts)_
 
 ## `architect secrets:download SECRETS_FILE`
 
@@ -935,7 +935,7 @@ EXAMPLES
   $ architect secrets --account=myaccount --environment=myenvironment ./mysecrets.yml
 ```
 
-_See code: [src/commands/secrets/download.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/secrets/download.ts)_
+_See code: [src/commands/secrets/download.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/secrets/download.ts)_
 
 ## `architect secrets:upload SECRETS_FILE`
 
@@ -974,7 +974,7 @@ EXAMPLES
   $ architect secrets:set --account=myaccount --environment=myenvironment --override ./mysecrets.yml
 ```
 
-_See code: [src/commands/secrets/upload.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/secrets/upload.ts)_
+_See code: [src/commands/secrets/upload.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/secrets/upload.ts)_
 
 ## `architect task COMPONENT TASK`
 
@@ -1004,7 +1004,7 @@ EXAMPLES
   $ architect task --account=myaccount --environment=myenvironment mycomponent:latest mytask
 ```
 
-_See code: [src/commands/task.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/task.ts)_
+_See code: [src/commands/task.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/task.ts)_
 
 ## `architect unlink [COMPONENTPATHORNAME]`
 
@@ -1028,5 +1028,5 @@ EXAMPLES
   $ architect unlink -p mycomponent
 ```
 
-_See code: [src/commands/unlink.ts](https://github.com/architect-team/architect-cli/blob/v1.42.1/src/commands/unlink.ts)_
+_See code: [src/commands/unlink.ts](https://github.com/architect-team/architect-cli/blob/v1.43.0-arc-tag-secrets.1/src/commands/unlink.ts)_
 <!-- commandsstop -->

--- a/architect-yml.md
+++ b/architect-yml.md
@@ -258,7 +258,7 @@ An empty object that optionally supports specifying a tag for backwards compatib
 
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
- | ~~`tag`~~ | string |  | Must match: <a target="_blank" href="https://regexr.com/?expression=%5E%5B%5Cw%5D%5B%5Cw%5C.-%5D%7B0%2C127%7D%24">Regex</a>Deprecated |
+ | ~~`tag`~~ | string \| [Expression](https://docs.architect.io/reference/contexts) |  | Deprecated |
 
 
 ## OutputDefinitionSpec

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@architect-io/cli",
-  "version": "1.43.0-arc-tag-secrets.1",
+  "version": "1.43.0-arc-tag-secrets.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@architect-io/cli",
-      "version": "1.43.0-arc-tag-secrets.1",
+      "version": "1.43.0-arc-tag-secrets.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@kubernetes/client-node": "^0.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@architect-io/cli",
-  "version": "1.42.1",
+  "version": "1.43.0-arc-tag-secrets.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@architect-io/cli",
-      "version": "1.42.1",
+      "version": "1.43.0-arc-tag-secrets.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@kubernetes/client-node": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@architect-io/cli",
   "description": "Command-line interface for Architect.io",
-  "version": "1.42.1",
+  "version": "1.43.0-arc-tag-secrets.1",
   "author": "Architect.io",
   "bin": {
     "architect": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@architect-io/cli",
   "description": "Command-line interface for Architect.io",
-  "version": "1.43.0-arc-tag-secrets.1",
+  "version": "1.43.0-arc-tag-secrets.2",
   "author": "Architect.io",
   "bin": {
     "architect": "./bin/run"

--- a/src/dependency-manager/schema/architect.schema.json
+++ b/src/dependency-manager/schema/architect.schema.json
@@ -247,6 +247,13 @@
               "pattern": "^[\\w][\\w\\.-]{0,127}$"
             },
             {
+              "type": "string",
+              "pattern": "\\${{\\s*(.*?)\\s*}}",
+              "errorMessage": {
+                "pattern": "must be an interpolation ref ex. $__arc__{{ secrets.example }}"
+              }
+            },
+            {
               "$ref": "#/definitions/DependencySpec"
             }
           ]
@@ -566,6 +573,13 @@
                     {
                       "type": "string",
                       "pattern": "^[\\w][\\w\\.-]{0,127}$"
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\${{\\s*(.*?)\\s*}}",
+                      "errorMessage": {
+                        "pattern": "must be an interpolation ref ex. $__arc__{{ secrets.example }}"
+                      }
                     },
                     {
                       "$ref": "#/definitions/DependencySpec"
@@ -4688,6 +4702,13 @@
                   "pattern": "^[\\w][\\w\\.-]{0,127}$"
                 },
                 {
+                  "type": "string",
+                  "pattern": "\\${{\\s*(.*?)\\s*}}",
+                  "errorMessage": {
+                    "pattern": "must be an interpolation ref ex. $__arc__{{ secrets.example }}"
+                  }
+                },
+                {
                   "$ref": "#/definitions/DependencySpec"
                 }
               ]
@@ -5007,6 +5028,13 @@
                         {
                           "type": "string",
                           "pattern": "^[\\w][\\w\\.-]{0,127}$"
+                        },
+                        {
+                          "type": "string",
+                          "pattern": "\\${{\\s*(.*?)\\s*}}",
+                          "errorMessage": {
+                            "pattern": "must be an interpolation ref ex. $__arc__{{ secrets.example }}"
+                          }
                         },
                         {
                           "$ref": "#/definitions/DependencySpec"
@@ -8992,6 +9020,13 @@
                   "pattern": "^[\\w][\\w\\.-]{0,127}$"
                 },
                 {
+                  "type": "string",
+                  "pattern": "\\${{\\s*(.*?)\\s*}}",
+                  "errorMessage": {
+                    "pattern": "must be an interpolation ref ex. $__arc__{{ secrets.example }}"
+                  }
+                },
+                {
                   "$ref": "#/definitions/_DebugDependencySpec"
                 }
               ]
@@ -9308,6 +9343,13 @@
                         {
                           "type": "string",
                           "pattern": "^[\\w][\\w\\.-]{0,127}$"
+                        },
+                        {
+                          "type": "string",
+                          "pattern": "\\${{\\s*(.*?)\\s*}}",
+                          "errorMessage": {
+                            "pattern": "must be an interpolation ref ex. $__arc__{{ secrets.example }}"
+                          }
                         },
                         {
                           "$ref": "#/definitions/_DebugDependencySpec"

--- a/src/dependency-manager/schema/architect.schema.json
+++ b/src/dependency-manager/schema/architect.schema.json
@@ -4103,7 +4103,19 @@
       "properties": {
         "tag": {
           "type": "string",
-          "pattern": "^[\\w][\\w\\.-]{0,127}$",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^[\\w][\\w\\.-]{0,127}$"
+            },
+            {
+              "type": "string",
+              "pattern": "\\${{\\s*(.*?)\\s*}}",
+              "errorMessage": {
+                "pattern": "must be an interpolation ref ex. $__arc__{{ secrets.example }}"
+              }
+            }
+          ],
           "deprecated": true
         }
       },
@@ -4120,7 +4132,19 @@
               "properties": {
                 "tag": {
                   "type": "string",
-                  "pattern": "^[\\w][\\w\\.-]{0,127}$",
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "pattern": "^[\\w][\\w\\.-]{0,127}$"
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\${{\\s*(.*?)\\s*}}",
+                      "errorMessage": {
+                        "pattern": "must be an interpolation ref ex. $__arc__{{ secrets.example }}"
+                      }
+                    }
+                  ],
                   "deprecated": true
                 }
               },
@@ -8395,7 +8419,19 @@
       "properties": {
         "tag": {
           "type": "string",
-          "pattern": "^[\\w][\\w\\.-]{0,127}$",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^[\\w][\\w\\.-]{0,127}$"
+            },
+            {
+              "type": "string",
+              "pattern": "\\${{\\s*(.*?)\\s*}}",
+              "errorMessage": {
+                "pattern": "must be an interpolation ref ex. $__arc__{{ secrets.example }}"
+              }
+            }
+          ],
           "deprecated": true
         }
       },
@@ -8412,7 +8448,19 @@
               "properties": {
                 "tag": {
                   "type": "string",
-                  "pattern": "^[\\w][\\w\\.-]{0,127}$",
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "pattern": "^[\\w][\\w\\.-]{0,127}$"
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\${{\\s*(.*?)\\s*}}",
+                      "errorMessage": {
+                        "pattern": "must be an interpolation ref ex. $__arc__{{ secrets.example }}"
+                      }
+                    }
+                  ],
                   "deprecated": true
                 }
               },

--- a/src/dependency-manager/spec/component-spec.ts
+++ b/src/dependency-manager/spec/component-spec.ts
@@ -39,7 +39,9 @@ export class DependencySpec {
   @IsOptional()
   @JSONSchema({
     type: 'string',
-    ...ExpressionOr({ type: 'string', pattern: Slugs.ComponentTagValidator.source }),
+    ...ExpressionOr({
+      type: 'string', pattern: Slugs.ComponentTagValidator.source,
+    }),
     deprecated: true,
   })
   tag?: string;

--- a/src/dependency-manager/spec/component-spec.ts
+++ b/src/dependency-manager/spec/component-spec.ts
@@ -9,6 +9,7 @@ import { SecretDefinitionSpec, SecretSpecValue } from './secret-spec';
 import { IngressSpec, ServiceSpec } from './service-spec';
 import { TaskSpec } from './task-spec';
 import { transformObject } from './transform/common-transform';
+import { EXPRESSION_REGEX } from './utils/interpolation';
 import { AnyOf, ArrayOf, ExpressionOr, ExpressionOrString } from './utils/json-schema-annotations';
 import { ComponentSlugUtils, Slugs } from './utils/slugs';
 
@@ -38,7 +39,7 @@ export class DependencySpec {
   @IsOptional()
   @JSONSchema({
     type: 'string',
-    pattern: Slugs.ComponentTagValidator.source,
+    ...ExpressionOr({ type: 'string', pattern: Slugs.ComponentTagValidator.source }),
     deprecated: true,
   })
   tag?: string;
@@ -250,6 +251,13 @@ export class ComponentSpec {
       [ComponentSlugUtils.Validator.source]: AnyOf({
         type: 'string',
         pattern: Slugs.ComponentTagValidator.source,
+      }, {
+        type: 'string',
+        pattern: EXPRESSION_REGEX.source,
+        errorMessage: {
+          // __arc__ is replaced later to avoid json pointer issues with ajv
+          pattern: 'must be an interpolation ref ex. $__arc__{{ secrets.example }}',
+        },
       }, DependencySpec),
     },
 

--- a/test/integration/stateless-component/architect.yml
+++ b/test/integration/stateless-component/architect.yml
@@ -15,9 +15,13 @@ secrets:
     description: |
       Applied as an environment variable to each service in the component
       (oneof: ['error', 'warning', 'debug', 'info', 'trace'])
+  hello_world_tag:
+    default: latest
+    description: |
+      The tag of the hello-world service to use as a dependency
 
 dependencies:
-  hello-world: latest
+  hello-world: ${{ secrets.hello_world_tag }}
 
 services:
   stateless-app:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3056,7 +3056,14 @@ dateformat@^4.5.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
   integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
-debug@4, debug@4.3.3, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@4.3.3, debug@^4.0.0, debug@^4.0.1:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
@@ -3069,13 +3076,6 @@ debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.3.3, debug@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Overview
Customers want to deploy different versions of their app at different times. This change allows you to use a secret as tag in the dependency block. Now you can change which version of a dependency will be used during deploy time.


## Changes
Allow tags to be secrets.


## Tests
Did a full end to end test locally and deployed different tagged components.
