### PR TITLE
allowing an ip whitelist to be submitted as a comma-delimited string of ips/cidrs

### DIFF
--- a/src/dependency-manager/config/service-config.ts
+++ b/src/dependency-manager/config/service-config.ts
@@ -15,7 +15,7 @@ export interface IngressConfig {
   subdomain?: string;
   tls?: IngressTlsConfig;
   path?: string;
-  ip_whitelist?: string[];
+  ip_whitelist?: string[] | string;
   sticky?: boolean | string;
   private: boolean;
 


### PR DESCRIPTION
## Overview
Allows the `ip-whitelist` to be submitted as a comma-separated list of IPs and CIDRs

## Tests
Added a test for the new format